### PR TITLE
docs(install): fix fzf build

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,12 +195,7 @@ return require('packer').startup(function(use)
   use { "nvim-tree/nvim-web-devicons" }
 
   -- mandatory
-  use {
-    "junegunn/fzf",
-    run = function()
-      vim.fn["fzf#install"] ()
-    end 
-  }
+  use { "junegunn/fzf", run = function() vim.fn["fzf#install"] () end }
   use {
     "linrongbin16/fzfx.nvim",
     config = function()
@@ -219,12 +214,7 @@ require("lazy").setup({
   { "nvim-tree/nvim-web-devicons" },
 
   -- mandatory
-  {
-    "junegunn/fzf",
-    build = function()
-      vim.fn["fzf#install"]()
-    end
-  },
+  { "junegunn/fzf", build = function() vim.fn["fzf#install"]() end },
   {
     "linrongbin16/fzfx.nvim",
     dependencies = { "junegunn/fzf", "nvim-tree/nvim-web-devicons" },

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ return require('packer').startup(function(use)
   use { "nvim-tree/nvim-web-devicons" }
 
   -- mandatory
-  use { "junegunn/fzf", run = ":call fzf#install()" }
+  use { "junegunn/fzf", run = function() vim.fn["fzf#install"]() end }
   use {
     "linrongbin16/fzfx.nvim",
     config = function()

--- a/README.md
+++ b/README.md
@@ -190,17 +190,19 @@ lua require('fzfx').setup()
 
 ```lua
 return require('packer').startup(function(use)
-    -- optional for icons
-    use { "nvim-tree/nvim-web-devicons" }
 
-    -- mandatory
-    use { "junegunn/fzf", run = ":call fzf#install()" }
-    use {
-        "linrongbin16/fzfx.nvim",
-        config = function()
-            require("fzfx").setup()
-        end
-    }
+  -- optional for icons
+  use { "nvim-tree/nvim-web-devicons" }
+
+  -- mandatory
+  use { "junegunn/fzf", run = ":call fzf#install()" }
+  use {
+    "linrongbin16/fzfx.nvim",
+    config = function()
+      require("fzfx").setup()
+    end
+  }
+
 end)
 ```
 
@@ -208,18 +210,20 @@ end)
 
 ```lua
 require("lazy").setup({
-    -- optional for icons
-    { "nvim-tree/nvim-web-devicons" },
+  -- optional for icons
+  { "nvim-tree/nvim-web-devicons" },
 
-    -- mandatory
-    { "junegunn/fzf", build = ":call fzf#install()" },
-    {
-        "linrongbin16/fzfx.nvim",
-        dependencies = { "junegunn/fzf", "nvim-tree/nvim-web-devicons" },
-        config = function()
-            require("fzfx").setup()
-        end
-    },
+  -- mandatory
+  {
+    "junegunn/fzf", build = function() vim.fn["fzf#install"]() end
+  },
+  {
+    "linrongbin16/fzfx.nvim",
+    dependencies = { "junegunn/fzf", "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("fzfx").setup()
+    end
+  },
 
 })
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,12 @@ return require('packer').startup(function(use)
   use { "nvim-tree/nvim-web-devicons" }
 
   -- mandatory
-  use { "junegunn/fzf", run = function() vim.fn["fzf#install"]() end }
+  use {
+    "junegunn/fzf",
+    run = function()
+      vim.fn["fzf#install"] ()
+    end 
+  }
   use {
     "linrongbin16/fzfx.nvim",
     config = function()
@@ -215,7 +220,10 @@ require("lazy").setup({
 
   -- mandatory
   {
-    "junegunn/fzf", build = function() vim.fn["fzf#install"]() end
+    "junegunn/fzf",
+    build = function()
+      vim.fn["fzf#install"]()
+    end
   },
   {
     "linrongbin16/fzfx.nvim",


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `eza` and `ls` works.
