### PR TITLE
refactor(config): rewrite live grep providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses:  ytanikin/PRConventionalCommits@1.1.0
+      - uses: ytanikin/PRConventionalCommits@1.1.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
   luacheck:

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -185,7 +185,7 @@ local default_unrestricted_grep = {
 }
 
 --- @param query string
---- @param unrestricted:boolean
+--- @param unrestricted boolean
 --- @return string[]|nil
 local function make_grep_command(query, unrestricted)
     local parsed_query = utils.parse_flag_query(query or "")

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -28,6 +28,7 @@ local default_git_log_pretty =
 -- files {
 
 -- fd
+-- "fd . -cnever -tf -tl -L -i"
 local default_restricted_fd = {
     constants.fd,
     ".",
@@ -37,6 +38,7 @@ local default_restricted_fd = {
     "-L",
     "-i",
 }
+-- "fd . -cnever -tf -tl -L -i -u"
 local default_unrestricted_fd = {
     constants.fd,
     ".",
@@ -48,6 +50,7 @@ local default_unrestricted_fd = {
     "-u",
 }
 -- find
+-- 'find -L . -type f -not -path "*/.*"'
 local default_restricted_find = constants.is_windows
         and {
             constants.find,
@@ -66,6 +69,7 @@ local default_restricted_find = constants.is_windows
         "-path",
         [[*/.*]],
     }
+-- "find -L . -type f"
 local default_unrestricted_find = {
     constants.find,
     "-L",
@@ -139,21 +143,83 @@ end
 
 -- live grep {
 
---- @param option string
---- @param merged string[]
---- @return string[]
-local function merge_query_options(merged, option)
-    local option_splits = utils.string_split(option, " ")
-    log.debug(
-        "|fzfx.config - merge_query_options| option_splits:%s",
-        vim.inspect(option_splits)
-    )
-    for _, o in ipairs(option_splits) do
-        if type(o) == "string" and string.len(o) > 0 then
-            table.insert(merged, o)
+-- rg
+-- "rg --column -n --no-heading --color=always -S"
+local default_restricted_rg = {
+    "rg",
+    "--column",
+    "-n",
+    "--no-heading",
+    "--color=always",
+    "-S",
+}
+-- "rg --column -n --no-heading --color=always -S -uu"
+local default_unrestricted_rg = {
+    "rg",
+    "--column",
+    "-n",
+    "--no-heading",
+    "--color=always",
+    "-S",
+    "-uu",
+}
+
+-- grep
+-- "grep --color=always -n -H -r --exclude-dir='./.*' --exclude='./.*'"
+local default_restricted_grep = {
+    constants.grep,
+    "--color=always",
+    "-n",
+    "-H",
+    "-r",
+    "--exclude-dir=" .. (constants.has_gnu_grep and [[.*]] or [[./.*]]),
+    "--exclude=" .. (constants.has_gnu_grep and [[.*]] or [[./.*]]),
+}
+-- "grep --color=always -n -H -r"
+local default_unrestricted_grep = {
+    constants.grep,
+    "--color=always",
+    "-n",
+    "-H",
+    "-r",
+}
+
+--- @param query string
+--- @param opts {command:"rg"|"grep",unrestricted:boolean}
+--- @return string[]|nil
+local function make_grep_command(query, opts)
+    local parsed_query = utils.parse_flag_query(query or "")
+    local content = parsed_query[1]
+    local option = parsed_query[2]
+
+    local args = nil
+    if opts.command == "rg" then
+        if opts.unrestricted then
+            args = vim.deepcopy(default_unrestricted_rg)
+        else
+            args = vim.deepcopy(default_restricted_rg)
+        end
+    elseif opts.command == "grep" then
+        if opts.unrestricted then
+            args = vim.deepcopy(default_unrestricted_grep)
+        else
+            args = vim.deepcopy(default_restricted_grep)
+        end
+    else
+        log.echo(LogLevels.INFO, "no rg/grep command found.")
+        return nil
+    end
+    if type(option) == "string" and string.len(option) > 0 then
+        local option_splits = utils.string_split(option, " ")
+        for _, o in ipairs(option_splits) do
+            if type(o) == "string" and string.len(o) > 0 then
+                table.insert(args, o)
+            end
         end
     end
-    return merged
+    table.insert(args, "--")
+    table.insert(args, content)
+    return args
 end
 
 --- @param line string
@@ -912,79 +978,11 @@ local Defaults = {
             restricted_mode = {
                 key = "ctrl-r",
                 provider = function(query)
-                    local parsed_query = utils.parse_flag_query(query or "")
-                    local content = parsed_query[1]
-                    local option = parsed_query[2]
-
-                    if vim.fn.executable("rg") > 0 then
-                        if
-                            type(option) == "string"
-                            and string.len(option) > 0
-                        then
-                            -- "rg --column -n --no-heading --color=always -S %s -- %s"
-                            local args = {
-                                "rg",
-                                "--column",
-                                "-n",
-                                "--no-heading",
-                                "--color=always",
-                                "-S",
-                            }
-                            args = merge_query_options(args, option)
-                            table.insert(args, "--")
-                            table.insert(args, content)
-                            return args
-                        else
-                            -- "rg --column -n --no-heading --color=always -S -- %s"
-                            return {
-                                "rg",
-                                "--column",
-                                "-n",
-                                "--no-heading",
-                                "--color=always",
-                                "-S",
-                                "--",
-                                content,
-                            }
-                        end
-                    else
-                        local grep_cmd = constants.has_gnu_grep
-                                and constants.gnu_grep
-                            or constants.grep
-                        local exclude_opt = constants.has_gnu_grep and [[.*]]
-                            or [[./.*]]
-                        if
-                            type(option) == "string"
-                            and string.len(option) > 0
-                        then
-                            -- "%s --color=always -n -H -r --exclude-dir=%s --exclude=%s %s -- %s"
-                            local args = {
-                                grep_cmd,
-                                "--color=always",
-                                "-n",
-                                "-H",
-                                "-r",
-                                "--exclude-dir=" .. exclude_opt,
-                                "--exclude=" .. exclude_opt,
-                            }
-                            args = merge_query_options(args, option)
-                            table.insert(args, "--")
-                            table.insert(args, content)
-                        else
-                            -- "%s --color=always -n -H -r --exclude-dir=%s --exclude=%s -- %s"
-                            return {
-                                grep_cmd,
-                                "--color=always",
-                                "-n",
-                                "-H",
-                                "-r",
-                                "--exclude-dir=" .. exclude_opt,
-                                "--exclude=" .. exclude_opt,
-                                "--",
-                                content,
-                            }
-                        end
-                    end
+                    return make_grep_command(query, {
+                        command = vim.fn.executable("rg") > 0 and "rg"
+                            or "grep",
+                        unrestricted = false,
+                    })
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
                 line_opts = {
@@ -996,75 +994,11 @@ local Defaults = {
             unrestricted_mode = {
                 key = "ctrl-u",
                 provider = function(query)
-                    local parsed_query = utils.parse_flag_query(query or "")
-                    local content = parsed_query[1]
-                    local option = parsed_query[2]
-
-                    if vim.fn.executable("rg") > 0 then
-                        if
-                            type(option) == "string"
-                            and string.len(option) > 0
-                        then
-                            -- "rg --column -n --no-heading --color=always -S -uu %s -- %s"
-                            local args = {
-                                "rg",
-                                "--column",
-                                "-n",
-                                "--no-heading",
-                                "--color=always",
-                                "-S",
-                                "-uu",
-                            }
-                            args = merge_query_options(args, option)
-                            table.insert(args, "--")
-                            table.insert(args, content)
-                            return args
-                        else
-                            -- "rg --column -n --no-heading --color=always -S -uu -- %s"
-                            return {
-                                "rg",
-                                "--column",
-                                "-n",
-                                "--no-heading",
-                                "--color=always",
-                                "-S",
-                                "-uu",
-                                "--",
-                                content,
-                            }
-                        end
-                    else
-                        local grep_cmd = constants.has_gnu_grep
-                                and constants.gnu_grep
-                            or constants.grep
-                        if
-                            type(option) == "string"
-                            and string.len(option) > 0
-                        then
-                            -- "%s --color=always -n -H -r %s -- %s"
-                            local args = {
-                                grep_cmd,
-                                "--color=always",
-                                "-n",
-                                "-H",
-                                "-r",
-                            }
-                            args = merge_query_options(args, option)
-                            table.insert(args, "--")
-                            table.insert(args, content)
-                        else
-                            -- "%s --color=always -n -H -r -- %s"
-                            return {
-                                grep_cmd,
-                                "--color=always",
-                                "-n",
-                                "-H",
-                                "-r",
-                                "--",
-                                content,
-                            }
-                        end
-                    end
+                    return make_grep_command(query, {
+                        command = vim.fn.executable("rg") > 0 and "rg"
+                            or "grep",
+                        unrestricted = true,
+                    })
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
                 line_opts = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -165,7 +165,7 @@ local default_unrestricted_rg = {
 }
 
 -- grep
--- "grep --color=always -n -H -r --exclude-dir='./.*' --exclude='./.*'"
+-- "grep --color=always -n -H -r --exclude-dir='.*' --exclude='.*'"
 local default_restricted_grep = {
     constants.grep,
     "--color=always",

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -187,7 +187,7 @@ local default_unrestricted_grep = {
 --- @param query string
 --- @param unrestricted boolean
 --- @return string[]|nil
-local function make_grep_command(query, unrestricted)
+local function live_grep_provider(query, unrestricted)
     local parsed_query = utils.parse_flag_query(query or "")
     local content = parsed_query[1]
     local option = parsed_query[2]
@@ -972,7 +972,7 @@ local Defaults = {
             restricted_mode = {
                 key = "ctrl-r",
                 provider = function(query)
-                    return make_grep_command(query, false)
+                    return live_grep_provider(query, false)
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
                 line_opts = {
@@ -984,7 +984,7 @@ local Defaults = {
             unrestricted_mode = {
                 key = "ctrl-u",
                 provider = function(query)
-                    return make_grep_command(query, true)
+                    return live_grep_provider(query, true)
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
                 line_opts = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -185,19 +185,19 @@ local default_unrestricted_grep = {
 }
 
 --- @param query string
---- @param opts {command:"rg"|"grep",unrestricted:boolean}
+--- @param unrestricted:boolean
 --- @return string[]|nil
-local function make_grep_command(query, opts)
+local function make_grep_command(query, unrestricted)
     local parsed_query = utils.parse_flag_query(query or "")
     local content = parsed_query[1]
     local option = parsed_query[2]
 
     local args = nil
-    if opts.command == "rg" then
-        args = opts.unrestricted and vim.deepcopy(default_unrestricted_rg)
+    if vim.fn.executable("rg") > 0 then
+        args = unrestricted and vim.deepcopy(default_unrestricted_rg)
             or vim.deepcopy(default_restricted_rg)
-    elseif opts.command == "grep" then
-        args = opts.unrestricted and vim.deepcopy(default_unrestricted_grep)
+    elseif vim.fn.executable("grep") > 0 or vim.fn.executable("ggrep") > 0 then
+        args = unrestricted and vim.deepcopy(default_unrestricted_grep)
             or vim.deepcopy(default_restricted_grep)
     else
         log.echo(LogLevels.INFO, "no rg/grep command found.")
@@ -972,11 +972,7 @@ local Defaults = {
             restricted_mode = {
                 key = "ctrl-r",
                 provider = function(query)
-                    return make_grep_command(query, {
-                        command = vim.fn.executable("rg") > 0 and "rg"
-                            or "grep",
-                        unrestricted = false,
-                    })
+                    return make_grep_command(query, false)
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
                 line_opts = {
@@ -988,11 +984,7 @@ local Defaults = {
             unrestricted_mode = {
                 key = "ctrl-u",
                 provider = function(query)
-                    return make_grep_command(query, {
-                        command = vim.fn.executable("rg") > 0 and "rg"
-                            or "grep",
-                        unrestricted = true,
-                    })
+                    return make_grep_command(query, true)
                 end,
                 provider_type = ProviderTypeEnum.COMMAND_LIST,
                 line_opts = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -194,17 +194,11 @@ local function make_grep_command(query, opts)
 
     local args = nil
     if opts.command == "rg" then
-        if opts.unrestricted then
-            args = vim.deepcopy(default_unrestricted_rg)
-        else
-            args = vim.deepcopy(default_restricted_rg)
-        end
+        args = opts.unrestricted and vim.deepcopy(default_unrestricted_rg)
+            or vim.deepcopy(default_restricted_rg)
     elseif opts.command == "grep" then
-        if opts.unrestricted then
-            args = vim.deepcopy(default_unrestricted_grep)
-        else
-            args = vim.deepcopy(default_restricted_grep)
-        end
+        args = opts.unrestricted and vim.deepcopy(default_unrestricted_grep)
+            or vim.deepcopy(default_restricted_grep)
     else
         log.echo(LogLevels.INFO, "no rg/grep command found.")
         return nil

--- a/lua/fzfx/constants.lua
+++ b/lua/fzfx/constants.lua
@@ -25,7 +25,7 @@ local has_gnu_grep = (
     (is_windows or is_linux) and vim.fn.executable("grep") > 0
 ) or vim.fn.executable("ggrep") > 0
 local gnu_grep = vim.fn.executable("ggrep") > 0 and "ggrep" or "grep"
-local grep = "grep"
+local grep = vim.fn.executable("ggrep") > 0 and "ggrep" or "grep"
 
 local has_eza = vim.fn.executable("exa") > 0 or vim.fn.executable("eza") > 0
 local eza = vim.fn.executable("eza") > 0 and "eza" or "exa"

--- a/lua/fzfx/module.lua
+++ b/lua/fzfx/module.lua
@@ -1,18 +1,20 @@
 local log = require("fzfx.log")
 
---- @return string|nil
+--- @param plugin string
+--- @param path string
+--- @return string?
 local function search_module_path(plugin, path)
-    local plugin_ok, plugin_module = pcall(require, plugin)
-    if not plugin_ok then
+    local ok, module_path_or_err = pcall(require, plugin)
+    if not ok then
         log.debug(
             "|fzfx.module - search_module_path| failed to load lua module %s: %s",
             vim.inspect(plugin),
-            vim.inspect(plugin_module)
+            vim.inspect(module_path_or_err)
         )
         return nil
     end
-    local rtp = vim.api.nvim_list_runtime_paths()
-    for i, p in ipairs(rtp) do
+    local runtime_paths = vim.api.nvim_list_runtime_paths()
+    for i, p in ipairs(runtime_paths) do
         -- log.debug("|fzfx.module - search_module_path| p[%d]:%s", i, p)
         if type(p) == "string" and string.match(p, path) then
             return p
@@ -21,38 +23,38 @@ local function search_module_path(plugin, path)
     log.debug(
         "|fzfx.module - search_module_path| failed to find lua module %s on runtimepath: %s",
         vim.inspect(plugin),
-        vim.inspect(rtp)
+        vim.inspect(runtime_paths)
     )
     return nil
 end
 
 --- @return string|nil
-local function search_vim_plugin_path(plugin)
-    local rtp = type(vim.o.runtimepath) == "string"
-            and vim.fn.split(vim.o.runtimepath, ",")
-        or {}
-    for i, p in ipairs(rtp) do
-        -- log.debug("|fzfx.module - search_vim_plugin_path| p[%d]:%s", i, p)
-        if
-            type(p) == "string"
-            and string.match(
-                require("fzfx.path").normalize(
-                    p,
-                    { transform_backslash = true }
-                ),
-                plugin
-            )
-        then
-            return p
-        end
-    end
-    log.debug(
-        "|fzfx.module - search_vim_plugin_path| failed to find vim plugin %s on runtimepath: %s",
-        vim.inspect(plugin),
-        vim.inspect(rtp)
-    )
-    return nil
-end
+-- local function search_vim_plugin_path(plugin)
+--     local rtp = type(vim.o.runtimepath) == "string"
+--             and vim.fn.split(vim.o.runtimepath, ",")
+--         or {}
+--     for i, p in ipairs(rtp) do
+--         -- log.debug("|fzfx.module - search_vim_plugin_path| p[%d]:%s", i, p)
+--         if
+--             type(p) == "string"
+--             and string.match(
+--                 require("fzfx.path").normalize(
+--                     p,
+--                     { transform_backslash = true }
+--                 ),
+--                 plugin
+--             )
+--         then
+--             return p
+--         end
+--     end
+--     log.debug(
+--         "|fzfx.module - search_vim_plugin_path| failed to find vim plugin %s on runtimepath: %s",
+--         vim.inspect(plugin),
+--         vim.inspect(rtp)
+--     )
+--     return nil
+-- end
 
 --- @param configs Configs
 local function setup(configs)


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `eza` and `ls` works.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
