### PR TITLE
feat(preview-label): add 'preview_label' for previewers

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -2263,11 +2263,12 @@ local Defaults = {
             restricted_mode = {
                 previewer = _file_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-                previewer_label = nil,
+                previewer_label = require("fzfx.previewer_labels").find_previewer_label,
             },
             unrestricted_mode = {
                 previewer = _file_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").find_previewer_label,
             },
         },
         actions = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -2263,6 +2263,7 @@ local Defaults = {
             restricted_mode = {
                 previewer = _file_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = nil,
             },
             unrestricted_mode = {
                 previewer = _file_previewer,

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -1,0 +1,31 @@
+local line_helpers = require("fzfx.line_helpers")
+
+--- @package
+--- @param opts {no_icon:boolean?}?
+--- @return PreviewerLabel
+local function _make_find_previewer_label(opts)
+    --- @param line string?
+    --- @param context PipelineContext
+    --- @return string?
+    local function impl(line, context)
+        if type(line) ~= "string" or string.len(line) == 0 then
+            return nil
+        end
+        return vim.fn.fnamemodify(line_helpers.parse_find(line, opts), ":t")
+    end
+    return impl
+end
+
+--- @param line string?
+--- @param context PipelineContext
+--- @return string?
+local function find_previewer_label(line, context)
+    local f = _make_find_previewer_label()
+    return f(line, context)
+end
+
+local M = {
+    find_previewer_label = find_previewer_label,
+}
+
+return M

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -24,9 +24,9 @@
 --
 --- @alias PipelineContextMaker fun():PipelineContext
 --
---- @alias PlainProvider string?|string[]?
---- @alias CommandProvider fun(query:string?,context:PipelineContext?):string?|string[]?
---- @alias ListProvider fun(query:string?,context:PipelineContext?):string[]?
+--- @alias PlainProvider string|string[]
+--- @alias CommandProvider fun(query:string?,context:PipelineContext):string|string[]|nil
+--- @alias ListProvider fun(query:string?,context:PipelineContext):string[]|nil
 --
 --- @alias Provider PlainProvider|CommandProvider|ListProvider
 --- @alias ProviderType "plain"|"command"|"list"|"plain_list"|"command_list"
@@ -49,9 +49,9 @@ local ProviderTypeEnum = {
 --
 -- The BuiltinPreviewer returns the configs for the nvim window.
 --
---- @alias CommandPreviewer fun(line:string?,context:PipelineContext?):string?
---- @alias ListPreviewer fun(line:string?,context:PipelineContext?):string[]?
---- @alias BuiltinPreviewer fun(line:string?,context:PipelineContext?):table?
+--- @alias CommandPreviewer fun(line:string?,context:PipelineContext):string|nil
+--- @alias ListPreviewer fun(line:string?,context:PipelineContext):string[]|nil
+--- @alias BuiltinPreviewer fun(line:string?,context:PipelineContext):table|nil
 --
 --- @alias Previewer CommandPreviewer|ListPreviewer|BuiltinPreviewer
 --- @alias PreviewerType "command"|"command_list"|"list"|"builtin"
@@ -148,9 +148,11 @@ local CommandFeedEnum = {
 --- @field provider_type ProviderType? by default "plain"
 --- @field line_opts ProviderConfigLineOpts?
 
+--- @alias PreviewerLabel fun(line:string?,context:PipelineContext):string?
 --- @class PreviewerConfig
 --- @field previewer Previewer
 --- @field previewer_type PreviewerType?
+--- @field previewer_label PreviewerLabel?
 
 --- @alias PipelineName string a pipeline name is a provider name, a previewer name
 --- @class CommandConfig
@@ -236,6 +238,7 @@ local M = {
     ProviderTypeEnum = ProviderTypeEnum,
     PreviewerTypeEnum = PreviewerTypeEnum,
     CommandFeedEnum = CommandFeedEnum,
+    PlainPreviewerLabelEnum = PlainPreviewerLabelEnum,
 
     is_command_config = is_command_config,
     is_provider_config = is_provider_config,


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
