### PR TITLE
fix: edit files actions on path containing whitespaces for fd/find/eza/ls results

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-Thanks to your contribute, while please finish below tasks:
-
 # Regresion test
 
 ## Platform

--- a/README.md
+++ b/README.md
@@ -86,13 +86,11 @@ Install with the below 3 options:
 
   <img alt="install-windows-git1.png" src="https://raw.githubusercontent.com/linrongbin16/lin.nvim.dev/main/assets/installations/install-windows-git1.png" width="70%" />
 
-- In **Adjusting your PATH environment**, select **Use Git and optional Unix tools
-  from the Command Prompt**.
+- In **Adjusting your PATH environment**, select **Use Git and optional Unix tools from the Command Prompt**.
 
   <img alt="install-windows-git2.png" src="https://raw.githubusercontent.com/linrongbin16/lin.nvim.dev/main/assets/installations/install-windows-git2.png" width="70%" />
 
-- In **Configuring the terminal emulator to use with Git Bash**, select **Use Windows's
-  default console window**.
+- In **Configuring the terminal emulator to use with Git Bash**, select **Use Windows's default console window**.
 
   <img alt="install-windows-git3.png" src="https://raw.githubusercontent.com/linrongbin16/lin.nvim.dev/main/assets/installations/install-windows-git3.png" width="70%" />
 
