### PR TITLE
feat: windows path is a disaster

### DIFF
--- a/lua/fzfx/path.lua
+++ b/lua/fzfx/path.lua
@@ -1,20 +1,11 @@
 local log = require("fzfx.log")
 local constants = require("fzfx.constants")
+local env = require('fzfx.env')
 
 local Context = {
     base_dir = nil,
     sep = nil,
 }
-
---- @param path string
---- @return string
-local function normalize(path)
-    local result = path
-    if string.match(path, "\\") then
-        result, _ = string.gsub(path, "\\", "/")
-    end
-    return vim.fn.trim(result)
-end
 
 local function sep()
     if Context.sep == nil then
@@ -40,6 +31,17 @@ end
 --- @return string
 local function tempname()
     return vim.fn.tempname()
+end
+
+
+--- @param path string
+--- @return string
+local function normalize(path)
+    local result = path
+    if string.match(path, "\\") then
+        result, _ = string.gsub(path, "\\", "/")
+    end
+    return vim.fn.trim(result)
 end
 
 --- @return string

--- a/lua/fzfx/utils.lua
+++ b/lua/fzfx/utils.lua
@@ -2,6 +2,7 @@ local log = require("fzfx.log")
 local path = require("fzfx.path")
 local env = require("fzfx.env")
 local color = require("fzfx.color")
+local constants = require("fzfx.constants")
 
 -- vim {
 
@@ -184,6 +185,10 @@ local function run_lua_script(script, nvim_exec)
     local nvim_path = ShellContext.nvim_path
     if nvim_exec ~= nil and string.len(nvim_exec) > 0 then
         nvim_path = nvim_exec
+    end
+    -- nvim_path = path.normalize(nvim_path)
+    if nvim_path:match("%s+") and constants.is_windows then
+        nvim_path = vim.fn.shellescape(nvim_path)
     end
     local temp = path.join(path.base_dir(), "bin", script)
     log.debug("|fzfx.utils - run_lua_script| temp:%s", vim.inspect(temp))


### PR DESCRIPTION
For now executing lua script needs the `nvim.exe`, but sometimes it is installed at `C:\Program Files\Neovim\bin\nvim.exe`.

The whitespace cannot be correctly handled by `cmd.exe`. And the lua scripts (provider and previewer) also have changes that contains whitespaces.

Here're some solutions:
1. use `sh`: since we asked users to install the [Git for Windows](https://git-scm.com/download/win), so we have `sh` in our environment. So just build the shell command in linux way, and execute it with `sh`.
2. use `cmd.exe`: in this case we need escape the nvim path, and Windows command prompt character escaping is quite different from linux. I'm not sure if I could handle it.

todo: I need to investigate how does fzf.vim do it, why it's working correctly on Windows?