### PR TITLE
feat: colors

### DIFF
--- a/bin/files/provider.lua
+++ b/bin/files/provider.lua
@@ -9,7 +9,7 @@ local shell_helpers = require("fzfx.shell_helpers")
 
 local provider = _G.arg[1]
 
-shell_helpers.log_debug("provider:[%s]\n", provider)
+shell_helpers.log_debug("provider:[%s]", provider)
 
 local cmd = shell_helpers.read_provider_command(provider) --[[@as string]]
 shell_helpers.log_debug("cmd:[%s]", cmd)

--- a/bin/live_grep/provider.lua
+++ b/bin/live_grep/provider.lua
@@ -10,8 +10,8 @@ local shell_helpers = require("fzfx.shell_helpers")
 local provider = _G.arg[1]
 local content = _G.arg[2]
 
-shell_helpers.log_debug("provider:[%s]\n", provider)
-shell_helpers.log_debug("DEBUG content:[%s]\n", content)
+shell_helpers.log_debug("provider:[%s]", provider)
+shell_helpers.log_debug("DEBUG content:[%s]", content)
 
 if content == nil then
     content = ""
@@ -44,7 +44,7 @@ else
     cmd = string.format("%s -- %s", provider_cmd, vim.fn.shellescape(query))
 end
 
