### PR TITLE
fix(actions): 'bdelete' filename containing whitespaces

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,11 @@
   - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
   - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
   - Press `ESC` to quit, `ENTER` to open file.
+- [ ] FzfxGBranches
+  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
+  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
+  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
+  - Press `ESC` to quit, `ENTER` to checkout branch.
 - [ ] FzfxGCommits
   - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
   - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,11 +19,11 @@
   - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
   - Use `-w` to match word only, use `-g *.lua` to search only lua files.
   - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
-  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files when searching `hello` and `goodbye` words.
+  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
   - Both `rg` and `grep` works.
 - [ ] FzfxBuffers
   - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
-  - Press `CTRL-D` to delete buffers.
+  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
   - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
   - Press `ESC` to quit, `ENTER` to open file.
 - [ ] FzfxGFiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,9 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - autoload
-      - bin
-      - lua
-      - test
   push:
     branches:
       - main
-    paths:
-      - autoload
-      - bin
-      - lua
-      - test
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - autoload
+      - bin
+      - lua
+      - test
   push:
     branches:
       - main
+    paths:
+      - autoload
+      - bin
+      - lua
+      - test
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -112,7 +112,7 @@ end
 --- @param lines string[]
 local function edit_grep(lines)
     local vim_commands = _make_edit_grep_commands(lines)
-    for i, vim_command in ipairs(vim_commands.edit) do
+    for i, vim_command in ipairs(vim_commands) do
         log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, vim_command)
         vim.cmd(vim_command)
     end

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -1,4 +1,5 @@
 local log = require("fzfx.log")
+local path = require("fzfx.path")
 local line_helpers = require("fzfx.line_helpers")
 
 --- @param lines string[]
@@ -7,17 +8,16 @@ local function nop(lines)
     log.debug("|fzfx.actions - nop| lines:%s", vim.inspect(lines))
 end
 
---- @alias EditFindVimCommands {edit:string[]}
 --- @package
 --- @param lines string[]
 --- @param opts {no_icon:boolean?}?
---- @return EditFindVimCommands
+--- @return string[]
 local function _make_edit_find_commands(lines, opts)
-    local results = { edit = {} }
+    local results = {}
     for i, line in ipairs(lines) do
         local filename = line_helpers.parse_find(line, opts)
         local edit_command = string.format("edit %s", filename)
-        table.insert(results.edit, edit_command)
+        table.insert(results, edit_command)
     end
     return results
 end
@@ -25,8 +25,8 @@ end
 -- Run 'edit' vim command on fd/find results.
 --- @param lines string[]
 local function edit_find(lines)
-    local vim_commands = _make_edit_find_commands(lines)
-    for i, edit_command in ipairs(vim_commands.edit) do
+    local edit_commands = _make_edit_find_commands(lines)
+    for i, edit_command in ipairs(edit_commands) do
         log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
         vim.cmd(edit_command)
     end
@@ -50,26 +50,25 @@ local function edit(lines)
     return edit_find(lines)
 end
 
---- @alias EditRgVimCommands {edit:string[], setpos:string?}
 --- @package
 --- @param lines string[]
 --- @param opts {no_icon:boolean?}?
---- @return EditRgVimCommands
+--- @return string[]
 local function _make_edit_rg_commands(lines, opts)
-    local results = { edit = {}, setpos = nil }
+    local results = {}
     for i, line in ipairs(lines) do
         local parsed = line_helpers.parse_rg(line, opts)
         local edit_command = string.format("edit %s", parsed.filename)
-        table.insert(results.edit, edit_command)
+        table.insert(results, edit_command)
         if parsed.lineno ~= nil then
             if i == #lines then
                 local column = parsed.column or 1
-                local setpos_cmd = string.format(
+                local setpos_command = string.format(
                     "call setpos('.', [0, %d, %d])",
                     parsed.lineno,
                     column
                 )
-                results.setpos = setpos_cmd
+                table.insert(results, setpos_command)
             end
         end
     end
@@ -79,36 +78,31 @@ end
 --- @param lines string[]
 local function edit_rg(lines)
     local vim_commands = _make_edit_rg_commands(lines)
-    for i, edit_command in ipairs(vim_commands.edit) do
-        log.debug("|fzfx.actions - edit_rg| edit[%d]:[%s]", i, edit_command)
-        vim.cmd(edit_command)
-    end
-    if vim_commands.setpos then
-        log.debug("|fzfx.actions - edit_rg| setpos:[%s]", vim_commands.setpos)
-        vim.cmd(vim_commands.setpos)
+    for i, vim_command in ipairs(vim_commands) do
+        log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, vim_command)
+        vim.cmd(vim_command)
     end
 end
 
