### PR TITLE
refactor(schema): add 'ProviderConfig' detection

### DIFF
--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -28,6 +28,19 @@ local function is_command_config(cfg)
         and type(cfg.opts) == "table"
 end
 
+--- @param cfg Configs
+--- @return boolean
+local function is_provider_config(cfg)
+    return type(cfg) == "table"
+        and type(cfg.key) == "string"
+        and string.len(cfg.key) > 0
+        and (
+            (type(cfg.provider) == "string" and string.len(cfg.provider) > 0)
+            or (type(cfg.provider) == "table" and #cfg.provider > 0)
+            or type(cfg.provider) == "function"
+        )
+end
+
 -- config class detect }
 
 -- provider switch {
@@ -915,6 +928,8 @@ end
 
 local M = {
     setup = setup,
+    is_command_config = is_command_config,
+    is_provider_config = is_provider_config,
     ProviderSwitch = ProviderSwitch,
     PreviewerSwitch = PreviewerSwitch,
     HeaderSwitch = HeaderSwitch,

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -172,7 +172,6 @@ local ProviderLineTypeEnum = {
 --- @field line_opts ProviderConfigLineOpts
 local ProviderConfig = {}
 
---- @deprecated
 function ProviderConfig:make(opts)
     local o = opts or {}
     o.provider_type = o.provider_type

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -174,9 +174,6 @@ local ProviderConfig = {}
 
 --- @deprecated
 function ProviderConfig:make(opts)
-    require("fzfx.deprecated").notify(
-        "deprecated 'schema.ProviderConfig', please use lua table!"
-    )
     local o = opts or {}
     o.provider_type = o.provider_type
         or (

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -172,7 +172,11 @@ local ProviderLineTypeEnum = {
 --- @field line_opts ProviderConfigLineOpts
 local ProviderConfig = {}
 
+--- @deprecated
 function ProviderConfig:make(opts)
+    require("fzfx.deprecated").notify(
+        "deprecated 'schema.ProviderConfig', please use lua table!"
+    )
     local o = opts or {}
     o.provider_type = o.provider_type
         or (
@@ -207,7 +211,7 @@ local CommandConfig = {}
 --- @deprecated
 function CommandConfig:make(opts)
     require("fzfx.deprecated").notify(
-        "deprecated 'CommandConfig', please use lua table!"
+        "deprecated 'schema.CommandConfig', please use lua table!"
     )
 
     local o = opts or {}
@@ -227,7 +231,7 @@ local InteractionConfig = {}
 --- @deprecated
 function InteractionConfig:make(opts)
     require("fzfx.deprecated").notify(
-        "deprecated 'InteractionConfig', please use lua table!"
+        "deprecated 'schema.InteractionConfig', please use lua table!"
     )
 
     local o = opts or {}
@@ -248,7 +252,7 @@ local GroupConfig = {}
 --- @deprecated
 function GroupConfig:make(opts)
     require("fzfx.deprecated").notify(
-        "deprecated 'GroupConfig', please use lua table!"
+        "deprecated 'schema.GroupConfig', please use lua table!"
     )
 
     local o = opts or {}

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -8,6 +8,7 @@ describe("actions", function()
     before_each(function()
         require("fzfx.config").setup()
         vim.api.nvim_command("cd " .. cwd)
+        vim.opt.swapfile = false
     end)
 
     local DEVICONS_PATH =

--- a/test/general_spec.lua
+++ b/test/general_spec.lua
@@ -422,4 +422,32 @@ describe("general", function()
             assert_true(utils.string_endswith(actual[3], "to upper"))
         end)
     end)
+    describe("[is_command_config]", function()
+        it("is command config", function()
+            local obj = schema.CommandConfig:make({
+                name = "FzfxLiveGrep",
+                feed = "args",
+                opts = {
+                    nargs = "?",
+                },
+            })
+            assert_true(general.is_command_config(obj))
+            local obj2 = {
+                name = "FzfxLiveGrep",
+                feed = "args",
+                opts = {
+                    nargs = "?",
+                },
+            }
+            assert_true(general.is_command_config(obj2))
+        end)
+        it("is not command config", function()
+            local obj1 = schema.CommandConfig:make({})
+            assert_false(general.is_command_config(obj1))
+            local obj2 = {
+                key = "FzfxLiveGrep",
+            }
+            assert_false(general.is_command_config(obj2))
+        end)
+    end)
 end)

--- a/test/general_spec.lua
+++ b/test/general_spec.lua
@@ -450,4 +450,50 @@ describe("general", function()
             assert_false(general.is_command_config(obj2))
         end)
     end)
+    describe("[is_provider_config]", function()
+        it("is provider config", function()
+            local p1 = schema.ProviderConfig:make({
+                key = "ctrl-l",
+                provider = "ls -lh",
+            })
+            local p2 = schema.ProviderConfig:make({
+                key = "ctrl-g",
+                provider = { "ls", "-lh" },
+            })
+            local p3 = schema.ProviderConfig:make({
+                key = "ctrl-k",
+                provider = function()
+                    return { "ls", "-lh" }
+                end,
+            })
+            assert_true(general.is_provider_config(p1))
+            assert_true(general.is_provider_config(p2))
+            assert_true(general.is_provider_config(p3))
+            local p4 = {
+                key = "ctrl-l",
+                provider = "ls -lh",
+            }
+            local p5 = {
+                key = "ctrl-g",
+                provider = { "ls", "-lh" },
+            }
+            local p6 = {
+                key = "ctrl-k",
+                provider = function()
+                    return { "ls", "-lh" }
+                end,
+            }
+            assert_true(general.is_provider_config(p4))
+            assert_true(general.is_provider_config(p5))
+            assert_true(general.is_provider_config(p6))
+        end)
+        it("is not provider config", function()
+            local p1 = schema.ProviderConfig:make({})
+            assert_false(general.is_provider_config(p1))
+            local p2 = {
+                name = "FzfxLiveGrep",
+            }
+            assert_false(general.is_provider_config(p2))
+        end)
+    end)
 end)


### PR DESCRIPTION
# Regresion test

## Platform

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