-shell_helpers.log_debug("cmd:%s\n", vim.inspect(cmd))
+shell_helpers.log_debug("cmd:%s", vim.inspect(cmd))
 
 local p = io.popen(cmd)
 shell_helpers.log_ensure(

--- a/lua/fzfx/color.lua
+++ b/lua/fzfx/color.lua
@@ -40,16 +40,6 @@ local function get_color(attr, group)
     return nil
 end
 
---- @param color string?
---- @return boolean
-local function valid_rgb_color(color)
-    if type(color) ~= "string" or string.len(color) == 0 then
-        return false
-    end
-    local r, g, b = color:match("#(..)(..)(..)")
-    return r and g and b
-end
-
 --- @param color string
 --- @param fg boolean
 --- @return string|nil
@@ -146,7 +136,6 @@ end
 --- @type table<string, function>
 local M = {
     get_color = get_color,
-    valid_rgb_color = valid_rgb_color,
     csi = csi,
     ansi = ansi,
 }

--- a/lua/fzfx/color.lua
+++ b/lua/fzfx/color.lua
@@ -40,6 +40,16 @@ local function get_color(attr, group)
     return nil
 end
 
+--- @param color string?
+--- @return boolean
+local function valid_rgb_color(color)
+    if type(color) ~= "string" or string.len(color) == 0 then
+        return false
+    end
+    local r, g, b = color:match("#(..)(..)(..)")
+    return r and g and b
+end
+
 --- @param color string
 --- @param fg boolean
 --- @return string|nil
@@ -136,6 +146,7 @@ end
 --- @type table<string, function>
 local M = {
     get_color = get_color,
+    valid_rgb_color = valid_rgb_color,
     csi = csi,
     ansi = ansi,
 }

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -360,6 +360,27 @@ local Defaults = {
         -- default = "",
     },
 
+    color = {
+        enable = true,
+        mappings = {
+            -- bg
+            bg = { "bg", "Normal" },
+            ["bg+"] = { "bg", "CursorLine" },
+            info = { "fg", "PreProc" },
+            border = { "bg", "Ignore" },
+            spinner = { "bg", "Statement" },
+            hl = { "bg", "Comment" },
+            -- fg
+            fg = { "fg", "Normal" },
+            header = { "fg", "Comment" },
+            ["fg+"] = { "fg", "Normal" },
+            pointer = { "fg", "Exception" },
+            marker = { "fg", "Keyword" },
+            prompt = { "fg", "Conditional" },
+            ["hl+"] = { "fg", "Statement" },
+        },
+    },
+
     -- environment variables
     env = {
         --- @type string|nil

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -330,9 +330,9 @@ local Defaults = {
             bg = { "bg", "Normal" },
             ["bg+"] = { "bg", "CursorLine" },
             info = { "fg", "PreProc" },
-            border = { "bg", "Ignore" },
-            spinner = { "bg", "Statement" },
-            hl = { "bg", "Comment" },
+            border = { "fg", "Ignore" },
+            spinner = { "fg", "Statement" },
+            hl = { "fg", "Comment" },
             -- fg
             fg = { "fg", "Normal" },
             header = { "fg", "Comment" },

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -422,16 +422,19 @@ local Defaults = {
             --     nf-fa-star                      \uf005
             -- 󰓎    nf-md-star                      \udb81\udcce
             --     nf-cod-star_full                \ueb59
-            --     nf-oct-dot_fill                 \uf444  (default)
+            --     nf-oct-dot_fill                 \uf444
             --     nf-fa-dot_circle_o              \uf192
+            --     nf-cod-check                    \ueab2
+            --     nf-fa-check                     \uf00c
+            -- 󰄬    nf-md-check                     \udb80\udd2c
             --
             -- unicode:
             -- https://symbl.cc/en/collections/star-symbols/
             -- https://symbl.cc/en/collections/list-bullets/
             -- https://symbl.cc/en/collections/special-symbols/
             -- •    U+2022                          &#8226;
-            -- ✓    U+2713                          &#10003;
-            marker = "",
+            -- ✓    U+2713                          &#10003;  (default)
+            marker = "✓",
         },
     },
 

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -319,6 +319,10 @@ local Defaults = {
     },
 
     -- fzf color options
+    -- color design based on doc: https://man.archlinux.org/man/fzf.1.en
+    --  * border (border): `Ignore` bg (not sure, `s:dark_bg + 3`, candidates: `MatchParen`, `Ignore`, `DiffChange`)
+    --  * spinner (input indicator: > ): `Statement` bg (not sure, candidates: `Statement`, `diffAdded`)
+    --  * hl+ (highlighted substring current line): `Statement` fg (not sure, candidates: `Statement`, `diffAdded`)
     fzf_color_opts = {
         enable = true,
         mappings = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -338,9 +338,6 @@ local Defaults = {
             spinner = { "fg", "Label" },
             header = { "fg", "Comment" },
         },
-
-        -- termimal colors: https://github.com/junegunn/fzf/blob/master/README-VIM.md#fzf-inside-terminal-buffer
-        term = {},
     },
 
     -- popup window options

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -329,11 +329,11 @@ local Defaults = {
             -- bg
             bg = { "bg", "Normal" },
             ["bg+"] = { "bg", "CursorLine" },
+            -- fg
             info = { "fg", "PreProc" },
             border = { "fg", "Ignore" },
             spinner = { "fg", "Statement" },
             hl = { "fg", "Comment" },
-            -- fg
             fg = { "fg", "Normal" },
             header = { "fg", "Comment" },
             ["fg+"] = { "fg", "Normal" },

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -385,50 +385,54 @@ local Defaults = {
     icon = {
         enable = true,
 
-        -- nerd fonts:
-        --     nf-fa-file_text_o               \uf0f6  (default)
-        --     nf-fa-file_o                    \uf016
-        unknown_file = "",
+        file = {
+            -- nerd fonts:
+            --     nf-fa-file_text_o               \uf0f6  (default)
+            --     nf-fa-file_o                    \uf016
+            unknown = "",
 
-        -- nerd fonts:
-        --     nf-custom-folder                \ue5ff (default)
-        --     nf-fa-folder                    \uf07b
-        -- 󰉋    nf-md-folder                    \udb80\ude4b
-        directory = "",
+            -- nerd fonts:
+            --     nf-custom-folder                \ue5ff (default)
+            --     nf-fa-folder                    \uf07b
+            -- 󰉋    nf-md-folder                    \udb80\ude4b
+            folder = "",
 
-        -- nerd fonts:
-        --     nf-custom-folder_open           \ue5fe (default)
-        --     nf-fa-folder_open               \uf07c
-        -- 󰝰    nf-md-folder_open               \udb81\udf70
-        directory_open = "",
+            -- nerd fonts:
+            --     nf-custom-folder_open           \ue5fe (default)
+            --     nf-fa-folder_open               \uf07c
+            -- 󰝰    nf-md-folder_open               \udb81\udf70
+            folder_open = "",
+        },
 
-        -- nerd fonts:
-        --     nf-oct-arrow_right              \uf432
-        --     nf-cod-arrow_right              \uea9c
-        --     nf-fa-caret_right               \uf0da  (default)
-        --     nf-weather-direction_right      \ue349
-        --     nf-fa-long_arrow_right          \uf178
-        --
-        -- unicode:
-        -- https://symbl.cc/en/collections/arrow-symbols/
-        -- ➜    U+279C                          &#10140;
-        -- ➤    U+27A4                          &#10148;
-        fzf_pointer = "",
+        fzf = {
+            -- nerd fonts:
+            --     nf-oct-arrow_right              \uf432
+            --     nf-cod-arrow_right              \uea9c
+            --     nf-fa-caret_right               \uf0da  (default)
+            --     nf-weather-direction_right      \ue349
+            --     nf-fa-long_arrow_right          \uf178
+            --
+            -- unicode:
+            -- https://symbl.cc/en/collections/arrow-symbols/
+            -- ➜    U+279C                          &#10140;
+            -- ➤    U+27A4                          &#10148;
+            pointer = "",
 
-        -- nerd fonts:
-        --     nf-fa-star                      \uf005
-        -- 󰓎    nf-md-star                      \udb81\udcce
-        --     nf-cod-star_full                \ueb59
-        --     nf-oct-dot_fill                 \uf444  (default)
-        --     nf-fa-dot_circle_o              \uf192
-        --
-        -- unicode:
-        -- https://symbl.cc/en/collections/star-symbols/
-        -- https://symbl.cc/en/collections/list-bullets/
-        -- https://symbl.cc/en/collections/special-symbols/
-        -- •    U+2022                          &#8226;
-        -- ✓    U+2713                          &#10003;
-        fzf_marker = "",
+            -- nerd fonts:
+            --     nf-fa-star                      \uf005
+            -- 󰓎    nf-md-star                      \udb81\udcce
+            --     nf-cod-star_full                \ueb59
+            --     nf-oct-dot_fill                 \uf444  (default)
+            --     nf-fa-dot_circle_o              \uf192
+            --
+            -- unicode:
+            -- https://symbl.cc/en/collections/star-symbols/
+            -- https://symbl.cc/en/collections/list-bullets/
+            -- https://symbl.cc/en/collections/special-symbols/
+            -- •    U+2022                          &#8226;
+            -- ✓    U+2713                          &#10003;
+            marker = "",
+        },
     },
 
     -- environment variables

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -386,8 +386,21 @@ local Defaults = {
         enable = true,
 
         -- nerd fonts:
-        --     nf-fa-file_text_o               \uf0f6
-        unknown_filetype = "",
+        --     nf-fa-file_text_o               \uf0f6  (default)
+        --     nf-fa-file_o                    \uf016
+        unknown_file = "",
+
+        -- nerd fonts:
+        --     nf-custom-folder                \ue5ff (default)
+        --     nf-fa-folder                    \uf07b
+        -- 󰉋    nf-md-folder                    \udb80\ude4b
+        directory = "",
+
+        -- nerd fonts:
+        --     nf-custom-folder_open           \ue5fe (default)
+        --     nf-fa-folder_open               \uf07c
+        -- 󰝰    nf-md-folder_open               \udb81\udf70
+        directory_open = "",
 
         -- nerd fonts:
         --     nf-oct-arrow_right              \uf432

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -380,10 +380,42 @@ local Defaults = {
         zindex = 51,
     },
 
-    -- icon
+    -- nerd fonts: https://www.nerdfonts.com/cheat-sheet
+    -- unicode: https://symbl.cc/en/
     icon = {
         enable = true,
-        -- default = "",
+
+        -- nerd fonts:
+        --     nf-fa-file_text_o               \uf0f6
+        unknown_filetype = "",
+
+        -- nerd fonts:
+        --     nf-oct-arrow_right              \uf432
+        --     nf-cod-arrow_right              \uea9c
+        --     nf-fa-caret_right               \uf0da  (default)
+        --     nf-weather-direction_right      \ue349
+        --     nf-fa-long_arrow_right          \uf178
+        --
+        -- unicode:
+        -- https://symbl.cc/en/collections/arrow-symbols/
+        -- ➜    U+279C                          &#10140;
+        -- ➤    U+27A4                          &#10148;
+        fzf_pointer = "",
+
+        -- nerd fonts:
+        --     nf-fa-star                      \uf005
+        -- 󰓎    nf-md-star                      \udb81\udcce
+        --     nf-cod-star_full                \ueb59
+        --     nf-oct-dot_fill                 \uf444  (default)
+        --     nf-fa-dot_circle_o              \uf192
+        --
+        -- unicode:
+        -- https://symbl.cc/en/collections/star-symbols/
+        -- https://symbl.cc/en/collections/list-bullets/
+        -- https://symbl.cc/en/collections/special-symbols/
+        -- •    U+2022                          &#8226;
+        -- ✓    U+2713                          &#10003;
+        fzf_marker = "",
     },
 
     -- environment variables

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -318,30 +318,29 @@ local Defaults = {
         "--height=100%",
     },
 
-    -- fzf color options
-    -- color design based on doc: https://man.archlinux.org/man/fzf.1.en
-    --  * border (border): `Ignore` bg (not sure, `s:dark_bg + 3`, candidates: `MatchParen`, `Ignore`, `DiffChange`)
-    --  * spinner (input indicator: > ): `Statement` bg (not sure, candidates: `Statement`, `diffAdded`)
-    --  * hl+ (highlighted substring current line): `Statement` fg (not sure, candidates: `Statement`, `diffAdded`)
-    fzf_color_opts = {
+    -- color
+    color = {
         enable = true,
-        mappings = {
-            -- bg
+
+        -- fzf colors: https://github.com/junegunn/fzf/blob/master/README-VIM.md#explanation-of-gfzf_colors
+        fzf = {
+            fg = { "fg", "Normal" },
             bg = { "bg", "Normal" },
-            ["bg+"] = { "bg", "CursorLine" },
-            -- fg
+            hl = { "fg", "Comment" },
+            ["fg+"] = { "fg", "CursorLine", "CursorColumn", "Normal" },
+            ["bg+"] = { "bg", "CursorLine", "CursorColumn" },
+            ["hl+"] = { "fg", "Statement" },
             info = { "fg", "PreProc" },
             border = { "fg", "Ignore" },
-            spinner = { "fg", "Statement" },
-            hl = { "fg", "Comment" },
-            fg = { "fg", "Normal" },
-            header = { "fg", "Comment" },
-            ["fg+"] = { "fg", "Normal" },
+            prompt = { "fg", "Conditional" },
             pointer = { "fg", "Exception" },
             marker = { "fg", "Keyword" },
-            prompt = { "fg", "Conditional" },
-            ["hl+"] = { "fg", "Statement" },
+            spinner = { "fg", "Label" },
+            header = { "fg", "Comment" },
         },
+
+        -- termimal colors: https://github.com/junegunn/fzf/blob/master/README-VIM.md#fzf-inside-terminal-buffer
+        term = {},
     },
 
     -- popup window options

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -415,7 +415,7 @@ local Defaults = {
             -- https://symbl.cc/en/collections/arrow-symbols/
             -- ➜    U+279C                          &#10140;
             -- ➤    U+27A4                          &#10148;
-            pointer = "",
+            pointer = "➤ ",
 
             -- nerd fonts:
             --     nf-fa-star                      \uf005
@@ -433,7 +433,7 @@ local Defaults = {
             -- https://symbl.cc/en/collections/special-symbols/
             -- •    U+2022                          &#8226;
             -- ✓    U+2713                          &#10003;  (default)
-            marker = "✓",
+            marker = " ",
         },
     },
 

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -318,6 +318,28 @@ local Defaults = {
         "--height=100%",
     },
 
+    -- fzf color options
+    fzf_color_opts = {
+        enable = true,
+        mappings = {
+            -- bg
+            bg = { "bg", "Normal" },
+            ["bg+"] = { "bg", "CursorLine" },
+            info = { "fg", "PreProc" },
+            border = { "bg", "Ignore" },
+            spinner = { "bg", "Statement" },
+            hl = { "bg", "Comment" },
+            -- fg
+            fg = { "fg", "Normal" },
+            header = { "fg", "Comment" },
+            ["fg+"] = { "fg", "Normal" },
+            pointer = { "fg", "Exception" },
+            marker = { "fg", "Keyword" },
+            prompt = { "fg", "Conditional" },
+            ["hl+"] = { "fg", "Statement" },
+        },
+    },
+
     -- popup window options
     -- implemented via float window, please check: https://neovim.io/doc/user/api.html#nvim_open_win()
     win_opts = {
@@ -358,27 +380,6 @@ local Defaults = {
     icon = {
         enable = true,
         -- default = "",
-    },
-
-    color = {
-        enable = true,
-        mappings = {
-            -- bg
-            bg = { "bg", "Normal" },
-            ["bg+"] = { "bg", "CursorLine" },
-            info = { "fg", "PreProc" },
-            border = { "bg", "Ignore" },
-            spinner = { "bg", "Statement" },
-            hl = { "bg", "Comment" },
-            -- fg
-            fg = { "fg", "Normal" },
-            header = { "fg", "Comment" },
-            ["fg+"] = { "fg", "Normal" },
-            pointer = { "fg", "Exception" },
-            marker = { "fg", "Keyword" },
-            prompt = { "fg", "Conditional" },
-            ["hl+"] = { "fg", "Statement" },
-        },
     },
 
     -- environment variables

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -102,6 +102,18 @@ local function make_fzf_color_opts()
     return { "--color", table.concat(builder, ",") }
 end
 
+--- @return string[]?
+local function make_fzf_icon_opts()
+    if not conf.get_config().icon.enable then
+        return nil
+    end
+    local icon_configs = conf.get_config().icon.fzf
+    return {
+        { "--pointer", icon_configs.pointer },
+        { "--marker", icon_configs.marker },
+    }
+end
+
 --- @param opts Config
 --- @return string|nil
 local function make_fzf_opts(opts)
@@ -136,6 +148,15 @@ local function make_fzf_opts(opts)
                 vim.fn.shellescape(color_opts[2])
             )
         )
+    end
+    local icon_opts = make_fzf_icon_opts()
+    if type(icon_opts) == "table" and #icon_opts > 0 then
+        for _, o in ipairs(icon_opts) do
+            table.insert(
+                result,
+                string.format("%s %s", o[1], vim.fn.shellescape(o[2]))
+            )
+        end
     end
     return table.concat(result, " ")
 end

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -85,21 +85,39 @@ end
 -- color design based on doc: https://man.archlinux.org/man/fzf.1.en
 -- we can assume:
 -- BG group
---  * bg (background): Normal bg (s:dark_bg)
---  * bg+ (background current line): CursorLine bg
---  * info (info line: right side numbers): PreProc fg
---  * border (border): Ignore bg (not sure, s:dark_bg + 3, candidates: MatchParen, Ignore, DiffChange)
---  * spinner (input indicator: > ): Statement bg (not sure, candidates: Statement, diffAdded)
---  * hl (highlighted substring): Comment bg
+--  * bg (background): `Normal` bg (`s:dark_bg`)
+--  * bg+ (background current line): `CursorLine` bg
+--  * info (info line: right side numbers): `PreProc` fg
+--  * border (border): `Ignore` bg (not sure, `s:dark_bg + 3`, candidates: `MatchParen`, `Ignore`, `DiffChange`)
+--  * spinner (input indicator: > ): `Statement` bg (not sure, candidates: `Statement`, `diffAdded`)
+--  * hl (highlighted substring): `Comment` bg
 -- FG group
---  * fg (text): Normal fg (s:dark_fg)
---  * header (text): Comment fg
---  * fg+ (text): Normal fg (s:dark_fg)
---  * pointer (pointer to current line): Exception fg
---  * marker (selected lines): Keyword fg
---  * prompt (prompt text): Conditional fg
---  * hl+ (highlighted substring current line): Statement fg (not sure, candidates: Statement, diffAdded)
-local function make_fzf_color_opts(opts) end
+--  * fg (text): `Normal` fg (`s:dark_fg`)
+--  * header (text): `Comment` fg
+--  * fg+ (text): `Normal` fg (`s:dark_fg`)
+--  * pointer (pointer to current line): `Exception` fg
+--  * marker (selected lines): `Keyword` fg
+--  * prompt (prompt text): `Conditional` fg
+--  * hl+ (highlighted substring current line): `Statement` fg (not sure, candidates: `Statement`, `diffAdded`)
+--- @return string[]?
+local function make_fzf_color_opts()
+    if not conf.get_config().color.enable then
+        return nil
+    end
+    local color_mappings = conf.get_config().color.mappings
+    local builder = {}
+    for name, opts in pairs(color_mappings) do
+        local c = color.get_color(opts[1], opts[2])
+        if type(c) == "string" and string.len(c) > 0 then
+            table.insert(builder, string.format("%s:%s", name, c))
+        end
+    end
+    log.debug(
+        "|fzfx.helpers - make_fzf_color_opts| builder:%s",
+        vim.inspect(builder)
+    )
+    return { "--color", table.concat(builder, ",") }
+end
 
 --- @param opts Config
 --- @return string|nil
@@ -124,6 +142,17 @@ local function make_fzf_opts(opts)
                 vim.inspect(o)
             )
         end
+    end
+    local color_opts = make_fzf_color_opts()
+    if type(color_opts) == "table" and #color_opts == 2 then
+        table.insert(
+            result,
+            string.format(
+                "%s %s",
+                color_opts[1],
+                vim.fn.shellescape(color_opts[2])
+            )
+        )
     end
     return table.concat(result, " ")
 end

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -84,15 +84,18 @@ end
 
 --- @return string[]?
 local function make_fzf_color_opts()
-    if not conf.get_config().fzf_color_opts.enable then
+    if not conf.get_config().color.enable then
         return nil
     end
-    local color_mappings = conf.get_config().fzf_color_opts.mappings
+    local fzf_colors = conf.get_config().color.fzf
     local builder = {}
-    for name, opts in pairs(color_mappings) do
-        local c = color.get_color(opts[1], opts[2])
-        if type(c) == "string" and string.len(c) > 0 then
-            table.insert(builder, string.format("%s:%s", name, c))
+    for name, opts in pairs(fzf_colors) do
+        for i = 2, #opts do
+            local c = color.get_color(opts[1], opts[i])
+            if type(c) == "string" and string.len(c) > 0 then
+                table.insert(builder, string.format("%s:%s", name, c))
+                break
+            end
         end
     end
     log.debug(
@@ -114,6 +117,25 @@ local function make_fzf_icon_opts()
     }
 end
 
+--- @param opts string[]
+--- @param o string|string[]
+--- @return string[]
+local function append_fzf_opt(opts, o)
+    if type(o) == "string" and string.len(o) > 0 then
+        table.insert(opts, o)
+    elseif type(o) == "table" and #o == 2 then
+        local k = o[1]
+        local v = o[2]
+        table.insert(opts, string.format("%s %s", k, vim.fn.shellescape(v)))
+    else
+        log.throw(
+            "|fzfx.helpers - append_fzf_opt| invalid fzf opt: %s",
+            vim.inspect(o)
+        )
+    end
+    return opts
+end
+
 --- @param opts Config
 --- @return string|nil
 local function make_fzf_opts(opts)
@@ -122,40 +144,16 @@ local function make_fzf_opts(opts)
     end
     local result = {}
     for _, o in ipairs(opts) do
-        if type(o) == "string" and string.len(o) > 0 then
-            table.insert(result, o)
-        elseif type(o) == "table" and #o == 2 then
-            local k = o[1]
-            local v = o[2]
-            table.insert(
-                result,
-                string.format("%s %s", k, vim.fn.shellescape(v))
-            )
-        else
-            log.throw(
-                "|fzfx.helpers - make_fzf_opts| invalid fzf option: %s",
-                vim.inspect(o)
-            )
-        end
+        append_fzf_opt(result, o)
     end
-    local color_opts = make_fzf_color_opts()
-    if type(color_opts) == "table" and #color_opts == 2 then
-        table.insert(
-            result,
-            string.format(
-                "%s %s",
-                color_opts[1],
-                vim.fn.shellescape(color_opts[2])
-            )
-        )
+    local color_opt = make_fzf_color_opts()
+    if type(color_opt) == "table" and #color_opt == 2 then
+        append_fzf_opt(result, color_opt)
     end
     local icon_opts = make_fzf_icon_opts()
     if type(icon_opts) == "table" and #icon_opts > 0 then
         for _, o in ipairs(icon_opts) do
-            table.insert(
-                result,
-                string.format("%s %s", o[1], vim.fn.shellescape(o[2]))
-            )
+            append_fzf_opt(result, o)
         end
     end
     return table.concat(result, " ")

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -82,23 +82,6 @@ end
 
 -- fzf opts {
 
--- color design based on doc: https://man.archlinux.org/man/fzf.1.en
--- we can assume:
--- BG group
---  * bg (background): `Normal` bg (`s:dark_bg`)
---  * bg+ (background current line): `CursorLine` bg
---  * info (info line: right side numbers): `PreProc` fg
---  * border (border): `Ignore` bg (not sure, `s:dark_bg + 3`, candidates: `MatchParen`, `Ignore`, `DiffChange`)
---  * spinner (input indicator: > ): `Statement` bg (not sure, candidates: `Statement`, `diffAdded`)
---  * hl (highlighted substring): `Comment` bg
--- FG group
---  * fg (text): `Normal` fg (`s:dark_fg`)
---  * header (text): `Comment` fg
---  * fg+ (text): `Normal` fg (`s:dark_fg`)
---  * pointer (pointer to current line): `Exception` fg
---  * marker (selected lines): `Keyword` fg
---  * prompt (prompt text): `Conditional` fg
---  * hl+ (highlighted substring current line): `Statement` fg (not sure, candidates: `Statement`, `diffAdded`)
 --- @return string[]?
 local function make_fzf_color_opts()
     if not conf.get_config().fzf_color_opts.enable then

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -1,6 +1,7 @@
 local log = require("fzfx.log")
 local env = require("fzfx.env")
 local path = require("fzfx.path")
+local color = require("fzfx.color")
 local conf = require("fzfx.config")
 
 -- visual select {
@@ -81,6 +82,23 @@ end
 
 -- fzf opts {
 
+-- color design based on doc: https://man.archlinux.org/man/fzf.1.en
+-- we can assume:
+-- BG group
+--  * bg (background): Normal bg (s:dark_bg)
+--  * bg+ (background current line): CursorLine bg
+--  * info (info line: right side numbers): PreProc fg
+--  * border (border): Ignore bg (not sure, s:dark_bg + 3, candidates: MatchParen, Ignore, DiffChange)
+--  * spinner (input indicator: > ): Statement bg (not sure, candidates: Statement, diffAdded)
+--  * hl (highlighted substring): Comment bg
+-- FG group
+--  * fg (text): Normal fg (s:dark_fg)
+--  * header (text): Comment fg
+--  * fg+ (text): Normal fg (s:dark_fg)
+--  * pointer (pointer to current line): Exception fg
+--  * marker (selected lines): Keyword fg
+--  * prompt (prompt text): Conditional fg
+--  * hl+ (highlighted substring current line): Statement fg (not sure, candidates: Statement, diffAdded)
 local function make_fzf_color_opts(opts) end
 
 --- @param opts Config

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -81,6 +81,8 @@ end
 
 -- fzf opts {
 
+local function make_fzf_color_opts(opts) end
+
 --- @param opts Config
 --- @return string|nil
 local function make_fzf_opts(opts)

--- a/lua/fzfx/helpers.lua
+++ b/lua/fzfx/helpers.lua
@@ -101,10 +101,10 @@ end
 --  * hl+ (highlighted substring current line): `Statement` fg (not sure, candidates: `Statement`, `diffAdded`)
 --- @return string[]?
 local function make_fzf_color_opts()
-    if not conf.get_config().color.enable then
+    if not conf.get_config().fzf_color_opts.enable then
         return nil
     end
-    local color_mappings = conf.get_config().color.mappings
+    local color_mappings = conf.get_config().fzf_color_opts.mappings
     local builder = {}
     for name, opts in pairs(color_mappings) do
         local c = color.get_color(opts[1], opts[2])

--- a/lua/fzfx/module.lua
+++ b/lua/fzfx/module.lua
@@ -44,6 +44,9 @@ local function setup(options)
             )
         else
             vim.env._FZFX_NVIM_DEVICON_PATH = devicon_path
+            vim.env._FZFX_NVIM_UNKNOWN_FILE_ICON = options.icon.unknown_file
+            vim.env._FZFX_NVIM_DIRECTORY_ICON = options.icon.directory
+            vim.env._FZFX_NVIM_DIRECTORY_OPEN_ICON = options.icon.directory_open
         end
     end
 

--- a/lua/fzfx/module.lua
+++ b/lua/fzfx/module.lua
@@ -44,9 +44,10 @@ local function setup(options)
             )
         else
             vim.env._FZFX_NVIM_DEVICON_PATH = devicon_path
-            vim.env._FZFX_NVIM_UNKNOWN_FILE_ICON = options.icon.unknown_file
-            vim.env._FZFX_NVIM_DIRECTORY_ICON = options.icon.directory
-            vim.env._FZFX_NVIM_DIRECTORY_OPEN_ICON = options.icon.directory_open
+            vim.env._FZFX_NVIM_FILE_UNKNOWN_ICON = options.icon.file.unknown
+            vim.env._FZFX_NVIM_FILE_FOLDER_ICON = options.icon.file.folder
+            vim.env._FZFX_NVIM_FILE_FOLDER_OPEN_ICON =
+                options.icon.file.folder_open
         end
     end
 

--- a/lua/fzfx/shell_helpers.lua
+++ b/lua/fzfx/shell_helpers.lua
@@ -113,6 +113,9 @@ end
 -- icon render {
 
 local DEVICONS_PATH = vim.env._FZFX_NVIM_DEVICON_PATH
+local UNKNOWN_FILE_ICON = vim.env._FZFX_NVIM_UNKNOWN_FILE_ICON
+local DIRECTORY_ICON = vim.env._FZFX_NVIM_DIRECTORY_ICON
+local DIRECTORY_OPEN_ICON = vim.env._FZFX_NVIM_DIRECTORY_OPEN_ICON
 local DEVICONS = nil
 if type(DEVICONS_PATH) == "string" and string.len(DEVICONS_PATH) > 0 then
     vim.opt.runtimepath:append(DEVICONS_PATH)
@@ -171,9 +174,9 @@ local function render_line_with_icon(line)
             end
         else
             if vim.fn.isdirectory(line) > 0 then
-                return string.format(" %s", line)
+                return string.format("%s %s", DIRECTORY_ICON, line)
             else
-                return string.format(" %s", line)
+                return string.format("%s %s", UNKNOWN_FILE_ICON, line)
             end
         end
     else
@@ -208,13 +211,9 @@ local function render_delimiter_line_with_icon(line, delimiter, pos)
             end
         else
             if vim.fn.isdirectory(filename) > 0 then
-                -- : nf-custom-folder, \ue5ff
-                -- : nf-custom-folder_open, \ue5fe
-                return string.format(" %s", line)
+                return string.format("%s %s", DIRECTORY_ICON, line)
             else
-                -- : nf-fa-file_text_o, \uf0f6
-                -- : nf-fa-file_o, \uf016
-                return string.format(" %s", line)
+                return string.format("%s %s", UNKNOWN_FILE_ICON, line)
             end
         end
     else

--- a/lua/fzfx/shell_helpers.lua
+++ b/lua/fzfx/shell_helpers.lua
@@ -113,9 +113,9 @@ end
 -- icon render {
 
 local DEVICONS_PATH = vim.env._FZFX_NVIM_DEVICON_PATH
-local UNKNOWN_FILE_ICON = vim.env._FZFX_NVIM_UNKNOWN_FILE_ICON
-local DIRECTORY_ICON = vim.env._FZFX_NVIM_DIRECTORY_ICON
-local DIRECTORY_OPEN_ICON = vim.env._FZFX_NVIM_DIRECTORY_OPEN_ICON
+local UNKNOWN_FILE_ICON = vim.env._FZFX_NVIM_FILE_UNKNOWN_ICON
+local FOLDER_ICON = vim.env._FZFX_NVIM_FILE_FOLDER_ICON
+local FOLDER_OPEN_ICON = vim.env._FZFX_NVIM_FILE_FOLDER_OPEN_ICON
 local DEVICONS = nil
 if type(DEVICONS_PATH) == "string" and string.len(DEVICONS_PATH) > 0 then
     vim.opt.runtimepath:append(DEVICONS_PATH)
@@ -174,7 +174,7 @@ local function render_line_with_icon(line)
             end
         else
             if vim.fn.isdirectory(line) > 0 then
-                return string.format("%s %s", DIRECTORY_ICON, line)
+                return string.format("%s %s", FOLDER_ICON, line)
             else
                 return string.format("%s %s", UNKNOWN_FILE_ICON, line)
             end
@@ -211,7 +211,7 @@ local function render_delimiter_line_with_icon(line, delimiter, pos)
             end
         else
             if vim.fn.isdirectory(filename) > 0 then
-                return string.format("%s %s", DIRECTORY_ICON, line)
+                return string.format("%s %s", FOLDER_ICON, line)
             else
                 return string.format("%s %s", UNKNOWN_FILE_ICON, line)
             end


### PR DESCRIPTION
colors based on doc: https://man.archlinux.org/man/fzf.1.en

```
EXAMPLES:

# Seoul256 theme with 8-bit colors
# (https://github.com/junegunn/seoul256.vim)
fzf --color='bg:237,bg+:236,info:143,border:240,spinner:108' \
--color='hl:65,fg:252,header:65,fg+:252' \
--color='pointer:161,marker:168,prompt:110,hl+:108'

# Seoul256 theme with 24-bit colors
fzf --color='bg:#4B4B4B,bg+:#3F3F3F,info:#BDBB72,border:#6B6B6B,spinner:#98BC99' \
--color='hl:#719872,fg:#D9D9D9,header:#719872,fg+:#D9D9D9' \ --color='pointer:#E12672,marker:#E17899,prompt:#98BEDE,hl+:#98BC99'

```

We can assume:

### BG group

* `bg` (background): `Normal` bg (`s:dark_bg`)
* `bg+` (background current line): `CursorLine` bg
* `info` (info line: right side numbers): `PreProc` fg
* `border` (border): `Ignore` bg (not sure, `s:dark_bg + 3`, candidates: `MatchParen`, `Ignore`, `DiffChange`)
* `spinner` (input indicator: > ): `Statement` bg (not sure, candidates: `Statement`, `diffAdded`)
* `hl` (highlighted substring): `Comment` bg

### FG group

* `fg` (text): `Normal` fg (`s:dark_fg`)
* `header` (text): `Comment` fg
* `fg+` (text): `Normal` fg (`s:dark_fg`)
* `pointer` (pointer to current line): `Exception` fg
* `marker` (selected lines): `Keyword` fg
* `prompt` (prompt text): `Conditional` fg
* `hl+` (highlighted substring current line): `Statement` fg (not sure, candidates: `Statement`, `diffAdded`)