---- @alias EditGrepVimCommands {edit:string[], setpos:string?}
 --- @package
 --- @param lines string[]
 --- @param opts {no_icon:boolean?}?
---- @return EditGrepVimCommands
+--- @return string[]
 local function _make_edit_grep_commands(lines, opts)
-    local results = { edit = {}, setpos = nil }
+    local results = {}
     for i, line in ipairs(lines) do
         local parsed = line_helpers.parse_grep(line, opts)
         local edit_command = string.format("edit %s", parsed.filename)
-        table.insert(results.edit, edit_command)
+        table.insert(results, edit_command)
         if parsed.lineno ~= nil then
             if i == #lines then
                 local column = 1
-                local setpos_cmd = string.format(
+                local setpos_command = string.format(
                     "call setpos('.', [0, %d, %d])",
                     parsed.lineno,
                     column
                 )
-                results.setpos = setpos_cmd
+                table.insert(results, setpos_command)
             end
         end
     end
@@ -118,21 +112,17 @@ end
 --- @param lines string[]
 local function edit_grep(lines)
     local vim_commands = _make_edit_grep_commands(lines)
-    for i, edit_command in ipairs(vim_commands.edit) do
-        log.debug("|fzfx.actions - edit_grep| edit[%d]:[%s]", i, edit_command)
-        vim.cmd(edit_command)
-    end
-    if vim_commands.setpos then
-        log.debug("|fzfx.actions - edit_grep| setpos:[%s]", vim_commands.setpos)
-        vim.cmd(vim_commands.setpos)
+    for i, vim_command in ipairs(vim_commands.edit) do
+        log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, vim_command)
+        vim.cmd(vim_command)
     end
 end
 
 -- Run 'edit' vim command on eza/exa/ls results.
 --- @param lines string[]
 local function edit_ls(lines)
-    local vim_commands = _make_edit_find_commands(lines, { no_icon = true })
-    for i, edit_command in ipairs(vim_commands.edit) do
+    local edit_commands = _make_edit_find_commands(lines, { no_icon = true })
+    for i, edit_command in ipairs(edit_commands) do
         log.debug("|fzfx.actions - edit_ls| [%d]:[%s]", i, edit_command)
         vim.cmd(edit_command)
     end
@@ -143,21 +133,25 @@ local function buffer(lines)
     return edit_find(lines)
 end
 
-local function bdelete(lines)
-    if type(lines) == "string" then
-        lines = { lines }
+--- @param line string?
+local function bdelete(line)
+    local list_bufnrs = vim.api.nvim_list_bufs()
+    local list_bufpaths = {}
+    for _, bufnr in ipairs(list_bufnrs) do
+        local bufpath = path.reduce(vim.api.nvim_buf_get_name(bufnr))
+        list_bufpaths[bufpath] = bufnr
     end
-    if type(lines) == "table" and #lines > 0 then
-        for _, line in ipairs(lines) do
-            local parsed = line_helpers.PathLine:new(line)
-            local cmd = string.format("bdelete %s", parsed.filename)
-            log.debug(
-                "|fzfx.actions - bdelete| line:[%s], bufname:[%s], cmd:[%s]",
-                line,
-                parsed.filename,
-                cmd
-            )
-            vim.cmd(cmd)
+    log.debug(
+        "|fzfx.actions - bdelete| list_bufpaths:%s",
+        vim.inspect(list_bufpaths)
+    )
+    log.debug("|fzfx.actions - bdelete| line:%s", vim.inspect(line))
+    if type(line) == "string" and string.len(line) > 0 then
+        local bufpath = line_helpers.parse_find(line)
+        log.debug("|fzfx.actions - bdelete| bufpath:%s", vim.inspect(bufpath))
+        local bufnr = list_bufpaths[bufpath]
+        if type(bufnr) == "number" then
+            vim.api.nvim_buf_delete(bufnr, {})
         end
     end
 end
