### PR TITLE
feat(logs): split shell command provider/previewer logs

### DIFF
--- a/bin/general/previewer.lua
+++ b/bin/general/previewer.lua
@@ -6,11 +6,12 @@ if type(SELF_PATH) ~= "string" or string.len(SELF_PATH) == 0 then
 end
 vim.opt.runtimepath:append(SELF_PATH)
 local shell_helpers = require("fzfx.shell_helpers")
+shell_helpers.setup("previewer")
 
 local SOCKET_ADDRESS = vim.env._FZFX_NVIM_SOCKET_ADDRESS
 shell_helpers.log_ensure(
     type(SOCKET_ADDRESS) == "string" and string.len(SOCKET_ADDRESS) > 0,
-    "|fzfx.bin.general.previewer| error! SOCKET_ADDRESS must not be empty!"
+    "SOCKET_ADDRESS must not be empty!"
 )
 local registry_id = _G.arg[1]
 local metafile = _G.arg[2]
@@ -28,7 +29,7 @@ local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
 -- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
 -- shell_helpers.log_ensure(
 --     channel_id > 0,
---     "|fzfx.bin.buffers.provider| error! failed to connect socket on SOCKET_ADDRESS:%s",
+--     "failed to connect socket on SOCKET_ADDRESS:%s",
 --     vim.inspect(SOCKET_ADDRESS)
 -- )
 vim.rpcrequest(
@@ -51,11 +52,11 @@ vim.fn.chanclose(channel_id)
 local metajsonstring = shell_helpers.readfile(metafile) --[[@as string]]
 shell_helpers.log_ensure(
     type(metajsonstring) == "string" and string.len(metajsonstring) > 0,
-    "|fzfx.bin.general.previewer| error! metajson is not string! %s",
+    "metajsonstring is not string! %s",
     vim.inspect(metajsonstring)
 )
 local metaopts = vim.fn.json_decode(metajsonstring) --[[@as PreviewerMetaOpts]]
-shell_helpers.log_debug("metajson:[%s]", vim.inspect(metaopts))
+shell_helpers.log_debug("metaopts:[%s]", vim.inspect(metaopts))
 
 --- @param l string?
 local function println(l)
@@ -67,7 +68,7 @@ end
 
 if metaopts.previewer_type == "command" then
     local cmd = shell_helpers.readfile(resultfile)
-    shell_helpers.log_debug("cmd:[%s]", vim.inspect(cmd))
+    shell_helpers.log_debug("cmd:%s", vim.inspect(cmd))
     if cmd == nil or string.len(cmd) == 0 then
         os.exit(0)
     else
@@ -75,7 +76,7 @@ if metaopts.previewer_type == "command" then
     end
 elseif metaopts.previewer_type == "command_list" then
     local cmd = shell_helpers.readfile(resultfile)
-    shell_helpers.log_debug("cmd:[%s]", vim.inspect(cmd))
+    shell_helpers.log_debug("cmd:%s", vim.inspect(cmd))
     if cmd == nil or string.len(cmd) == 0 then
         os.exit(0)
         return
@@ -89,7 +90,7 @@ elseif metaopts.previewer_type == "command_list" then
     local async_spawn = shell_helpers.AsyncSpawn:make(cmd_splits, println) --[[@as AsyncSpawn]]
     shell_helpers.log_ensure(
         async_spawn ~= nil,
-        "|provider| error! failed to open async command: %s",
+        "failed to open async command: %s",
         vim.inspect(cmd_splits)
     )
     async_spawn:run()
@@ -97,7 +98,7 @@ elseif metaopts.previewer_type == "list" then
     local f = io.open(resultfile, "r")
     shell_helpers.log_ensure(
         f ~= nil,
-        "error! failed to open file on resultfile! %s",
+        "failed to open file on resultfile! %s",
         vim.inspect(resultfile)
     )
     --- @diagnostic disable-next-line: need-check-nil
@@ -109,7 +110,7 @@ elseif metaopts.previewer_type == "list" then
     f:close()
 else
     shell_helpers.log_throw(
-        "|fzfx.bin.general.previewer| error! unknown previewer type:%s",
+        "unknown previewer type:%s",
         vim.inspect(metajsonstring)
     )
 end

--- a/bin/general/provider.lua
+++ b/bin/general/provider.lua
@@ -4,26 +4,27 @@ if type(SELF_PATH) ~= "string" or string.len(SELF_PATH) == 0 then
 end
 vim.opt.runtimepath:append(SELF_PATH)
 local shell_helpers = require("fzfx.shell_helpers")
+shell_helpers.setup("provider")
 
 local SOCKET_ADDRESS = vim.env._FZFX_NVIM_SOCKET_ADDRESS
 shell_helpers.log_ensure(
     type(SOCKET_ADDRESS) == "string" and string.len(SOCKET_ADDRESS) > 0,
-    "|provider| error! SOCKET_ADDRESS must not be empty!"
+    "SOCKET_ADDRESS must not be empty!"
 )
 local registry_id = _G.arg[1]
 local metafile = _G.arg[2]
 local resultfile = _G.arg[3]
 local query = _G.arg[4]
-shell_helpers.log_debug("|provider| registry_id:[%s]", registry_id)
-shell_helpers.log_debug("|provider| metafile:[%s]", metafile)
-shell_helpers.log_debug("|provider| resultfile:[%s]", resultfile)
-shell_helpers.log_debug("|provider| query:[%s]", query)
+shell_helpers.log_debug("registry_id:[%s]", registry_id)
+shell_helpers.log_debug("metafile:[%s]", metafile)
+shell_helpers.log_debug("resultfile:[%s]", resultfile)
+shell_helpers.log_debug("query:[%s]", query)
 
 local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
 -- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
 -- shell_helpers.log_ensure(
 --     channel_id > 0,
---     "|fzfx.bin.buffers.provider| error! failed to connect socket on SOCKET_ADDRESS:%s",
+--     "failed to connect socket on SOCKET_ADDRESS:%s",
 --     vim.inspect(SOCKET_ADDRESS)
 -- )
 vim.rpcrequest(
@@ -46,12 +47,12 @@ vim.fn.chanclose(channel_id)
 local metajsonstring = shell_helpers.readfile(metafile) --[[@as string]]
 shell_helpers.log_ensure(
     type(metajsonstring) == "string" and string.len(metajsonstring) > 0,
-    "|provider| error! metajson is not string! %s",
+    "metajsonstring is not string! %s",
     vim.inspect(metajsonstring)
 )
 --- @type ProviderMetaOpts
 local metaopts = vim.fn.json_decode(metajsonstring) --[[@as ProviderMetaOpts]]
-shell_helpers.log_debug("|provider| metajson:[%s]", vim.inspect(metaopts))
+shell_helpers.log_debug("metaopt:[%s]", vim.inspect(metaopts))
 
 --- @param line string?
 local function println(line)
@@ -73,10 +74,7 @@ end
 if metaopts.provider_type == "plain" or metaopts.provider_type == "command" then
     --- @type string
     local cmd = shell_helpers.readfile(resultfile) --[[@as string]]
-    shell_helpers.log_debug(
-        "|provider| plain or command cmd:[%s]",
-        vim.inspect(cmd)
-    )
+    shell_helpers.log_debug("plain/command cmd:%s", vim.inspect(cmd))
     if cmd == nil or string.len(cmd) == 0 then
         os.exit(0)
         return
@@ -85,7 +83,7 @@ if metaopts.provider_type == "plain" or metaopts.provider_type == "command" then
     local p = io.popen(cmd)
     shell_helpers.log_ensure(
         p ~= nil,
-        "|provider| error! failed to open pipe on provider cmd! %s",
+        "failed to open pipe on provider cmd! %s",
         vim.inspect(cmd)
     )
     ---@diagnostic disable-next-line: need-check-nil
@@ -99,10 +97,7 @@ elseif
     or metaopts.provider_type == "command_list"
 then
     local cmd = shell_helpers.readfile(resultfile) --[[@as string]]
-    shell_helpers.log_debug(
-        "|provider| plain_list or command_list cmd:[%s]",
-        vim.inspect(cmd)
-    )
+    shell_helpers.log_debug("plain_list/command_list cmd:%s", vim.inspect(cmd))
     if cmd == nil or string.len(cmd) == 0 then
         os.exit(0)
         return
@@ -117,7 +112,7 @@ then
     local async_spawn = shell_helpers.AsyncSpawn:make(cmd_splits, println) --[[@as AsyncSpawn]]
     shell_helpers.log_ensure(
         async_spawn ~= nil,
-        "|provider| error! failed to open async command: %s",
+        "failed to open async command: %s",
         vim.inspect(cmd_splits)
     )
     async_spawn:run()
@@ -125,7 +120,7 @@ elseif metaopts.provider_type == "list" then
     local reader = shell_helpers.FileLineReader:open(resultfile) --[[@as FileLineReader ]]
     shell_helpers.log_ensure(
         reader ~= nil,
-        "|provider| error! failed to open resultfile: %s",
+        "failed to open resultfile: %s",
         vim.inspect(resultfile)
     )
 
@@ -136,7 +131,7 @@ elseif metaopts.provider_type == "list" then
     reader:close()
 else
     shell_helpers.log_throw(
-        "|provider| error! unknown provider type:%s",
+        "unknown provider type:%s",
         vim.inspect(metajsonstring)
     )
 end

--- a/lua/fzfx/shell_helpers.lua
+++ b/lua/fzfx/shell_helpers.lua
@@ -23,37 +23,35 @@ local PATH_SEPARATOR = (vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0)
 local DEBUG_ENABLE = tostring(vim.env._FZFX_NVIM_DEBUG_ENABLE):lower() == "1"
 
 local LoggerContext = {
-    --- @type "DEBUG"|"INFO"|"WARN"|"ERROR"
-    level = DEBUG_ENABLE and "DEBUG" or "INFO",
-    --- @type boolean
-    console_log = true,
-    --- @type string|nil
-    name = "[fzfx-shell-helpers]",
-    --- @type boolean
+    level = DEBUG_ENABLE and require("fzfx.log").LogLevels.DEBUG
+        or require("fzfx.log").LogLevels.INFO,
+    console_log = DEBUG_ENABLE and true or false,
     file_log = DEBUG_ENABLE and true or false,
-    --- @type string|nil
-    file_path = string.format(
+    file_path = nil,
+}
+
+--- @param name string
+local function setup(name)
+    LoggerContext.file_path = string.format(
         "%s%s%s",
         vim.fn.stdpath("data"),
         PATH_SEPARATOR,
-        "fzfx_shell_helpers.log"
-    ),
-}
+        string.format("fzfx_shell_helpers_%s.log", name)
+    )
+end
 
---- @param level "DEBUG"|"INFO"|"WARN"|"ERROR"
+--- @param level integer
 --- @param msg string
---- @return nil
 local function _log(level, msg)
-    local LogLevels = require("fzfx.log").LogLevels
-
-    if LogLevels[level] < LogLevels[LoggerContext.level] then
+    local LogLevelNames = require("fzfx.log").LogLevelNames
+    if level < LoggerContext.level then
         return
     end
 
     local msg_lines = require("fzfx.utils").string_split(msg, "\n")
     if LoggerContext.console_log then
         for _, line in ipairs(msg_lines) do
-            io.write(string.format("%s %s\n", level, line))
+            io.write(string.format("%s %s\n", LogLevelNames[level], line))
         end
     end
     if LoggerContext.file_log then
@@ -64,7 +62,7 @@ local function _log(level, msg)
                     string.format(
                         "%s [%s]: %s\n",
                         os.date("%Y-%m-%d %H:%M:%S"),
-                        level,
+                        LogLevelNames[level],
                         line
                     )
                 )
