### PR TITLE
test(actions): add test cases for 'git_checkout'

### DIFF
--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -159,7 +159,7 @@ local function bdelete(line)
 end
 
 --- @param lines string[]
---- @return string
+--- @return string?
 local function _make_git_checkout_command(lines)
     log.debug(
         "|fzfx.actions - _make_git_checkout_command| lines:%s",
@@ -203,7 +203,7 @@ end
 
 --- @param lines string[]
 local function git_checkout(lines)
-    local checkout_command = _make_git_checkout_command(lines)
+    local checkout_command = _make_git_checkout_command(lines) --[[@as string]]
     vim.cmd(checkout_command)
 end
 

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -1927,7 +1927,6 @@ local Defaults = {
                             )
                         end
                     end
-
                     return branch_results
                 end,
                 provider_type = ProviderTypeEnum.LIST,
@@ -1976,7 +1975,6 @@ local Defaults = {
                             )
                         end
                     end
-
                     return branch_results
                 end,
                 provider_type = ProviderTypeEnum.LIST,

--- a/lua/fzfx/utils.lua
+++ b/lua/fzfx/utils.lua
@@ -79,7 +79,7 @@ end
 --- @return integer?
 local function string_find(s, t, start)
     -- start = start or 1
-    -- local result = vim.fn.stridx(s, c, start - 1)
+    -- local result = vim.fn.stridx(s, t, start - 1)
     -- return result >= 0 and (result + 1) or nil
 
     start = start or 1
@@ -110,7 +110,7 @@ end
 --- @return integer?
 local function string_rfind(s, t, rstart)
     -- rstart = rstart or 1
-    -- local result = vim.fn.strridx(s, c, rstart - 1)
+    -- local result = vim.fn.strridx(s, t, rstart - 1)
     -- return result >= 0 and (result + 1) or nil
 
     rstart = rstart or #s
@@ -196,25 +196,25 @@ local function string_split(s, delimiter, opts)
 end
 
 --- @param s string
---- @param c string
-local function string_startswith(s, c)
+--- @param t string
+local function string_startswith(s, t)
     local start_pos = 1
-    local end_pos = #c
+    local end_pos = #t
     if start_pos > end_pos then
         return false
     end
-    return s:sub(start_pos, end_pos) == c
+    return s:sub(start_pos, end_pos) == t
 end
 
 --- @param s string
---- @param c string
-local function string_endswith(s, c)
-    local start_pos = #s - #c + 1
+--- @param t string
+local function string_endswith(s, t)
+    local start_pos = #s - #t + 1
     local end_pos = #s
     if start_pos > end_pos then
         return false
     end
-    return s:sub(start_pos, end_pos) == c
+    return s:sub(start_pos, end_pos) == t
 end
 
 --- @param s string

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -387,4 +387,88 @@ describe("actions", function()
             assert_true(actual == nil)
         end)
     end)
+    describe("[_make_git_checkout_command]", function()
+        it("checkout local git branch", function()
+            local lines = {
+                "main",
+                "master",
+                "my-plugin-dev",
+                "test-config1",
+            }
+            for _, line in ipairs(lines) do
+                assert_eq(
+                    string.format("!git checkout %s", line),
+                    actions._make_git_checkout_command({ line })
+                )
+            end
+        end)
+        it("checkout remote git branch", function()
+            local lines = {
+                "origin/HEAD -> origin/main",
+                "origin/main",
+                "origin/my-plugin-dev",
+                "origin/ci-fix-create-tags",
+                "origin/ci-verbose",
+                "origin/docs-table",
+                "origin/feat-setqflist",
+                "origin/feat-vim-commands",
+                "origin/main",
+                "origin/release-please--branches--main--components--fzfx.nvim",
+            }
+            for i, line in ipairs(lines) do
+                if utils.string_find(line, "origin/main") then
+                    local actual = actions._make_git_checkout_command({ line })
+                    print(
+                        string.format("git checkout remote[%d]:%s\n", i, actual)
+                    )
+                    assert_eq(string.format("!git checkout main"), actual)
+                else
+                    assert_eq(
+                        string.format(
+                            "!git checkout %s",
+                            line:sub(string.len("origin/") + 1)
+                        ),
+                        actions._make_git_checkout_command({ line })
+                    )
+                end
+            end
+        end)
+        it("checkout all git branch", function()
+            local lines = {
+                "main",
+                "my-plugin-dev",
+                "remotes/origin/HEAD -> origin/main",
+                "remotes/origin/main",
+                "remotes/origin/my-plugin-dev",
+                "remotes/origin/ci-fix-create-tags",
+                "remotes/origin/ci-verbose",
+            }
+            for i, line in ipairs(lines) do
+                if utils.string_find(line, "main") then
+                    assert_eq(
+                        string.format("!git checkout main"),
+                        actions._make_git_checkout_command({ line })
+                    )
+                else
+                    local actual = actions._make_git_checkout_command({ line })
+                    print(string.format("git checkout all[%d]:%s\n", i, actual))
+                    local split_pos = utils.string_find(line, "remotes/origin/")
+                    if split_pos then
+                        assert_eq(
+                            string.format(
+                                "!git checkout %s",
+                                line:sub(string.len("remotes/origin/") + 1)
+                            ),
+                            actual
+                        )
+                    else
+                        assert_eq(
+                            string.format("!git checkout %s", line),
+                            actual
+                        )
+                    end
+                end
+            end
+        end)
+    end)
 end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `eza` and `ls` works.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