@@ -213,7 +211,7 @@ require("lazy").setup({
     { "junegunn/fzf", build = ":call fzf#install()" },
     {
         "linrongbin16/fzfx.nvim",
-        dependencies = { "junegunn/fzf" },
+        dependencies = { "junegunn/fzf", "nvim-tree/nvim-web-devicons" },
         config = function()
             require("fzfx").setup()
         end

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -125,6 +125,18 @@ local function edit_find(lines)
     end
 end
 
+-- Run 'edit' vim command on buffers results.
+--- @param lines string[]
+local function edit_buffers(lines)
+    return edit_find(lines)
+end
+
+-- Run 'edit' vim command on git files results.
+--- @param lines string[]
+local function edit_git_files(lines)
+    return edit_find(lines)
+end
+
 --- @deprecated
 --- @param lines string[]
 local function edit(lines)
@@ -215,6 +227,8 @@ local M = {
     make_edit_find_commands = make_edit_find_commands,
     edit = edit,
     edit_find = edit_find,
+    edit_buffers = edit_buffers,
+    edit_git_files = edit_git_files,
     edit_ls = edit_ls,
     edit_rg = edit_rg,
     edit_grep = edit_grep,

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -103,19 +103,19 @@ end
 
 --- @alias EditFindVimCommands {edit:string[]}
 --- @param lines string[]
+--- @param opts {no_icon:boolean?}?
 --- @return EditFindVimCommands
-local function make_edit_find_commands(lines)
+local function make_edit_find_commands(lines, opts)
     local results = { edit = {} }
     for i, line in ipairs(lines) do
-        local filename = line_helpers.parse_find(line)
-        local edit = string.format("edit %s", filename)
-        table.insert(results.edit, edit)
+        local filename = line_helpers.parse_find(line, opts)
+        local edit_command = string.format("edit %s", filename)
+        table.insert(results.edit, edit_command)
     end
     return results
 end
 
--- Run 'edit' vim command on fd/find result lines.
--- This will open files in nvim, or navigate to files that already opened.
+-- Run 'edit' vim command on fd/find results.
 --- @param lines string[]
 local function edit_find(lines)
     local vim_commands = make_edit_find_commands(lines)
@@ -137,6 +137,16 @@ end
 
 local function edit_grep(lines)
     return make_edit(":", 1, 2)(lines)
+end
+
+-- Run 'edit' vim command on eza/exa/ls results.
+--- @param lines string[]
+local function edit_ls(lines)
+    local vim_commands = make_edit_find_commands(lines, { no_icon = true })
+    for i, edit_command in ipairs(vim_commands.edit) do
+        log.debug("|fzfx.actions - edit_ls| [%d]:[%s]", i, edit_command)
+        vim.cmd(edit_command)
+    end
 end
 
 local function buffer(lines)
@@ -205,6 +215,7 @@ local M = {
     make_edit_find_commands = make_edit_find_commands,
     edit = edit,
     edit_find = edit_find,
+    edit_ls = edit_ls,
     edit_rg = edit_rg,
     edit_grep = edit_grep,
     buffer = buffer,

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -140,6 +140,9 @@ end
 --- @deprecated
 --- @param lines string[]
 local function edit(lines)
+    require("fzfx.deprecated").notify(
+        "deprecated 'actions.edit', please use 'actions.edit_find'!"
+    )
     return edit_find(lines)
 end
 

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -101,9 +101,34 @@ local function make_edit(delimiter, file_pos, lineno_pos, colno_pos)
     return impl
 end
 
+--- @alias EditFindVimCommands {edit:string[]}
+--- @param lines string[]
+--- @return EditFindVimCommands
+local function make_edit_find_commands(lines)
+    local results = { edit = {} }
+    for i, line in ipairs(lines) do
+        local filename = line_helpers.parse_find(line)
+        local edit = string.format("edit %s", filename)
+        table.insert(results.edit, edit)
+    end
+    return results
+end
+
+-- Run 'edit' vim command on fd/find result lines.
+-- This will open files in nvim, or navigate to files that already opened.
+--- @param lines string[]
+local function edit_find(lines)
+    local vim_commands = make_edit_find_commands(lines)
+    for i, edit_command in ipairs(vim_commands.edit) do
+        log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
+        vim.cmd(edit_command)
+    end
+end
+
 --- @deprecated
+--- @param lines string[]
 local function edit(lines)
-    return make_edit()(lines)
+    return edit_find(lines)
 end
 
 local function edit_rg(lines)
@@ -177,7 +202,9 @@ local M = {
     nop = nop,
     make_edit_vim_commands = make_edit_vim_commands,
     make_edit = make_edit,
+    make_edit_find_commands = make_edit_find_commands,
     edit = edit,
+    edit_find = edit_find,
     edit_rg = edit_rg,
     edit_grep = edit_grep,
     buffer = buffer,

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -631,99 +631,98 @@ local function directory_previewer(filename)
     end
 end
 
---- @return fun(line:string,context:FileExplorerPipelineContext):string[]|nil
-local function make_file_explorer_previewer()
-    -- The `eza -lh` (`exa -lh`) in windows output looks like:
-    --
-    -- ```
-    -- Mode  Size Date Modified Name
-    -- d----    - 30 Sep 21:55  deps
-    -- -a---  585 22 Jul 14:26  init.vim
-    -- -a--- 6.4k 30 Sep 21:55  install.ps1
-    -- -a--- 5.3k 23 Sep 13:43  install.sh
-    -- ```
-    --
-    -- So file name starts from the 5th space.
-    --
-    -- While in macOS it looks like:
-    --
-    -- ```
-    -- Permissions Size User Date Modified Name
-    -- drwxr-xr-x     - linrongbin 28 Aug 12:39  autoload
-    -- drwxr-xr-x     - linrongbin 22 Sep 10:11  bin
-    -- .rw-r--r--   120 linrongbin  5 Sep 14:14  codecov.yml
-    -- .rw-r--r--  1.1k linrongbin 28 Aug 12:39  LICENSE
-    -- drwxr-xr-x     - linrongbin  8 Oct 09:14  lua
-    -- .rw-r--r--   28k linrongbin  8 Oct 11:37  README.md
-    -- drwxr-xr-x     - linrongbin  8 Oct 11:44  test
-    -- .rw-r--r--   28k linrongbin  8 Oct 12:10  test1-README.md
-    -- .rw-r--r--   28k linrongbin  8 Oct 12:10  test2-README.md
-    -- ```
-    --
-    -- File name starts from the 6th space.
-    --
-    -- You can see in different platform, there will be different fields: 'Permission', 'User', 'Mode'.
-    --
-    -- While the `ls -lh` in both windows and macOS always looks like the same:
-    --
-    -- windows:
-    -- ```
-    -- total 31K
-    -- -rwxrwxrwx 1 somebody somegroup  150 Aug  3 21:29 .editorconfig
-    -- drwxrwxrwx 1 somebody somegroup    0 Oct  8 12:02 .github
-    -- -rwxrwxrwx 1 somebody somegroup  363 Aug 30 15:51 .gitignore
-    -- -rwxrwxrwx 1 somebody somegroup  124 Sep 18 23:56 .luacheckrc
-    -- -rwxrwxrwx 1 somebody somegroup   68 Sep 11 21:58 .luacov
-    -- ```
-    --
-    -- macOS:
-    -- ```
-    -- total 184
-    -- -rw-r--r--   1 rlin  staff   1.0K Aug 28 12:39 LICENSE
-    -- -rw-r--r--   1 rlin  staff    27K Oct  8 11:37 README.md
-    -- drwxr-xr-x   3 rlin  staff    96B Aug 28 12:39 autoload
-    -- drwxr-xr-x   4 rlin  staff   128B Sep 22 10:11 bin
-    -- -rw-r--r--   1 rlin  staff   120B Sep  5 14:14 codecov.yml
-    -- ```
-    --
-    -- File name alawys starts from the 8th space for `ls -lh`.
+-- The `eza -lh` (`exa -lh`) in windows output looks like:
+--
+-- ```
+-- Mode  Size Date Modified Name
+-- d----    - 30 Sep 21:55  deps
+-- -a---  585 22 Jul 14:26  init.vim
+-- -a--- 6.4k 30 Sep 21:55  install.ps1
+-- -a--- 5.3k 23 Sep 13:43  install.sh
+-- ```
+--
+-- So file name starts from the 5th space.
+--
+-- While in macOS it looks like:
+--
+-- ```
+-- Permissions Size User Date Modified Name
+-- drwxr-xr-x     - linrongbin 28 Aug 12:39  autoload
+-- drwxr-xr-x     - linrongbin 22 Sep 10:11  bin
+-- .rw-r--r--   120 linrongbin  5 Sep 14:14  codecov.yml
+-- .rw-r--r--  1.1k linrongbin 28 Aug 12:39  LICENSE
+-- drwxr-xr-x     - linrongbin  8 Oct 09:14  lua
+-- .rw-r--r--   28k linrongbin  8 Oct 11:37  README.md
+-- drwxr-xr-x     - linrongbin  8 Oct 11:44  test
+-- .rw-r--r--   28k linrongbin  8 Oct 12:10  test1-README.md
+-- .rw-r--r--   28k linrongbin  8 Oct 12:10  test2-README.md
+-- ```
+--
+-- File name starts from the 6th space.
+--
+-- You can see in different platform, there will be different fields: 'Permission', 'User', 'Mode'.
+--
+-- While the `ls -lh` in both windows and macOS always looks like the same:
+--
+-- windows:
+-- ```
+-- total 31K
+-- -rwxrwxrwx 1 somebody somegroup  150 Aug  3 21:29 .editorconfig
+-- drwxrwxrwx 1 somebody somegroup    0 Oct  8 12:02 .github
+-- -rwxrwxrwx 1 somebody somegroup  363 Aug 30 15:51 .gitignore
+-- -rwxrwxrwx 1 somebody somegroup  124 Sep 18 23:56 .luacheckrc
+-- -rwxrwxrwx 1 somebody somegroup   68 Sep 11 21:58 .luacov
+-- ```
+--
+-- macOS:
+-- ```
+-- total 184
+-- -rw-r--r--   1 rlin  staff   1.0K Aug 28 12:39 LICENSE
+-- -rw-r--r--   1 rlin  staff    27K Oct  8 11:37 README.md
+-- drwxr-xr-x   3 rlin  staff    96B Aug 28 12:39 autoload
+-- drwxr-xr-x   4 rlin  staff   128B Sep 22 10:11 bin
+-- -rw-r--r--   1 rlin  staff   120B Sep  5 14:14 codecov.yml
+-- ```
+--
+-- File name alawys starts from the 8th space for `ls -lh`.
 
-    local parse_ls_start_pos = 8
-    local run_eza_failed = false
+local file_explorer_parse_ls_start_pos = 8
+local file_explorer_run_eza_failed = false
 
-    --- @return boolean, integer?
-    local function parse_eza_columns()
-        local cmd = require("fzfx.cmd")
-        local run_cmd = cmd.Cmd:run({ constants.eza, "-lh" })
-        if run_cmd:wrong() then
-            return false, nil
-        end
-        local header = run_cmd.result.stdout[1]
-        if type(header) ~= "string" or string.len(header) == 0 then
-            return false, nil
-        end
-        local eza_header_words = {
-            "Mode",
-            "Permissions",
-            "Size",
-            "User",
-            "Date Modified",
-            "Name",
-        }
-        local columns = 0
-        for _, hword in ipairs(eza_header_words) do
-            if utils.string_find(header, hword) ~= nil then
-                -- log.echo(
-                --     LogLevels.INFO,
-                --     "|parse_eza_columns| search hword:%s",
-                --     vim.inspect(hword)
-                -- )
-                columns = columns + 1
-            end
-        end
-        return true, columns + 1
+--- @return boolean, integer?
+local function parse_eza_columns()
+    local cmd = require("fzfx.cmd")
+    local run_cmd = cmd.Cmd:run({ constants.eza, "-lh" })
+    if run_cmd:wrong() then
+        return false, nil
     end
+    local header = run_cmd.result.stdout[1]
+    if type(header) ~= "string" or string.len(header) == 0 then
+        return false, nil
+    end
+    local eza_header_words = {
+        "Mode",
+        "Permissions",
+        "Size",
+        "User",
+        "Date Modified",
+        "Name",
+    }
+    local columns = 0
+    for _, hword in ipairs(eza_header_words) do
+        if utils.string_find(header, hword) ~= nil then
+            -- log.echo(
+            --     LogLevels.INFO,
+            --     "|parse_eza_columns| search hword:%s",
+            --     vim.inspect(hword)
+            -- )
+            columns = columns + 1
+        end
+    end
+    return true, columns + 1
+end
 
+do
     if constants.has_eza then
         local ok, start_pos_or_err = parse_eza_columns()
         -- log.echo(
@@ -733,8 +732,9 @@ local function make_file_explorer_previewer()
         --     vim.inspect(start_pos)
         -- )
         if ok then
-            parse_ls_start_pos = start_pos_or_err --[[@as integer]]
+            file_explorer_parse_ls_start_pos = start_pos_or_err --[[@as integer]]
         else
+            file_explorer_run_eza_failed = true
             log.echo(
                 LogLevels.WARN,
                 "failed to run '%s -lh'! %s",
@@ -743,41 +743,52 @@ local function make_file_explorer_previewer()
             )
         end
     end
+end
 
+--- @param line string
+--- @param context FileExplorerPipelineContext
+--- @return string
+local function make_filename_by_file_explorer_context(line, context)
+    line = vim.trim(line)
+    local cwd = utils.readfile(context.cwd)
+    local target = line_helpers.parse_ls(line, file_explorer_parse_ls_start_pos)
+    if
+        (
+            utils.string_startswith(target, "'")
+            and utils.string_endswith(target, "'")
+        )
+        or (
+            utils.string_startswith(target, '"')
+            and utils.string_endswith(target, '"')
+        )
+    then
+        target = target:sub(2, #target - 1)
+    end
+    local p = path.join(cwd, target)
+    log.debug(
+        "|fzfx.config - make_filename_by_file_explorer_context| cwd:%s, target:%s, p:%s",
+        vim.inspect(cwd),
+        vim.inspect(target),
+        vim.inspect(p)
+    )
+    return p
+end
+
+--- @return fun(line:string,context:FileExplorerPipelineContext):string[]|nil
+local function make_file_explorer_previewer()
     --- @param line string
     --- @param context FileExplorerPipelineContext
     --- @return string[]|nil
     local function impl(line, context)
-        if run_eza_failed then
-            log.echo(LogLevels.INFO, "failed to run 'eza -lh'.")
+        if file_explorer_run_eza_failed then
+            log.echo(LogLevels.INFO, "failed to run '%s -lh'.", constants.eza)
             return nil
         end
         log.debug(
             "|fzfx.config - make_file_explorer_previewer.impl| parse_ls_start_pos:%s",
-            vim.inspect(parse_ls_start_pos)
+            vim.inspect(file_explorer_parse_ls_start_pos)
         )
-        line = vim.trim(line)
-        local cwd = utils.readfile(context.cwd)
-        local target = line_helpers.parse_ls(line, parse_ls_start_pos)
-        if
-            (
-                utils.string_startswith(target, "'")
-                and utils.string_endswith(target, "'")
-            )
-            or (
-                utils.string_startswith(target, '"')
-                and utils.string_endswith(target, '"')
-            )
-        then
-            target = target:sub(2, #target - 1)
-        end
-        local p = path.join(cwd, target)
-        log.debug(
-            "|fzfx.config - make_file_explorer_previewer| cwd:%s, target:%s, p:%s",
-            vim.inspect(cwd),
-            vim.inspect(target),
-            vim.inspect(p)
-        )
+        local p = make_filename_by_file_explorer_context(line, context)
         if vim.fn.filereadable(p) > 0 then
             local preview = make_file_previewer(p)
             return preview()
@@ -794,24 +805,16 @@ end
 --- @param context FileExplorerPipelineContext
 --- @return any
 local function edit_file_explorer(lines, context)
-    ---@diagnostic disable-next-line: undefined-field
-    local cwd = utils.readfile(context.cwd)
-    log.debug(
-        "|fzfx.config - file_explorer.actions| cwd:%s, lines:%s",
-        vim.inspect(cwd),
-        vim.inspect(lines)
-    )
-    local full_lines = {}
+    local fullpath_lines = {}
     for _, line in ipairs(lines) do
-        local splits = utils.string_split(line, " ")
-        local p = splits[#splits]
-        table.insert(full_lines, path.join(cwd, p))
+        local p = make_filename_by_file_explorer_context(line, context)
+        table.insert(fullpath_lines, p)
     end
     log.debug(
         "|fzfx.config - file_explorer.actions| full_lines:%s",
-        vim.inspect(full_lines)
+        vim.inspect(fullpath_lines)
     )
-    return require("fzfx.actions").edit(full_lines)
+    return require("fzfx.actions").edit_ls(fullpath_lines)
 end
 
 -- file explorer }

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -791,11 +791,11 @@ local function make_file_explorer_previewer()
 end
 
 --- @param lines string[]
---- @param context PipelineContext
+--- @param context FileExplorerPipelineContext
 --- @return any
 local function edit_file_explorer(lines, context)
     ---@diagnostic disable-next-line: undefined-field
-    local cwd = utils.readfile(context.cwd) --[[@as string]]
+    local cwd = utils.readfile(context.cwd)
     log.debug(
         "|fzfx.config - file_explorer.actions| cwd:%s, lines:%s",
         vim.inspect(cwd),

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -935,8 +935,8 @@ local Defaults = {
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,
-            ["enter"] = require("fzfx.actions").edit,
-            ["double-click"] = require("fzfx.actions").edit,
+            ["enter"] = require("fzfx.actions").edit_find,
+            ["double-click"] = require("fzfx.actions").edit_find,
         },
         fzf_opts = {
             default_fzf_options.multi,
@@ -1322,8 +1322,8 @@ local Defaults = {
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,
-            ["enter"] = require("fzfx.actions").edit,
-            ["double-click"] = require("fzfx.actions").edit,
+            ["enter"] = require("fzfx.actions").edit_buffers,
+            ["double-click"] = require("fzfx.actions").edit_buffers,
         },
         fzf_opts = {
             default_fzf_options.multi,
@@ -1450,8 +1450,8 @@ local Defaults = {
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,
-            ["enter"] = require("fzfx.actions").edit,
-            ["double-click"] = require("fzfx.actions").edit,
+            ["enter"] = require("fzfx.actions").edit_git_files,
+            ["double-click"] = require("fzfx.actions").edit_git_files,
         },
         fzf_opts = {
             default_fzf_options.multi,

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -719,12 +719,12 @@ local function parse_eza_columns()
             columns = columns + 1
         end
     end
-    return true, columns + 1
+    return true, columns
 end
 
 do
     if constants.has_eza then
-        local ok, start_pos_or_err = parse_eza_columns()
+        local ok, eza_columns_or_err = parse_eza_columns()
         -- log.echo(
         --     LogLevels.INFO,
         --     "|make_file_explorer_previewer| ok:%s, start_pos:%s",
@@ -732,14 +732,15 @@ do
         --     vim.inspect(start_pos)
         -- )
         if ok then
-            file_explorer_parse_ls_start_pos = start_pos_or_err --[[@as integer]]
+            file_explorer_parse_ls_start_pos = eza_columns_or_err --[[@as integer]]
+                + 1
         else
             file_explorer_run_eza_failed = true
             log.echo(
                 LogLevels.WARN,
                 "failed to run '%s -lh'! %s",
                 constants.eza,
-                start_pos_or_err
+                eza_columns_or_err
             )
         end
     end

--- a/lua/fzfx/files.lua
+++ b/lua/fzfx/files.lua
@@ -1,5 +1,4 @@
 local log = require("fzfx.log")
-local LogLevels = require("fzfx.log").LogLevels
 local conf = require("fzfx.config")
 local general = require("fzfx.general")
 local ProviderConfig = require("fzfx.schema").ProviderConfig

--- a/lua/fzfx/live_grep.lua
+++ b/lua/fzfx/live_grep.lua
@@ -1,5 +1,4 @@
 local log = require("fzfx.log")
-local LogLevels = require("fzfx.log").LogLevels
 local conf = require("fzfx.config")
 local utils = require("fzfx.utils")
 local general = require("fzfx.general")

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -264,5 +264,31 @@ describe("actions", function()
                 assert_eq(actual.edit[i], expect)
             end
         end)
+        it("run edit file command without icon", function()
+            vim.env._FZFX_NVIM_DEVICONS_PATH = nil
+            local lines = {
+                "README.md",
+                "lua/fzfx.lua",
+                "lua/fzfx/config.lua",
+                "lua/fzfx/test/goodbye world/goodbye.lua",
+                "lua/fzfx/test/goodbye world/world.txt",
+                "lua/fzfx/test/hello world.txt",
+            }
+            actions.edit_find(lines)
+            assert_true(true)
+        end)
+        it("run edit file command with prepend icon", function()
+            vim.env._FZFX_NVIM_DEVICONS_PATH = DEVICONS_PATH
+            local lines = {
+                " README.md",
+                "󰢱 lua/fzfx.lua",
+                "󰢱 lua/fzfx/config.lua",
+                "󰢱 lua/fzfx/test/goodbye world/goodbye.lua",
+                "󰢱 lua/fzfx/test/goodbye world/world.txt",
+                "󰢱 lua/fzfx/test/hello world.txt",
+            }
+            actions.edit_find(lines)
+            assert_true(true)
+        end)
     end)
 end)

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -14,6 +14,7 @@ describe("actions", function()
         "~/github/linrongbin16/.config/nvim/lazy/nvim-web-devicons"
     local actions = require("fzfx.actions")
     local utils = require("fzfx.utils")
+    local path = require("fzfx.path")
     describe("[nop]", function()
         it("do nothing", function()
             local nop = actions.nop
@@ -217,6 +218,51 @@ describe("actions", function()
                 assert_eq(actual.edit[i], expect)
             end
             assert_eq("call setpos('.', [0, 4, 71])", actual.setpos)
+        end)
+    end)
+    describe("[make_edit_find_commands]", function()
+        it("edit file without icon", function()
+            vim.env._FZFX_NVIM_DEVICONS_PATH = nil
+            local lines = {
+                "~/github/linrongbin16/fzfx.nvim/README.md",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
+            }
+            local actual = actions.make_edit_find_commands(lines)
+            assert_eq(type(actual), "table")
+            assert_eq(type(actual.edit), "table")
+            assert_eq(#actual.edit, 5)
+            for i, line in ipairs(lines) do
+                local expect = string.format(
+                    "edit %s",
+                    vim.fn.expand(path.normalize(line))
+                )
+                assert_eq(actual.edit[i], expect)
+            end
+        end)
+        it("edit file with prepend icon", function()
+            vim.env._FZFX_NVIM_DEVICONS_PATH = DEVICONS_PATH
+            local lines = {
+                " ~/github/linrongbin16/fzfx.nvim/README.md",
+                "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
+                "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua",
+                "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
+                "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
+            }
+            local actual = actions.make_edit_find_commands(lines)
+            assert_eq(type(actual), "table")
+            assert_eq(type(actual.edit), "table")
+            assert_eq(#actual.edit, 5)
+            for i, line in ipairs(lines) do
+                local first_space_pos = utils.string_find(line, " ")
+                local expect = string.format(
+                    "edit %s",
+                    vim.fn.expand(path.normalize(line:sub(first_space_pos + 1)))
+                )
+                assert_eq(actual.edit[i], expect)
+            end
         end)
     end)
 end)


### PR DESCRIPTION
Thanks to your contribute, while please finish below tasks:

# Regresion test

## Platform

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
