### PR TITLE
feat(schema): add 'PreviewerConfig' detection

### DIFF
--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -16,7 +16,7 @@ local DEFAULT_PIPELINE = "default"
 
 -- config class detect {
 
---- @param cfg Configs
+--- @param cfg Configs?
 --- @return boolean
 local function is_command_config(cfg)
     return type(cfg) == "table"
@@ -27,7 +27,7 @@ local function is_command_config(cfg)
         and type(cfg.opts) == "table"
 end
 
---- @param cfg Configs
+--- @param cfg Configs?
 --- @return boolean
 local function is_provider_config(cfg)
     return type(cfg) == "table"
@@ -37,6 +37,20 @@ local function is_provider_config(cfg)
             (type(cfg.provider) == "string" and string.len(cfg.provider) > 0)
             or (type(cfg.provider) == "table" and #cfg.provider > 0)
             or type(cfg.provider) == "function"
+        )
+end
+
+--- @param cfg Configs?
+--- @return boolean
+local function is_previewer_config(cfg)
+    return type(cfg) == "table"
+        and type(cfg.previewer) == "function"
+        and (
+            cfg.previewer_type == nil
+            or (
+                type(cfg.previewer_type) == "string"
+                and string.len(cfg.previewer_type) > 0
+            )
         )
 end
 
@@ -951,6 +965,7 @@ local M = {
     setup = setup,
     is_command_config = is_command_config,
     is_provider_config = is_provider_config,
+    is_previewer_config = is_previewer_config,
     make_cache_filename = make_cache_filename,
     ProviderSwitch = ProviderSwitch,
     PreviewerSwitch = PreviewerSwitch,

--- a/test/general_spec.lua
+++ b/test/general_spec.lua
@@ -591,4 +591,42 @@ describe("general", function()
             )
         end)
     end)
+    describe("[is_previewer_config]", function()
+        it("is previewer config", function()
+            local p1 = schema.PreviewerConfig:make({
+                previewer = function()
+                    return "ls -lh"
+                end,
+            })
+            local p2 = schema.PreviewerConfig:make({
+                previewer = function()
+                    return { "ls", "-lh", "~" }
+                end,
+                previewer_type = "command_list",
+            })
+            assert_true(general.is_previewer_config(p1))
+            assert_true(general.is_previewer_config(p2))
+            local p4 = {
+                previewer = function()
+                    return "ls -lh"
+                end,
+            }
+            local p5 = {
+                previewer = function()
+                    return { "ls", "-lh" }
+                end,
+                previewer_type = "command_list",
+            }
+            assert_true(general.is_previewer_config(p4))
+            assert_true(general.is_previewer_config(p5))
+        end)
+        it("is not previewer config", function()
+            local p1 = schema.PreviewerConfig:make({})
+            assert_false(general.is_previewer_config(p1))
+            local p2 = {
+                name = "FzfxLiveGrep",
+            }
+            assert_false(general.is_previewer_config(p2))
+        end)
+    end)
 end)

--- a/test/general_spec.lua
+++ b/test/general_spec.lua
@@ -604,8 +604,15 @@ describe("general", function()
                 end,
                 previewer_type = "command_list",
             })
+            local p3 = schema.PreviewerConfig:make({
+                previewer = function()
+                    return "ls -lh"
+                end,
+                previewer_type = "command",
+            })
             assert_true(general.is_previewer_config(p1))
             assert_true(general.is_previewer_config(p2))
+            assert_true(general.is_previewer_config(p3))
             local p4 = {
                 previewer = function()
                     return "ls -lh"


### PR DESCRIPTION
# Regresion test

## Platform

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
