### PR TITLE
fix(config): use cache.dir instead of hard coding

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -2659,12 +2659,7 @@ local Defaults = {
     },
 
     cache = {
-        --- @type string
-        dir = string.format(
-            "%s%sfzfx.nvim",
-            vim.fn.stdpath("data"),
-            constants.path_separator
-        ),
+        dir = path.join(vim.fn.stdpath("data"), "fzfx.nvim"),
     },
 
     -- debug

--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -1,5 +1,4 @@
 local log = require("fzfx.log")
-local LogLevels = require("fzfx.log").LogLevels
 local Popup = require("fzfx.popup").Popup
 local helpers = require("fzfx.helpers")
 local server = require("fzfx.server")
@@ -12,6 +11,7 @@ local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local clazz = require("fzfx.clazz")
 local ProviderConfig = require("fzfx.schema").ProviderConfig
 local PreviewerConfig = require("fzfx.schema").PreviewerConfig
+local conf = require("fzfx.config")
 
 local DEFAULT_PIPELINE = "default"
 
@@ -55,13 +55,11 @@ function ProviderSwitch:new(name, pipeline, provider_configs)
         pipeline = pipeline,
         provider_configs = provider_configs_map,
         metafile = env.debug_enable() and path.join(
-            vim.fn.stdpath("data"),
-            "fzfx.nvim",
+            conf.get_config().cache.dir,
             "provider_switch_metafile_" .. name
         ) or vim.fn.tempname(),
         resultfile = env.debug_enable() and path.join(
-            vim.fn.stdpath("data"),
-            "fzfx.nvim",
+            conf.get_config().cache.dir,
             "provider_switch_resultfile_" .. name
         ) or vim.fn.tempname(),
     }
@@ -333,13 +331,11 @@ function PreviewerSwitch:new(name, pipeline, previewer_configs)
         previewers = previewers_map,
         previewer_types = previewer_types_map,
         metafile = env.debug_enable() and path.join(
-            vim.fn.stdpath("data"),
-            "fzfx.nvim",
+            conf.get_config().cache.dir,
             "previewer_switch_metafile_" .. name
         ) or vim.fn.tempname(),
         resultfile = env.debug_enable() and path.join(
-            vim.fn.stdpath("data"),
-            "fzfx.nvim",
+            conf.get_config().cache.dir,
             "previewer_switch_resultfile_" .. name
         ) or vim.fn.tempname(),
     }


### PR DESCRIPTION
# Regresion test

## Platform

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
