### PR TITLE
refactor(schema): deprecate 'ProviderConfig'

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -9,7 +9,6 @@ local line_helpers = require("fzfx.line_helpers")
 local ProviderTypeEnum = require("fzfx.schema").ProviderTypeEnum
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
-local ProviderConfig = require("fzfx.schema").ProviderConfig
 local PreviewerConfig = require("fzfx.schema").PreviewerConfig
 
 --- @type table<string, FzfOpt>
@@ -911,18 +910,18 @@ local Defaults = {
             },
         },
         providers = {
-            restricted_mode = ProviderConfig:make({
+            restricted_mode = {
                 key = "ctrl-r",
                 provider = constants.has_fd and default_restricted_fd
                     or default_restricted_find,
                 line_opts = { prepend_icon_by_ft = true },
-            }),
-            unrestricted_mode = ProviderConfig:make({
+            },
+            unrestricted_mode = {
                 key = "ctrl-u",
                 provider = constants.has_fd and default_unrestricted_fd
                     or default_unrestricted_find,
                 line_opts = { prepend_icon_by_ft = true },
-            }),
+            },
         },
         previewers = {
             restricted_mode = PreviewerConfig:make({
@@ -1036,7 +1035,7 @@ local Defaults = {
             },
         },
         providers = {
-            restricted_mode = ProviderConfig:make({
+            restricted_mode = {
                 key = "ctrl-r",
                 provider = function(query)
                     local parsed_query = utils.parse_flag_query(query or "")
@@ -1119,8 +1118,8 @@ local Defaults = {
                     prepend_icon_path_delimiter = ":",
                     prepend_icon_path_position = 1,
                 },
-            }),
-            unrestricted_mode = ProviderConfig:make({
+            },
+            unrestricted_mode = {
                 key = "ctrl-u",
                 provider = function(query)
                     local parsed_query = utils.parse_flag_query(query or "")
@@ -1199,7 +1198,7 @@ local Defaults = {
                     prepend_icon_path_delimiter = ":",
                     prepend_icon_path_position = 1,
                 },
-            }),
+            },
         },
         previewers = {
             restricted_mode = PreviewerConfig:make({
@@ -1275,7 +1274,7 @@ local Defaults = {
                 },
             },
         },
-        providers = ProviderConfig:make({
+        providers = {
             key = "default",
             provider = function(query, context)
                 local function valid_bufnr(b)
@@ -1309,7 +1308,7 @@ local Defaults = {
             end,
             provider_type = ProviderTypeEnum.LIST,
             line_opts = { prepend_icon_by_ft = true },
-        }),
+        },
         previewers = PreviewerConfig:make({
             previewer = file_previewer,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
@@ -1428,16 +1427,16 @@ local Defaults = {
             },
         },
         providers = {
-            current_folder = ProviderConfig:make({
+            current_folder = {
                 key = "ctrl-u",
                 provider = { "git", "ls-files" },
                 line_opts = { prepend_icon_by_ft = true },
-            }),
-            workspace = ProviderConfig:make({
+            },
+            workspace = {
                 key = "ctrl-w",
                 provider = { "git", "ls-files", ":/" },
                 line_opts = { prepend_icon_by_ft = true },
-            }),
+            },
         },
         previewers = {
             current_folder = PreviewerConfig:make({
@@ -1553,7 +1552,7 @@ local Defaults = {
             },
         },
         providers = {
-            local_branch = ProviderConfig:make({
+            local_branch = {
                 key = "ctrl-o",
                 provider = function(query, context)
                     local cmd = require("fzfx.cmd")
@@ -1601,8 +1600,8 @@ local Defaults = {
                     return branch_results
                 end,
                 provider_type = ProviderTypeEnum.LIST,
-            }),
-            remote_branch = ProviderConfig:make({
+            },
+            remote_branch = {
                 key = "ctrl-r",
                 provider = function(query, context)
                     local cmd = require("fzfx.cmd")
@@ -1650,7 +1649,7 @@ local Defaults = {
                     return branch_results
                 end,
                 provider_type = ProviderTypeEnum.LIST,
-            }),
+            },
         },
         previewers = {
             local_branch = PreviewerConfig:make({
@@ -1790,7 +1789,7 @@ local Defaults = {
             },
         },
         providers = {
-            all_commits = ProviderConfig:make({
+            all_commits = {
                 key = "ctrl-a",
                 provider = {
                     "git",
@@ -1799,8 +1798,8 @@ local Defaults = {
                     "--date=short",
                     "--color=always",
                 },
-            }),
-            buffer_commits = ProviderConfig:make({
+            },
+            buffer_commits = {
                 key = "ctrl-u",
                 provider = function(query, context)
                     if not utils.is_buf_valid(context.bufnr) then
@@ -1827,7 +1826,7 @@ local Defaults = {
                     }
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
-            }),
+            },
         },
         previewers = {
             all_commits = PreviewerConfig:make({
@@ -1901,7 +1900,7 @@ local Defaults = {
             },
         },
         providers = {
-            default = ProviderConfig:make({
+            default = {
                 key = "default",
                 provider = function(query, context)
                     if not utils.is_buf_valid(context.bufnr) then
@@ -1927,7 +1926,7 @@ local Defaults = {
                     }
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
-            }),
+            },
         },
         previewers = {
             default = PreviewerConfig:make({
@@ -2037,7 +2036,7 @@ local Defaults = {
             },
         },
         providers = {
-            workspace_diagnostics = ProviderConfig:make({
+            workspace_diagnostics = {
                 key = "ctrl-w",
                 provider = function(query, context)
                     return lsp_diagnostics_provider({
@@ -2050,8 +2049,8 @@ local Defaults = {
                     prepend_icon_path_delimiter = ":",
                     prepend_icon_path_position = 1,
                 },
-            }),
-            buffer_diagnostics = ProviderConfig:make({
+            },
+            buffer_diagnostics = {
                 key = "ctrl-u",
                 provider = function(query, context)
                     return lsp_diagnostics_provider({
@@ -2065,7 +2064,7 @@ local Defaults = {
                     prepend_icon_path_delimiter = ":",
                     prepend_icon_path_position = 1,
                 },
-            }),
+            },
         },
         previewers = {
             workspace_diagnostics = PreviewerConfig:make({
@@ -2104,7 +2103,7 @@ local Defaults = {
                 desc = "Search lsp definitions",
             },
         },
-        providers = ProviderConfig:make({
+        providers = {
             key = "default",
             provider = function(query, context)
                 return lsp_locations_provider({
@@ -2120,7 +2119,7 @@ local Defaults = {
                 prepend_icon_path_delimiter = ":",
                 prepend_icon_path_position = 1,
             },
-        }),
+        },
         previewers = PreviewerConfig:make({
             previewer = file_previewer_rg,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
@@ -2165,7 +2164,7 @@ local Defaults = {
                 desc = "Search lsp type definitions",
             },
         },
-        providers = ProviderConfig:make({
+        providers = {
             key = "default",
             provider = function(query, context)
                 return lsp_locations_provider({
@@ -2181,7 +2180,7 @@ local Defaults = {
                 prepend_icon_path_delimiter = ":",
                 prepend_icon_path_position = 1,
             },
-        }),
+        },
         previewers = PreviewerConfig:make({
             previewer = file_previewer_rg,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
@@ -2226,7 +2225,7 @@ local Defaults = {
                 desc = "Search lsp references",
             },
         },
-        providers = ProviderConfig:make({
+        providers = {
             key = "default",
             provider = function(query, context)
                 return lsp_locations_provider({
@@ -2242,7 +2241,7 @@ local Defaults = {
                 prepend_icon_path_delimiter = ":",
                 prepend_icon_path_position = 1,
             },
-        }),
+        },
         previewers = PreviewerConfig:make({
             previewer = file_previewer_rg,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
@@ -2287,7 +2286,7 @@ local Defaults = {
                 desc = "Search lsp implementations",
             },
         },
-        providers = ProviderConfig:make({
+        providers = {
             key = "default",
             provider = function(query, context)
                 return lsp_locations_provider({
@@ -2303,7 +2302,7 @@ local Defaults = {
                 prepend_icon_path_delimiter = ":",
                 prepend_icon_path_position = 1,
             },
-        }),
+        },
         previewers = PreviewerConfig:make({
             previewer = file_previewer_rg,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
@@ -2421,16 +2420,16 @@ local Defaults = {
             },
         },
         providers = {
-            filter_hidden = ProviderConfig:make({
+            filter_hidden = {
                 key = "ctrl-r",
                 provider = make_file_explorer_provider("-lh"),
                 provider_type = ProviderTypeEnum.COMMAND,
-            }),
-            include_hidden = ProviderConfig:make({
+            },
+            include_hidden = {
                 key = "ctrl-u",
                 provider = make_file_explorer_provider("-lha"),
                 provider_type = ProviderTypeEnum.COMMAND,
-            }),
+            },
         },
         previewers = {
             filter_hidden = PreviewerConfig:make({

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -383,14 +383,14 @@ local function lsp_location_render_line(line, range, color_renderer)
     return result
 end
 
+--- @alias LspLocationPipelineContext {bufnr:integer,winnr:integer,tabnr:integer,position_params:any}
+--- @return LspLocationPipelineContext
 local function lsp_position_context_maker()
-    --- @type PipelineContext
     local context = {
         bufnr = vim.api.nvim_get_current_buf(),
         winnr = vim.api.nvim_get_current_win(),
         tabnr = vim.api.nvim_get_current_tabpage(),
     }
-    ---@diagnostic disable-next-line: inject-field
     context.position_params =
         vim.lsp.util.make_position_params(context.winnr, nil)
     context.position_params.context = {
@@ -2105,6 +2105,8 @@ local Defaults = {
         },
         providers = {
             key = "default",
+            --- @param query string
+            --- @param context LspLocationPipelineContext
             provider = function(query, context)
                 return lsp_locations_provider({
                     method = "textDocument/definition",
@@ -2166,6 +2168,8 @@ local Defaults = {
         },
         providers = {
             key = "default",
+            --- @param query string
+            --- @param context LspLocationPipelineContext
             provider = function(query, context)
                 return lsp_locations_provider({
                     method = "textDocument/type_definition",
@@ -2227,6 +2231,8 @@ local Defaults = {
         },
         providers = {
             key = "default",
+            --- @param query string
+            --- @param context LspLocationPipelineContext
             provider = function(query, context)
                 return lsp_locations_provider({
                     method = "textDocument/references",
@@ -2288,6 +2294,8 @@ local Defaults = {
         },
         providers = {
             key = "default",
+            --- @param query string
+            --- @param context LspLocationPipelineContext
             provider = function(query, context)
                 return lsp_locations_provider({
                     method = "textDocument/implementation",

--- a/lua/fzfx/files.lua
+++ b/lua/fzfx/files.lua
@@ -21,6 +21,7 @@ local function setup()
         if provider_name == "restricted" or provider_name == "unrestricted" then
             local action_key = provider_opts[1]
             local grep_cmd = provider_opts[2]
+            ---@diagnostic disable-next-line: deprecated
             new_providers[provider_name .. "_mode"] = ProviderConfig:make({
                 key = action_key,
                 provider = grep_cmd,

--- a/lua/fzfx/git_files.lua
+++ b/lua/fzfx/git_files.lua
@@ -21,11 +21,13 @@ local function setup()
         and string.len(git_files_configs.providers) > 0
     then
         git_files_configs.providers = {
+            ---@diagnostic disable-next-line: deprecated
             current_folder = ProviderConfig:make({
                 key = "ctrl-u",
                 provider = git_files_configs.providers,
                 line_type = ProviderLineTypeEnum.FILE,
             }),
+            ---@diagnostic disable-next-line: deprecated
             workspace = ProviderConfig:make({
                 key = "ctrl-w",
                 provider = git_files_configs.providers,

--- a/lua/fzfx/live_grep.lua
+++ b/lua/fzfx/live_grep.lua
@@ -23,6 +23,7 @@ local function setup()
         if provider_name == "restricted" or provider_name == "unrestricted" then
             local action_key = provider_opts[1]
             local grep_cmd = provider_opts[2]
+            ---@diagnostic disable-next-line: deprecated
             new_providers[provider_name .. "_mode"] = ProviderConfig:make({
                 key = action_key,
                 provider = function(query)

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -168,11 +168,15 @@ local ProviderLineTypeEnum = {
 --- @class ProviderConfig
 --- @field key ActionKey
 --- @field provider Provider
---- @field provider_type ProviderType by default "plain"
---- @field line_opts ProviderConfigLineOpts
+--- @field provider_type ProviderType? by default "plain"
+--- @field line_opts ProviderConfigLineOpts?
 local ProviderConfig = {}
 
+--- @deprecated
 function ProviderConfig:make(opts)
+    require("fzfx.deprecated").notify(
+        "deprecated 'schema.ProviderConfig', please use lua table!"
+    )
     local o = opts or {}
     o.provider_type = o.provider_type
         or (


### PR DESCRIPTION
# Regresion test

## Platform

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file.
- [x] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