@@ -75,11 +73,13 @@ local function _log(level, msg)
 end
 
 local function log_debug(fmt, ...)
-    _log("DEBUG", string.format(fmt, ...))
+    local LogLevels = require("fzfx.log").LogLevels
+    _log(LogLevels.DEBUG, string.format(fmt, ...))
 end
 
 local function log_err(fmt, ...)
-    _log("ERROR", string.format(fmt, ...))
+    local LogLevels = require("fzfx.log").LogLevels
+    _log(LogLevels.ERROR, string.format(fmt, ...))
 end
 
 local function log_throw(fmt, ...)
@@ -87,11 +87,11 @@ local function log_throw(fmt, ...)
     error(string.format(fmt, ...))
 end
 
---- @param condition boolean
+--- @param cond boolean
 --- @param fmt string
 --- @param ... any[]|any
-local function log_ensure(condition, fmt, ...)
-    if not condition then
+local function log_ensure(cond, fmt, ...)
+    if not cond then
         log_throw(fmt, ...)
     end
 end
@@ -159,7 +159,7 @@ end
 -- icon render }
 
 local M = {
-    is_windows = is_windows,
+    setup = setup,
     log_debug = log_debug,
     log_err = log_err,
     log_throw = log_throw,

--- a/lua/fzfx/shell_helpers.lua
+++ b/lua/fzfx/shell_helpers.lua
@@ -36,7 +36,7 @@ local function setup(name)
         "%s%s%s",
         vim.fn.stdpath("data"),
         PATH_SEPARATOR,
-        string.format("fzfx_shell_helpers_%s.log", name)
+        string.format("fzfx_bin_%s.log", name)
     )
 end
 