@@ -200,9 +194,9 @@ end
 
 local M = {
     nop = nop,
-    make_edit_find_commands = _make_edit_find_commands,
-    make_edit_grep_commands = _make_edit_grep_commands,
-    make_edit_rg_commands = _make_edit_rg_commands,
+    _make_edit_find_commands = _make_edit_find_commands,
+    _make_edit_grep_commands = _make_edit_grep_commands,
+    _make_edit_rg_commands = _make_edit_rg_commands,
     edit = edit,
     edit_find = edit_find,
     edit_buffers = edit_buffers,

--- a/lua/fzfx/line_helpers.lua
+++ b/lua/fzfx/line_helpers.lua
@@ -126,78 +126,6 @@ end
 local parse_ls = make_parse_ls(8)
 local parse_eza = constants.is_windows and make_parse_ls(5) or make_parse_ls(6)
 
---- @param line string
---- @return string
-local function parse_filename(line)
-    local filename = nil
-    if env.icon_enable() then
-        local splits = utils.string_split(line, " ")
-        filename = splits[#splits]
-    else
-        filename = line
-    end
-    return path.normalize(filename)
-end
-
---- @alias PathLineParsedResult {filename:string,lineno:string?,column:string?}
---- @param line string
---- @param delimiter string?
---- @param file_pos integer?
---- @param lineno_pos integer?
---- @param colno_pos integer?
---- @return PathLineParsedResult
-local function parse_path_line(line, delimiter, file_pos, lineno_pos, colno_pos)
-    local filename = nil
-    local lineno = nil
-    local column = nil
-    if type(delimiter) == "string" and string.len(delimiter) > 0 then
-        local parts = utils.string_split(line, delimiter)
-        filename = parse_filename(
-            parts[file_pos > 0 and file_pos or (#parts + file_pos + 1)]
-        )
-        if type(lineno_pos) == "number" then
-            lineno = tonumber(
-                parts[lineno_pos > 0 and lineno_pos or (#parts + lineno_pos + 1)]
-            )
-        end
-        if type(colno_pos) == "number" then
-            column = tonumber(
-                parts[colno_pos > 0 and colno_pos or (#parts + colno_pos + 1)]
-            )
-        end
-    else
-        filename = parse_filename(line)
-    end
-    return { filename = filename, lineno = lineno, column = column }
-end
-
---- @class PathLine
---- @field source string
---- @field filename string
---- @field lineno integer?
---- @field column integer?
-local PathLine = {}
-
---- @param line string
---- @param delimiter string?
---- @param file_pos integer?
---- @param lineno_pos integer?
---- @param colno_pos integer?
---- @return PathLine
-function PathLine:new(line, delimiter, file_pos, lineno_pos, colno_pos)
-    local parsed =
-        parse_path_line(line, delimiter, file_pos, lineno_pos, colno_pos)
-    local o = {
-        line = line,
-        filename = parsed.filename,
-        lineno = parsed.lineno,
-        column = parsed.column,
-    }
-    setmetatable(o, self)
-    self.__index = self
-    return o
-end
-
 local M = {
     parse_find = parse_find,
     parse_grep = parse_grep,
@@ -205,9 +133,6 @@ local M = {
     make_parse_ls = make_parse_ls,
     parse_ls = parse_ls,
     parse_eza = parse_eza,
-    parse_filename = parse_filename,
-    parse_path_line = parse_path_line,
-    PathLine = PathLine,
 }
 
 return M

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -23,7 +23,7 @@ describe("actions", function()
             assert_true(nop({}) == nil)
         end)
     end)
-    describe("[make_edit_find_commands]", function()
+    describe("[_make_commands_for_find]", function()
         it("edit file without icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil
             local lines = {
@@ -33,16 +33,15 @@ describe("actions", function()
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
             }
-            local actual = actions.make_edit_find_commands(lines)
+            local actual = actions._make_edit_find_commands(lines)
             assert_eq(type(actual), "table")
-            assert_eq(type(actual.edit), "table")
-            assert_eq(#actual.edit, 5)
+            assert_eq(#actual, 5)
             for i, line in ipairs(lines) do
                 local expect = string.format(
                     "edit %s",
                     vim.fn.expand(path.normalize(line))
                 )
-                assert_eq(actual.edit[i], expect)
+                assert_eq(actual[i], expect)
             end
         end)
         it("edit file with prepend icon", function()
@@ -54,17 +53,16 @@ describe("actions", function()
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
             }
-            local actual = actions.make_edit_find_commands(lines)
+            local actual = actions._make_edit_find_commands(lines)
             assert_eq(type(actual), "table")
-            assert_eq(type(actual.edit), "table")
-            assert_eq(#actual.edit, 5)
+            assert_eq(#actual, 5)
             for i, line in ipairs(lines) do
                 local first_space_pos = utils.string_find(line, " ")
                 local expect = string.format(
                     "edit %s",
                     vim.fn.expand(path.normalize(line:sub(first_space_pos + 1)))
                 )
-                assert_eq(actual.edit[i], expect)
+                assert_eq(actual[i], expect)
             end
         end)
         it("run edit file command without icon", function()
@@ -94,7 +92,7 @@ describe("actions", function()
             assert_true(true)
         end)
     end)
-    describe("[make_edit_grep_commands]", function()
+    describe("[_make_edit_grep_commands]", function()
         it("edit file without icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil
             local lines = {
@@ -104,20 +102,22 @@ describe("actions", function()
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81: goodbye",
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:72:9129",
             }
-            local actual = actions.make_edit_grep_commands(lines)
+            local actual = actions._make_edit_grep_commands(lines)
             assert_eq(type(actual), "table")
-            assert_eq(type(actual.edit), "table")
-            assert_eq(#actual.edit, 5)
-            for i, line in ipairs(lines) do
-                local expect = string.format(
-                    "edit %s",
-                    vim.fn.expand(
-                        path.normalize(utils.string_split(line, ":")[1])
+            assert_eq(#actual, 6)
+            for i, act in ipairs(actual) do
+                if i <= #lines then
+                    local expect = string.format(
+                        "edit %s",
+                        vim.fn.expand(
+                            path.normalize(utils.string_split(lines[i], ":")[1])
+                        )
                     )
-                )
-                assert_eq(actual.edit[i], expect)
+                    assert_eq(act, expect)
+                else
+                    assert_eq(act, "call setpos('.', [0, 81, 1])")
+                end
             end
-            assert_eq(actual.setpos, "call setpos('.', [0, 81, 1])")
         end)
         it("edit file with prepend icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = DEVICONS_PATH
@@ -128,19 +128,17 @@ describe("actions", function()
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
             }
-            local actual = actions.make_edit_grep_commands(lines)
+            local actual = actions._make_edit_grep_commands(lines)
             assert_eq(type(actual), "table")
-            assert_eq(type(actual.edit), "table")
-            assert_eq(#actual.edit, 5)
+            assert_eq(#actual, 5)
             for i, line in ipairs(lines) do
                 local first_space_pos = utils.string_find(line, " ")
                 local expect = string.format(
                     "edit %s",
                     vim.fn.expand(path.normalize(line:sub(first_space_pos + 1)))
                 )
-                assert_eq(actual.edit[i], expect)
+                assert_eq(actual[i], expect)
             end
-            assert_true(actual.setpos == nil)
         end)
         it("run edit file command without icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil
@@ -169,7 +167,7 @@ describe("actions", function()
             assert_true(true)
         end)
     end)
-    describe("[make_edit_rg_commands]", function()
+    describe("[_make_edit_rg_commands]", function()
         it("edit file without icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil
             local lines = {
@@ -179,20 +177,22 @@ describe("actions", function()
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81: goodbye",
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:71:9129",
             }
-            local actual = actions.make_edit_rg_commands(lines)
+            local actual = actions._make_edit_rg_commands(lines)
             assert_eq(type(actual), "table")
-            assert_eq(type(actual.edit), "table")
-            assert_eq(#actual.edit, 5)
-            for i, line in ipairs(lines) do
-                local expect = string.format(
-                    "edit %s",
-                    vim.fn.expand(
-                        path.normalize(utils.string_split(line, ":")[1])
+            assert_eq(#actual, 6)
+            for i, act in ipairs(actual) do
+                if i <= #lines then
+                    local expect = string.format(
+                        "edit %s",
+                        vim.fn.expand(
+                            path.normalize(utils.string_split(lines[i], ":")[1])
+                        )
                     )
-                )
-                assert_eq(actual.edit[i], expect)
+                    assert_eq(act, expect)
+                else
+                    assert_eq(act, "call setpos('.', [0, 81, 71])")
+                end
             end
-            assert_eq(actual.setpos, "call setpos('.', [0, 81, 71])")
         end)
         it("edit file with prepend icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = DEVICONS_PATH
@@ -203,19 +203,17 @@ describe("actions", function()
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
             }
-            local actual = actions.make_edit_rg_commands(lines)
+            local actual = actions._make_edit_rg_commands(lines)
             assert_eq(type(actual), "table")
-            assert_eq(type(actual.edit), "table")
-            assert_eq(#actual.edit, 5)
+            assert_eq(#actual, 5)
             for i, line in ipairs(lines) do
                 local first_space_pos = utils.string_find(line, " ")
                 local expect = string.format(
                     "edit %s",
                     vim.fn.expand(path.normalize(line:sub(first_space_pos + 1)))
                 )
-                assert_eq(actual.edit[i], expect)
+                assert_eq(actual[i], expect)
             end
-            assert_true(actual.setpos == nil)
         end)
         it("run edit file command without icon", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files when searching `hello` and `goodbye` words.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `eza` and `ls` works.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
