### PR TITLE
deprecate: remove CommandConfig from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
           package-name: fzfx.nvim
       - uses: actions/checkout@v4
       - uses: rickstaa/action-create-tag@v1
-      - name: tag stable versions
         if: ${{ steps.release.outputs.release_created }}
         with:
           tag: stable

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -11,7 +11,6 @@ local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 local ProviderConfig = require("fzfx.schema").ProviderConfig
 local PreviewerConfig = require("fzfx.schema").PreviewerConfig
-local CommandConfig = require("fzfx.schema").CommandConfig
 
 --- @type table<string, FzfOpt>
 local default_fzf_options = {
@@ -2093,14 +2092,14 @@ local Defaults = {
     -- the 'Lsp Definitions' command
     --- @type GroupConfig
     lsp_definitions = {
-        commands = CommandConfig:make({
+        commands = {
             name = "FzfxLspDefinitions",
             feed = CommandFeedEnum.ARGS,
             opts = {
                 bang = true,
                 desc = "Search lsp definitions",
             },
-        }),
+        },
         providers = ProviderConfig:make({
             key = "default",
             provider = function(query, context)
@@ -2154,14 +2153,14 @@ local Defaults = {
     -- the 'Lsp Type Definitions' command
     --- @type GroupConfig
     lsp_type_definitions = {
-        commands = CommandConfig:make({
+        commands = {
             name = "FzfxLspTypeDefinitions",
             feed = CommandFeedEnum.ARGS,
             opts = {
                 bang = true,
                 desc = "Search lsp type definitions",
             },
-        }),
+        },
         providers = ProviderConfig:make({
             key = "default",
             provider = function(query, context)
@@ -2215,14 +2214,14 @@ local Defaults = {
     -- the 'Lsp References' command
     --- @type GroupConfig
     lsp_references = {
-        commands = CommandConfig:make({
+        commands = {
             name = "FzfxLspReferences",
             feed = CommandFeedEnum.ARGS,
             opts = {
                 bang = true,
                 desc = "Search lsp references",
             },
-        }),
+        },
         providers = ProviderConfig:make({
             key = "default",
             provider = function(query, context)
@@ -2276,14 +2275,14 @@ local Defaults = {
     -- the 'Lsp Implementations' command
     --- @type GroupConfig
     lsp_implementations = {
-        commands = CommandConfig:make({
+        commands = {
             name = "FzfxLspImplementations",
             feed = CommandFeedEnum.ARGS,
             opts = {
                 bang = true,
                 desc = "Search lsp implementations",
             },
-        }),
+        },
         providers = ProviderConfig:make({
             key = "default",
             provider = function(query, context)

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -285,7 +285,7 @@ local function lsp_diagnostics_provider(opts)
         local d = process_diagnostic_item(diag)
         if d then
             -- it looks like:
-            -- `lua/fzfx/config.lua:10:13:local ProviderConfig = require("fzfx.schema").ProviderConfig`
+            -- `lua/fzfx/config.lua:10:13: Unused local `query`.
             log.debug(
                 "|fzfx.config - lsp_diagnostics_provider| d:%s",
                 vim.inspect(d)

--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -12,9 +12,23 @@ local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local clazz = require("fzfx.clazz")
 local ProviderConfig = require("fzfx.schema").ProviderConfig
 local PreviewerConfig = require("fzfx.schema").PreviewerConfig
-local CommandConfig = require("fzfx.schema").CommandConfig
 
 local DEFAULT_PIPELINE = "default"
+
+-- config class detect {
+
+--- @param cfg Configs
+--- @return boolean
+local function is_command_config(cfg)
+    return type(cfg) == "table"
+        and type(cfg.name) == "string"
+        and string.len(cfg.name) > 0
+        and type(cfg.feed) == "string"
+        and string.len(cfg.feed) > 0
+        and type(cfg.opts) == "table"
+end
+
+-- config class detect }
 
 -- provider switch {
 
@@ -864,7 +878,7 @@ local function setup(name, pipeline_configs)
     --     vim.inspect(pipeline_configs)
     -- )
     -- User commands
-    if clazz.instanceof(pipeline_configs.commands, CommandConfig) then
+    if is_command_config(pipeline_configs.commands) then
         vim.api.nvim_create_user_command(
             pipeline_configs.commands.name,
             function(opts)

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -204,6 +204,7 @@ end
 --- @field default_provider PipelineName?
 local CommandConfig = {}
 
+--- @deprecated
 function CommandConfig:make(opts)
     require("fzfx.deprecated").notify(
         "deprecated 'CommandConfig', please use lua table!"
@@ -223,6 +224,7 @@ end
 --- @field reload_after_execute boolean?
 local InteractionConfig = {}
 
+--- @deprecated
 function InteractionConfig:make(opts)
     require("fzfx.deprecated").notify(
         "deprecated 'InteractionConfig', please use lua table!"
@@ -243,6 +245,7 @@ end
 --- @field fzf_opts FzfOpt[]?
 local GroupConfig = {}
 
+--- @deprecated
 function GroupConfig:make(opts)
     require("fzfx.deprecated").notify(
         "deprecated 'GroupConfig', please use lua table!"

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -205,6 +205,10 @@ end
 local CommandConfig = {}
 
 function CommandConfig:make(opts)
+    require("fzfx.deprecated").notify(
+        "deprecated 'CommandConfig', please use lua table!"
+    )
+
     local o = opts or {}
     setmetatable(o, self)
     self.__index = self


### PR DESCRIPTION
Thanks to your contribute, while please finish below tasks:

# Regresion test

## Platform

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