--- a/test/shell_helpers_spec.lua
+++ b/test/shell_helpers_spec.lua
@@ -11,6 +11,7 @@ describe("shell_helpers", function()
 
     vim.env._FZFX_NVIM_DEVICONS_PATH = nil
     local shell_helpers = require("fzfx.shell_helpers")
+    shell_helpers.setup("test")
     describe("[log]", function()
         it("debug", function()
             assert_true(shell_helpers.log_debug("logs without params") == nil)

--- a/test/shell_helpers_spec.lua
+++ b/test/shell_helpers_spec.lua
@@ -11,11 +11,6 @@ describe("shell_helpers", function()
 
     vim.env._FZFX_NVIM_DEVICONS_PATH = nil
     local shell_helpers = require("fzfx.shell_helpers")
-    describe("[is_windows]", function()
-        it("is windows", function()
-            assert_eq(type(shell_helpers.is_windows), "boolean")
-        end)
-    end)
     describe("[log]", function()
         it("debug", function()
             assert_true(shell_helpers.log_debug("logs without params") == nil)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `eza` and `ls` works.
- [ ] Backward Compatible
  - Open with `nvim -u ./test/minimal_buffers_deprecate_init.lua` and test `FzfxBuffers`.
  - Open with `nvim -u ./test/minimal_files_deprecate_init.lua` and test `FzfxFiles`.
  - Open with `nvim -u ./test/minimal_git_branches_deprecate_init.lua` and test `FzfxGBranches`.
  - Open with `nvim -u ./test/minimal_git_commits_deprecate_init.lua` and test `FzfxGCommits`.
  - Open with `nvim -u ./test/minimal_git_files_deprecate_init.lua` and test `FzfxGFiles`.
  - Open with `nvim -u ./test/minimal_live_grep_deprecate_init.lua` and test `FzfxLiveGrep`.
