### PR TITLE
perf(test): improve test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       #     task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","break"]'
   luacheck:
     name: Lua check
+    if: ${{ github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
     name: Release
     if: ${{ github.ref == 'refs/heads/main' }}
     needs:
-      - luacheck
       - unit_test
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ luac.out
 *.i*86
 *.x86_64
 *.hex
+
+# MacOS
+.DS_Store

--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -6,7 +6,6 @@ local general = require("fzfx.general")
 local function setup(options)
     -- configs
     local configs = require("fzfx.config").setup(options)
-    local defaults = require("fzfx.config").get_defaults()
 
     -- log
     log.setup({
@@ -15,7 +14,12 @@ local function setup(options)
         file_log = configs.debug.file_log,
     })
 
-    log.debug("|fzfx - setup| Defaults:\n%s", vim.inspect(defaults))
+    if configs.debug.enable then
+        log.debug(
+            "|fzfx - setup| Defaults:\n%s",
+            vim.inspect(require("fzfx.config").get_defaults())
+        )
+    end
     log.debug("|fzfx - setup| Configs:\n%s", vim.inspect(configs))
 
     -- cache

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -205,11 +205,26 @@ local function git_checkout(lines)
     vim.cmd(checkout_command)
 end
 
-local function yank_git_commit(lines)
+--- @param lines string[]
+--- @return string?
+local function _make_yank_git_commit_command(lines)
     if type(lines) == "table" and #lines > 0 then
         local line = lines[#lines]
-        local git_commit = vim.fn.split(line)[1]
-        vim.api.nvim_command("let @+ = '" .. git_commit .. "'")
+        local space_pos = utils.string_find(line, " ")
+        if not space_pos then
+            return nil
+        end
+        local git_commit = line:sub(1, space_pos - 1)
+        return string.format("let @+ = '%s'", git_commit)
+    end
+    return nil
+end
+
+--- @param lines string[]
+local function yank_git_commit(lines)
+    local yank_command = _make_yank_git_commit_command(lines)
+    if yank_command then
+        vim.api.nvim_command(yank_command)
     end
 end
 
@@ -362,6 +377,7 @@ local M = {
     bdelete = bdelete,
     _make_git_checkout_command = _make_git_checkout_command,
     git_checkout = git_checkout,
+    _make_yank_git_commit_command = _make_yank_git_commit_command,
     yank_git_commit = yank_git_commit,
     _make_feed_vim_command_params = _make_feed_vim_command_params,
     _make_feed_vim_key_params = _make_feed_vim_key_params,

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -523,4 +523,21 @@ describe("actions", function()
             end
         end)
     end)
+    describe("[_make_yank_git_commit_command]", function()
+        it("yank git commits", function()
+            local lines = {
+                "3c2e32c 2023-10-10 linrongbin16 perf(schema): deprecate 'ProviderConfig' & 'PreviewerConfig' (#268)",
+                "2bdcef7 2023-10-10 linrongbin16 feat(schema): add 'PreviewerConfig' detection (#266)",
+                "5cabd9b 2023-10-10 linrongbin16 refactor(schema): deprecate 'ProviderConfig' (#264)",
+                "9eac0c0 2023-10-10 linrongbin16 fix(push): revert direct push to main branch",
+                "78a195a 2023-10-10 linrongbin16 refactor(schema): deprecate 'ProviderConfig'",
+            }
+            for _, line in ipairs(lines) do
+                assert_eq(
+                    string.format("let @+ = '%s'", line:sub(1, 7)),
+                    actions._make_yank_git_commit_command({ line })
+                )
+            end
+        end)
+    end)
 end)

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -379,12 +379,64 @@ describe("actions", function()
             end
         end)
     end)
-    describe("[feed_vim_command]", function()
+    describe("[_make_feed_vim_command_params]", function()
         it("feedkeys", function()
-            local actual = actions.feed_vim_command({
-                ":FzfxCommands    Y | N | N/A  ~/github/linrongbin16/fzfx.nvim/lua/fzfx/general.lua:215",
+            local actual = actions._make_feed_vim_command_params({
+                "FzfxCommands    Y | N | N/A  ~/github/linrongbin16/fzfx.nvim/lua/fzfx/general.lua:215",
             })
-            assert_true(actual == nil)
+            print(string.format("feed vim command:%s\n", vim.inspect(actual)))
+            -- assert_true(actual == nil)
+        end)
+    end)
+    describe("[_make_feed_vim_key_params]", function()
+        it("feed normal key", function()
+            local feedtype, input, mode = actions._make_feed_vim_key_params({
+                '<C-Tab>                                      n   |Y      |N     |N      "<C-C><C-W>w"',
+            })
+            print(
+                string.format(
+                    "feed normal key:%s, %s, %s\n",
+                    vim.inspect(feedtype),
+                    vim.inspect(input),
+                    vim.inspect(mode)
+                )
+            )
+            assert_eq(feedtype, "feedkeys")
+            assert_eq(type(input), "string")
+            assert_true(string.len(input --[[@as string]]) > 0)
+            assert_eq(mode, "n")
+        end)
+        it("feed operator-pending key", function()
+            local feedtype, input, mode = actions._make_feed_vim_key_params({
+                '<C-Tab>                                      o   |Y      |N     |N      "<C-C><C-W>w"',
+            })
+            print(
+                string.format(
+                    "feed operator-pending key:%s, %s, %s\n",
+                    vim.inspect(feedtype),
+                    vim.inspect(input),
+                    vim.inspect(mode)
+                )
+            )
+            assert_true(feedtype == nil)
+            assert_true(input == nil)
+            assert_true(mode == nil)
+        end)
+        it("feed <plug>", function()
+            local feedtype, input, mode = actions._make_feed_vim_key_params({
+                "<Plug>(YankyCycleBackward)                   n   |Y      |N     |Y      ~/.config/nvim/lazy/yanky.nvim/lua/yanky.lua:290",
+            })
+            print(
+                string.format(
+                    "feed <plug> key:%s, %s, %s\n",
+                    vim.inspect(feedtype),
+                    vim.inspect(input),
+                    vim.inspect(mode)
+                )
+            )
+            assert_eq(feedtype, "cmd")
+            assert_eq(type(input), "string")
+            assert_true(utils.string_startswith(input, [[execute "normal \]]))
         end)
     end)
     describe("[_make_git_checkout_command]", function()

--- a/test/minimal_fzfx_action_not_found_init.lua
+++ b/test/minimal_fzfx_action_not_found_init.lua
@@ -405,8 +405,9 @@ M.keys = {
 
 require("lazy").setup({
     {
-        "linrongbin16/fzfx.nvim",
-        -- dir = "~/.local/share/nvim/site/pack/plugins/start/fzfx.nvim",
+        -- "linrongbin16/fzfx.nvim",
+        dir = "~/github/linrongbin16/fzfx.nvim",
+        dev = true,
         keys = M.keys,
         config = function()
             M.config()
@@ -416,4 +417,4 @@ require("lazy").setup({
             "junegunn/fzf",
         },
     },
-})
+}, { dev = { path = "~/github/linrongbin16" } })

--- a/test/minimal_fzfx_action_not_found_init.lua
+++ b/test/minimal_fzfx_action_not_found_init.lua
@@ -1,0 +1,419 @@
+-- test case: https://github.com/linrongbin16/fzfx.nvim/issues/317
+
+vim.o.number = true
+vim.o.autoread = true
+vim.o.autowrite = true
+vim.o.swapfile = false
+vim.o.confirm = true
+vim.o.termguicolors = true
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+    vim.fn.system({
+        "git",
+        "clone",
+        "--filter=blob:none",
+        "https://github.com/folke/lazy.nvim.git",
+        "--branch=stable", -- latest stable release
+        lazypath,
+    })
+end
+vim.opt.rtp:prepend(lazypath)
+
+local M = {}
+
+local function file_previewer_rg(line)
+    local line_helpers = require("fzfx.line_helpers")
+    local parsed = line_helpers.parse_grep(line)
+    local style = "numbers,changes"
+    if
+        type(vim.env["BAT_STYLE"]) == "string"
+        and string.len(vim.env["BAT_STYLE"]) > 0
+    then
+        style = vim.env["BAT_STYLE"]
+    end
+    local theme = "base16"
+    if
+        type(vim.env["BAT_THEME"]) == "string"
+        and string.len(vim.env["BAT_THEME"]) > 0
+    then
+        theme = vim.env["BAT_THEME"]
+    end
+    -- "%s --style=%s --theme=%s --color=always --pager=never --highlight-line=%s -- %s"
+    return {
+        vim.fn.executable("batcat") > 0 and "batcat" or "bat",
+        "--style=" .. style,
+        "--theme=" .. theme,
+        "--color=always",
+        "--pager=never",
+        "--highlight-line=" .. parsed.lineno,
+        "--",
+        parsed.filename,
+    }
+end
+
+local function merge_query_options(merged, option)
+    local option_splits =
+        vim.split(option, " ", { plain = true, trimempty = true })
+    for _, o in ipairs(option_splits) do
+        if type(o) == "string" and string.len(o) > 0 then
+            table.insert(merged, o)
+        end
+    end
+    return merged
+end
+
+local live_grep_curr = {
+    commands = {
+        -- normal
+        {
+            name = "FzfxLiveGrep",
+            feed = "args",
+            opts = {
+                bang = true,
+                nargs = "*",
+                desc = "Live grep",
+            },
+            default_provider = "restricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepU",
+            feed = "args",
+            opts = {
+                bang = true,
+                nargs = "*",
+                desc = "Live grep unrestricted",
+            },
+            default_provider = "unrestricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepB",
+            feed = "args",
+            opts = {
+                bang = true,
+                nargs = "*",
+                desc = "Live grep only on current buffer",
+            },
+            default_provider = "buffer_mode",
+        },
+        -- visual
+        {
+            name = "FzfxLiveGrepV",
+            feed = "visual",
+            opts = {
+                bang = true,
+                range = true,
+                desc = "Live grep by visual select",
+            },
+            default_provider = "restricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepUV",
+            feed = "visual",
+            opts = {
+                bang = true,
+                range = true,
+                desc = "Live grep unrestricted by visual select",
+            },
+            default_provider = "unrestricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepBV",
+            feed = "visual",
+            opts = {
+                bang = true,
+                nargs = "*",
+                desc = "Live grep only on current buffer by visual select",
+            },
+            default_provider = "buffer_mode",
+        },
+        -- cword
+        {
+            name = "FzfxLiveGrepW",
+            feed = "cword",
+            opts = {
+                bang = true,
+                desc = "Live grep by cursor word",
+            },
+            default_provider = "restricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepUW",
+            feed = "cword",
+            opts = {
+                bang = true,
+                desc = "Live grep unrestricted by cursor word",
+            },
+            default_provider = "unrestricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepBW",
+            feed = "cword",
+            opts = {
+                bang = true,
+                nargs = "*",
+                desc = "Live grep only on current buffer by cursor word",
+            },
+            default_provider = "buffer_mode",
+        },
+        -- put
+        {
+            name = "FzfxLiveGrepP",
+            feed = "put",
+            opts = {
+                bang = true,
+                desc = "Live grep by yank text",
+            },
+            default_provider = "restricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepUP",
+            feed = "put",
+            opts = {
+                bang = true,
+                desc = "Live grep unrestricted by yank text",
+            },
+            default_provider = "unrestricted_mode",
+        },
+        {
+            name = "FzfxLiveGrepBP",
+            feed = "put",
+            opts = {
+                bang = true,
+                nargs = "*",
+                desc = "Live grep only on current buffer by yank text",
+            },
+            default_provider = "buffer_mode",
+        },
+    },
+    providers = {
+        restricted_mode = {
+            key = "ctrl-r",
+            provider = function(query)
+                local parsed_query =
+                    require("fzfx.utils").parse_flag_query(query or "")
+                local content = parsed_query[1]
+                local option = parsed_query[2]
+
+                if type(option) == "string" and string.len(option) > 0 then
+                    -- "rg --column -n --no-heading --color=always -S %s -- %s"
+                    local args = {
+                        "rg",
+                        "--column",
+                        "-n",
+                        "--no-heading",
+                        "--color=always",
+                        "-S",
+                    }
+                    args = merge_query_options(args, option)
+                    table.insert(args, "--")
+                    table.insert(args, content)
+                    return args
+                else
+                    -- "rg --column -n --no-heading --color=always -S -- %s"
+                    return {
+                        "rg",
+                        "--column",
+                        "-n",
+                        "--no-heading",
+                        "--color=always",
+                        "-S",
+                        "--",
+                        content,
+                    }
+                end
+            end,
+            provider_type = "command_list",
+            line_opts = {
+                prepend_icon_by_ft = true,
+                prepend_icon_path_delimiter = ":",
+                prepend_icon_path_position = 1,
+            },
+        },
+        unrestricted_mode = {
+            key = "ctrl-u",
+            provider = function(query)
+                local parsed_query =
+                    require("fzfx.utils").parse_flag_query(query or "")
+                local content = parsed_query[1]
+                local option = parsed_query[2]
+
+                if type(option) == "string" and string.len(option) > 0 then
+                    -- "rg --column -n --no-heading --color=always -S -uu %s -- %s"
+                    local args = {
+                        "rg",
+                        "--column",
+                        "-n",
+                        "--no-heading",
+                        "--color=always",
+                        "-S",
+                        "-uu",
+                    }
+                    args = merge_query_options(args, option)
+                    table.insert(args, "--")
+                    table.insert(args, content)
+                    return args
+                else
+                    -- "rg --column -n --no-heading --color=always -S -uu -- %s"
+                    return {
+                        "rg",
+                        "--column",
+                        "-n",
+                        "--no-heading",
+                        "--color=always",
+                        "-S",
+                        "-uu",
+                        "--",
+                        content,
+                    }
+                end
+            end,
+            provider_type = "command_list",
+            line_opts = {
+                prepend_icon_by_ft = true,
+                prepend_icon_path_delimiter = ":",
+                prepend_icon_path_position = 1,
+            },
+        },
+        buffer_mode = {
+            key = "ctrl-o",
+            provider = function(query, context)
+                local utils = require("fzfx.utils")
+                local log = require("fzfx.log")
+                local path = require("fzfx.path")
+
+                local parsed_query = utils.parse_flag_query(query or "")
+                local content = parsed_query[1]
+                local option = parsed_query[2]
+                if not utils.is_buf_valid(context.bufnr) then
+                    log.echo(
+                        log.LogLevels.INFO,
+                        "not valid buffer(%s).",
+                        vim.inspect(context.bufnr)
+                    )
+                    return nil
+                end
+                local current_bufpath =
+                    path.reduce(vim.api.nvim_buf_get_name(context.bufnr))
+                if type(option) == "string" and string.len(option) > 0 then
+                    -- "rg --column -n --no-heading --color=always -S -uu %s -- %s"
+                    local args = {
+                        "rg",
+                        "--column",
+                        "-n",
+                        "--no-heading",
+                        "--color=always",
+                        "-S",
+                        "-g",
+                        current_bufpath,
+                    }
+                    args = merge_query_options(args, option)
+                    table.insert(args, "--")
+                    table.insert(args, content)
+                    return args
+                else
+                    -- "rg --column -n --no-heading --color=always -S -uu -- %s"
+                    return {
+                        "rg",
+                        "--column",
+                        "-n",
+                        "--no-heading",
+                        "--color=always",
+                        "-S",
+                        "-g",
+                        current_bufpath,
+                        "--",
+                        content,
+                    }
+                end
+            end,
+            provider_type = "command_list",
+            line_opts = {
+                prepend_icon_by_ft = true,
+                prepend_icon_path_delimiter = ":",
+                prepend_icon_path_position = 1,
+            },
+        },
+    },
+    previewers = {
+        restricted_mode = {
+            previewer = file_previewer_rg,
+            previewer_type = "command_list",
+        },
+        unrestricted_mode = {
+            previewer = file_previewer_rg,
+            previewer_type = "command_list",
+        },
+        buffer_mode = {
+            previewer = file_previewer_rg,
+            previewer_type = "command_list",
+        },
+    },
+    actions = {
+        ["esc"] = require("fzfx.actions").nop,
+        ["enter"] = require("fzfx.actions").edit_rg,
+        ["double-click"] = require("fzfx.actions").edit_rg,
+    },
+    fzf_opts = {
+        "--multi",
+        "--disabled",
+        { "--prompt", "Live Grep > " },
+        { "--delimiter", ":" },
+        { "--preview-window", "top,75%,+{2}-/2" },
+    },
+    other_opts = {
+        reload_on_change = true,
+    },
+}
+
+M.config = function()
+    local fzfx = require("fzfx")
+    local GroupConfig = require("fzfx.schema").GroupConfig
+    fzfx.setup({
+        live_grep = live_grep_curr,
+        -- live_grep = {
+        --     fzf_opts = {
+        --       "--disabled",
+        --       { "--prompt",         "Live Grep > " },
+        --       { "--delimiter",      ":" },
+        --       { "--preview-window", "top,75%,+{2}-/2" },
+        --     },
+        -- },
+        buffers = {
+            fzf_opts = {
+                { "--prompt", "Buffers > " },
+                { "--delimiter", ":" },
+                { "--preview-window", "top,75%,+{2}-/2" },
+            },
+        },
+        files = {
+            fzf_opts = {
+                { "--prompt", "Files > " },
+                { "--delimiter", ":" },
+                { "--preview-window", "top,50%,+{2}-/2" },
+            },
+        },
+    })
+end
+
+M.keys = {
+    { "<leader>xg", "<cmd>FzfxLiveGrep<cr>" },
+    { "<leader><Leader>xg", "<cmd>FzfxLiveGrepW<cr>" },
+    { "<leader>xs", "<cmd>FzfxLiveGrepB<cr>" },
+    { "<leader><Leader>xs", "<cmd>FzfxLiveGrepBW<cr>" },
+}
+
+require("lazy").setup({
+    {
+        "linrongbin16/fzfx.nvim",
+        -- dir = "~/.local/share/nvim/site/pack/plugins/start/fzfx.nvim",
+        keys = M.keys,
+        config = function()
+            M.config()
+        end,
+        dependencies = {
+            "nvim-tree/nvim-web-devicons",
+            "junegunn/fzf",
+        },
+    },
+})

--- a/test/minimal_init.lua
+++ b/test/minimal_init.lua
@@ -27,7 +27,9 @@ require("lazy").setup({
         build = ":call fzf#install()",
     },
     {
-        "linrongbin16/fzfx.nvim",
+        -- "linrongbin16/fzfx.nvim",
+        dir = "~/github/linrongbin16/fzfx.nvim",
+        dev = true,
         opts = {
             icon = {
                 enable = false,
@@ -35,6 +37,6 @@ require("lazy").setup({
         },
         dependencies = { "junegunn/fzf" },
     },
-}, opts)
+}, { dev = { path = "~/github/linrongbin16" }, defaults = { lazy = false } })
 
 require("lazy").sync({ wait = true, show = false })

--- a/test/minimal_init.lua
+++ b/test/minimal_init.lua
@@ -28,8 +28,6 @@ require("lazy").setup({
     },
     {
         "linrongbin16/fzfx.nvim",
-        dev = true,
-        dir = "~/github/linrongbin16/fzfx.nvim",
         opts = {
             icon = {
                 enable = false,

--- a/test/minimal_packer_init.lua
+++ b/test/minimal_packer_init.lua
@@ -32,7 +32,7 @@ require("packer").startup(function(use)
     use("nvim-tree/nvim-web-devicons")
     use({ "junegunn/fzf", run = ":call fzf#install()" })
     use({
-        vim.fn.expand("~/github/linrongbin16/fzfx.nvim"),
+        "linrongbin16/fzfx.nvim",
         config = function()
             require("fzfx").setup({
                 debug = { enable = false, file_log = true },

--- a/test/minimal_packer_init.lua
+++ b/test/minimal_packer_init.lua
@@ -32,7 +32,7 @@ require("packer").startup(function(use)
     use("nvim-tree/nvim-web-devicons")
     use({ "junegunn/fzf", run = ":call fzf#install()" })
     use({
-        "linrongbin16/fzfx.nvim",
+        vim.fn.expand("~/github/linrongbin16/fzfx.nvim"),
         config = function()
             require("fzfx").setup({
                 debug = { enable = false, file_log = true },

--- a/test/minimal_powershell_init.lua
+++ b/test/minimal_powershell_init.lua
@@ -42,8 +42,6 @@ require("lazy").setup({
     },
     {
         "linrongbin16/fzfx.nvim",
-        dev = true,
-        dir = "~/github/linrongbin16/fzfx.nvim",
         opts = {
             env = {
                 nvim = "nvim",

--- a/test/minimal_powershell_init.lua
+++ b/test/minimal_powershell_init.lua
@@ -29,10 +29,6 @@ if not vim.loop.fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
-local opts = {
-    defaults = { lazy = false },
-}
-
 require("lazy").setup({
     "folke/tokyonight.nvim",
     "nvim-tree/nvim-web-devicons",
@@ -41,7 +37,9 @@ require("lazy").setup({
         build = ":call fzf#install()",
     },
     {
-        "linrongbin16/fzfx.nvim",
+        -- "linrongbin16/fzfx.nvim",
+        dir = "~/github/linrongbin16/fzfx.nvim",
+        dev = true,
         opts = {
             env = {
                 nvim = "nvim",
@@ -58,7 +56,7 @@ require("lazy").setup({
             "junegunn/fzf",
         },
     },
-}, opts)
+}, { dev = { path = "~/github/linrongbin16" }, defaults = { lazy = false } })
 
 require("lazy").sync({ wait = true, show = false })
 

--- a/test/minimal_termguicolors_init.lua
+++ b/test/minimal_termguicolors_init.lua
@@ -30,7 +30,9 @@ require("lazy").setup({
         build = ":call fzf#install()",
     },
     {
-        "linrongbin16/fzfx.nvim",
+        -- "linrongbin16/fzfx.nvim",
+        dir = "~/github/linrongbin16/fzfx.nvim",
+        dev = true,
         opts = {},
         dependencies = {
             "folke/tokyonight.nvim",
@@ -38,7 +40,7 @@ require("lazy").setup({
             "junegunn/fzf",
         },
     },
-}, opts)
+}, { dev = { path = "~/github/linrongbin16" }, defaults = { lazy = false } })
 
 require("lazy").sync({ wait = true, show = false })
 

--- a/test/minimal_termguicolors_init.lua
+++ b/test/minimal_termguicolors_init.lua
@@ -31,8 +31,6 @@ require("lazy").setup({
     },
     {
         "linrongbin16/fzfx.nvim",
-        dev = true,
-        dir = "~/github/linrongbin16/fzfx.nvim",
         opts = {},
         dependencies = {
             "folke/tokyonight.nvim",


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [x] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [x] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [x] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `eza` and `ls` works.
