### PR TITLE
feat(actions): require user confirm to discard modified buffer when jump to other files

### DIFF
--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -3,6 +3,7 @@ local LogLevels = require("fzfx.log").LogLevels
 local path = require("fzfx.path")
 local line_helpers = require("fzfx.line_helpers")
 local utils = require("fzfx.utils")
+local ui = require("fzfx.ui")
 
 --- @param lines string[]
 --- @return nil
@@ -26,27 +27,30 @@ end
 
 -- Run 'edit' vim command on fd/find results.
 --- @param lines string[]
-local function edit_find(lines)
-    local edit_commands = _make_edit_find_commands(lines)
-    for i, edit_command in ipairs(edit_commands) do
-        log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
-        vim.cmd(edit_command)
-    end
+--- @param context PipelineContext
+local function edit_find(lines, context)
+    ui.confirm_discard_buffer_modified(context.bufnr, function()
+        local edit_commands = _make_edit_find_commands(lines)
+        for i, edit_command in ipairs(edit_commands) do
+            log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
+            vim.cmd(edit_command)
+        end
+    end)
 end
 
 --- @deprecated
-local function edit_buffers(lines)
-    return edit_find(lines)
+local function edit_buffers(lines, context)
+    return edit_find(lines, context)
 end
 
 --- @deprecated
-local function edit_git_files(lines)
-    return edit_find(lines)
+local function edit_git_files(lines, context)
+    return edit_find(lines, context)
 end
 
 --- @deprecated
-local function edit(lines)
-    return edit_find(lines)
+local function edit(lines, context)
+    return edit_find(lines, context)
 end
 
 --- @package
@@ -128,8 +132,8 @@ local function edit_ls(lines)
 end
 
 --- @deprecated
-local function buffer(lines)
-    return edit_find(lines)
+local function buffer(lines, context)
+    return edit_find(lines, context)
 end
 
 --- @deprecated

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -29,8 +29,8 @@ end
 --- @param lines string[]
 --- @param context PipelineContext
 local function edit_find(lines, context)
+    local edit_commands = _make_edit_find_commands(lines)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
-        local edit_commands = _make_edit_find_commands(lines)
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
             vim.cmd(edit_command)
@@ -67,7 +67,7 @@ local function _make_edit_rg_commands(lines, opts)
     local results = {}
     for i, line in ipairs(lines) do
         local parsed = line_helpers.parse_rg(line, opts)
-        local edit_command = string.format("edit %s", parsed.filename)
+        local edit_command = string.format("edit! %s", parsed.filename)
         table.insert(results, edit_command)
         if parsed.lineno ~= nil then
             if i == #lines then
@@ -85,12 +85,15 @@ local function _make_edit_rg_commands(lines, opts)
 end
 
 --- @param lines string[]
-local function edit_rg(lines)
+--- @param context PipelineContext
+local function edit_rg(lines, context)
     local vim_commands = _make_edit_rg_commands(lines)
-    for i, vim_command in ipairs(vim_commands) do
-        log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, vim_command)
-        vim.cmd(vim_command)
-    end
+    ui.confirm_discard_buffer_modified(context.bufnr, function()
+        for i, vim_command in ipairs(vim_commands) do
+            log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, vim_command)
+            vim.cmd(vim_command)
+        end
+    end)
 end
 
 --- @package
@@ -119,12 +122,15 @@ local function _make_edit_grep_commands(lines, opts)
 end
 
 --- @param lines string[]
-local function edit_grep(lines)
+--- @param context PipelineContext
+local function edit_grep(lines, context)
     local vim_commands = _make_edit_grep_commands(lines)
-    for i, vim_command in ipairs(vim_commands) do
-        log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, vim_command)
-        vim.cmd(vim_command)
-    end
+    ui.confirm_discard_buffer_modified(context.bufnr, function()
+        for i, vim_command in ipairs(vim_commands) do
+            log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, vim_command)
+            vim.cmd(vim_command)
+        end
+    end)
 end
 
 -- Run 'edit' vim command on eza/exa/ls results.
@@ -409,38 +415,60 @@ end
 
 -- Run 'edit' vim command on gits status results.
 --- @param lines string[]
-local function edit_git_status(lines)
+--- @param context PipelineContext
+local function edit_git_status(lines, context)
     local edit_commands = _make_edit_git_status_commands(lines)
-    for i, edit_command in ipairs(edit_commands) do
-        log.debug("|fzfx.actions - edit_git_status| [%d]:[%s]", i, edit_command)
-        vim.cmd(edit_command)
-    end
+    ui.confirm_discard_buffer_modified(context.bufnr, function()
+        for i, edit_command in ipairs(edit_commands) do
+            log.debug(
+                "|fzfx.actions - edit_git_status| [%d]:[%s]",
+                i,
+                edit_command
+            )
+            vim.cmd(edit_command)
+        end
+    end)
 end
 
 local M = {
     nop = nop,
+
+    -- find/buffers/git files
     _make_edit_find_commands = _make_edit_find_commands,
-    _make_edit_grep_commands = _make_edit_grep_commands,
-    _make_edit_rg_commands = _make_edit_rg_commands,
     edit = edit,
     edit_find = edit_find,
     edit_buffers = edit_buffers,
     edit_git_files = edit_git_files,
-    edit_ls = edit_ls,
-    edit_rg = edit_rg,
-    edit_grep = edit_grep,
+    -- deprecated
     buffer = buffer,
     bdelete = bdelete,
+
+    -- ls/eza/lsd
+    edit_ls = edit_ls,
+
+    -- rg/grep
+    _make_edit_rg_commands = _make_edit_rg_commands,
+    edit_rg = edit_rg,
+    _make_edit_grep_commands = _make_edit_grep_commands,
+    edit_grep = edit_grep,
+
+    -- git branch
     _make_git_checkout_command = _make_git_checkout_command,
     git_checkout = git_checkout,
+
+    -- git commit
     _make_yank_git_commit_command = _make_yank_git_commit_command,
     yank_git_commit = yank_git_commit,
+
+    -- git status
     _make_edit_git_status_commands = _make_edit_git_status_commands,
     edit_git_status = edit_git_status,
+
     _make_feed_vim_command_params = _make_feed_vim_command_params,
     _make_feed_vim_key_params = _make_feed_vim_key_params,
     feed_vim_command = feed_vim_command,
     feed_vim_key = feed_vim_key,
+
     _make_setqflist_find_items = _make_setqflist_find_items,
     _make_setqflist_rg_items = _make_setqflist_rg_items,
     _make_setqflist_grep_items = _make_setqflist_grep_items,

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -39,16 +39,22 @@ local function edit_find(lines, context)
 end
 
 --- @deprecated
+--- @param lines string[]
+--- @param context PipelineContext
 local function edit_buffers(lines, context)
     return edit_find(lines, context)
 end
 
 --- @deprecated
+--- @param lines string[]
+--- @param context PipelineContext
 local function edit_git_files(lines, context)
     return edit_find(lines, context)
 end
 
 --- @deprecated
+--- @param lines string[]
+--- @param context PipelineContext
 local function edit(lines, context)
     return edit_find(lines, context)
 end
@@ -132,6 +138,8 @@ local function edit_ls(lines)
 end
 
 --- @deprecated
+--- @param lines string[]
+--- @param context PipelineContext
 local function buffer(lines, context)
     return edit_find(lines, context)
 end

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -18,7 +18,7 @@ local function _make_edit_find_commands(lines, opts)
     local results = {}
     for i, line in ipairs(lines) do
         local filename = line_helpers.parse_find(line, opts)
-        local edit_command = string.format("edit %s", filename)
+        local edit_command = string.format("edit! %s", filename)
         table.insert(results, edit_command)
     end
     return results
@@ -57,7 +57,7 @@ local function _make_edit_rg_commands(lines, opts)
     local results = {}
     for i, line in ipairs(lines) do
         local parsed = line_helpers.parse_rg(line, opts)
-        local edit_command = string.format("edit %s", parsed.filename)
+        local edit_command = string.format("edit! %s", parsed.filename)
         table.insert(results, edit_command)
         if parsed.lineno ~= nil then
             if i == #lines then
@@ -91,7 +91,7 @@ local function _make_edit_grep_commands(lines, opts)
     local results = {}
     for i, line in ipairs(lines) do
         local parsed = line_helpers.parse_grep(line, opts)
-        local edit_command = string.format("edit %s", parsed.filename)
+        local edit_command = string.format("edit! %s", parsed.filename)
         table.insert(results, edit_command)
         if parsed.lineno ~= nil then
             if i == #lines then
@@ -389,7 +389,7 @@ local function _make_edit_git_status_commands(lines)
     local results = {}
     for i, line in ipairs(lines) do
         local filename = line_helpers.parse_git_status(line)
-        local edit_command = string.format("edit %s", filename)
+        local edit_command = string.format("edit! %s", filename)
         table.insert(results, edit_command)
     end
     return results

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -67,7 +67,7 @@ local function _make_edit_rg_commands(lines, opts)
     local results = {}
     for i, line in ipairs(lines) do
         local parsed = line_helpers.parse_rg(line, opts)
-        local edit_command = string.format("edit! %s", parsed.filename)
+        local edit_command = string.format("edit %s", parsed.filename)
         table.insert(results, edit_command)
         if parsed.lineno ~= nil then
             if i == #lines then

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -10,7 +10,7 @@ local user_canceled_error = "canceled."
 local function confirm_discard_buffer_modified(bufnr, callback)
     if utils.get_buf_option(bufnr, "modified") then
         vim.ui.input({
-            prompt = "[fzfx] current buffer has been modified, continue? (y/n) ",
+            prompt = "[fzfx] current buffer has been modified, discard? (y/n) ",
         }, function(input)
             if
                 type(input) == "string"

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -8,22 +8,18 @@ local user_cancelled_error = "cancelled."
 --- @param callback fun():any
 local function confirm_discard_buffer_modified(bufnr, callback)
     if utils.get_buf_option(bufnr, "modified") then
-        vim.ui.input({
+        local user_input = vim.fn.input({
             prompt = "[fzfx] current buffer has been modified, continue? (y/n) ",
-        }, function(input)
-            if
-                type(input) == "string"
-                and string.len(input) > 0
-                and utils.string_startswith(input:lower(), "y")
-            then
-                callback()
-            else
-                log.echo(LogLevels.INFO, user_cancelled_error)
-            end
-        end)
-        local current_mode = vim.api.nvim_get_mode()
-        if utils.string_find(current_mode.mode, "i") == nil then
-            vim.api.nvim_feedkeys("i", "m", false)
+            cancelreturn = "n",
+        })
+        if
+            type(user_input) == "string"
+            and string.len(user_input) > 0
+            and utils.string_startswith(user_input:lower(), "y")
+        then
+            callback()
+        else
+            log.echo(LogLevels.INFO, user_cancelled_error)
         end
     else
         callback()

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -1,0 +1,33 @@
+local log = require("fzfx.log")
+local LogLevels = require("fzfx.log").LogLevels
+local utils = require("fzfx.utils")
+
+local default_user_canceled_error = "canceled."
+
+--- @param bufnr integer
+--- @param callback fun():any
+--- @return boolean
+local function confirm_discard_buffer_modified(bufnr, callback)
+    if utils.get_buf_option(bufnr, "modified") then
+        vim.ui.input(
+            { prompt = "Current buffer has unsaved changes, discard? (y/n)" },
+            function(input)
+                if
+                    type(input) == "string"
+                    and string.len(input) > 0
+                    and utils.string_startswith(input:lower(), "y")
+                then
+                    callback()
+                else
+                    log.echo(LogLevels.INFO, default_user_canceled_error)
+                end
+            end
+        )
+    end
+end
+
+local M = {
+    confirm_discard_buffer_modified = confirm_discard_buffer_modified,
+}
+
+return M

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -6,7 +6,6 @@ local user_canceled_error = "canceled."
 
 --- @param bufnr integer
 --- @param callback fun():any
---- @return boolean
 local function confirm_discard_buffer_modified(bufnr, callback)
     if utils.get_buf_option(bufnr, "modified") then
         vim.ui.input({

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -8,14 +8,14 @@ local user_cancelled_error = "cancelled."
 --- @param callback fun():any
 local function confirm_discard_buffer_modified(bufnr, callback)
     if utils.get_buf_option(bufnr, "modified") then
-        local user_input = vim.fn.input({
+        local input = vim.fn.input({
             prompt = "[fzfx] current buffer has been modified, continue? (y/n) ",
             cancelreturn = "n",
         })
         if
-            type(user_input) == "string"
-            and string.len(user_input) > 0
-            and utils.string_startswith(user_input:lower(), "y")
+            type(input) == "string"
+            and string.len(input) > 0
+            and utils.string_startswith(input:lower(), "y")
         then
             callback()
         else

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -2,27 +2,26 @@ local log = require("fzfx.log")
 local LogLevels = require("fzfx.log").LogLevels
 local utils = require("fzfx.utils")
 
-local default_user_canceled_error = "canceled."
+local user_canceled_error = "canceled."
 
 --- @param bufnr integer
 --- @param callback fun():any
 --- @return boolean
 local function confirm_discard_buffer_modified(bufnr, callback)
     if utils.get_buf_option(bufnr, "modified") then
-        vim.ui.input(
-            { prompt = "Current buffer has unsaved changes, discard? (y/n)" },
-            function(input)
-                if
-                    type(input) == "string"
-                    and string.len(input) > 0
-                    and utils.string_startswith(input:lower(), "y")
-                then
-                    callback()
-                else
-                    log.echo(LogLevels.INFO, default_user_canceled_error)
-                end
+        vim.ui.input({
+            prompt = "[fzfx] current buffer has been modified, continue? (y/n) ",
+        }, function(input)
+            if
+                type(input) == "string"
+                and string.len(input) > 0
+                and utils.string_startswith(input:lower(), "y")
+            then
+                callback()
+            else
+                log.echo(LogLevels.INFO, user_canceled_error)
             end
-        )
+        end)
     else
         callback()
     end

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -23,6 +23,8 @@ local function confirm_discard_buffer_modified(bufnr, callback)
                 end
             end
         )
+    else
+        callback()
     end
 end
 

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -9,7 +9,7 @@ local user_canceled_error = "canceled."
 local function confirm_discard_buffer_modified(bufnr, callback)
     if utils.get_buf_option(bufnr, "modified") then
         vim.ui.input({
-            prompt = "[fzfx] current buffer has been modified, discard? (y/n) ",
+            prompt = "[fzfx] current buffer has been modified, continue? (y/n) ",
         }, function(input)
             if
                 type(input) == "string"

--- a/lua/fzfx/ui.lua
+++ b/lua/fzfx/ui.lua
@@ -2,7 +2,7 @@ local log = require("fzfx.log")
 local LogLevels = require("fzfx.log").LogLevels
 local utils = require("fzfx.utils")
 
-local user_canceled_error = "canceled."
+local user_cancelled_error = "cancelled."
 
 --- @param bufnr integer
 --- @param callback fun():any
@@ -18,9 +18,13 @@ local function confirm_discard_buffer_modified(bufnr, callback)
             then
                 callback()
             else
-                log.echo(LogLevels.INFO, user_canceled_error)
+                log.echo(LogLevels.INFO, user_cancelled_error)
             end
         end)
+        local current_mode = vim.api.nvim_get_mode()
+        if utils.string_find(current_mode.mode, "i") == nil then
+            vim.api.nvim_feedkeys("i", "m", false)
+        end
     else
         callback()
     end

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -180,7 +180,7 @@ describe("actions", function()
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81: goodbye",
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:72:9129",
             }
-            actions.edit_grep(lines)
+            actions.edit_grep(lines, make_context())
             assert_true(true)
         end)
         it("run edit grep command with prepend icon", function()
@@ -192,7 +192,7 @@ describe("actions", function()
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:83 goodbye",
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:83:82:71:world",
             }
-            actions.edit_grep(lines)
+            actions.edit_grep(lines, make_context())
             assert_true(true)
         end)
     end)
@@ -262,7 +262,7 @@ describe("actions", function()
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81: goodbye",
                 "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:71:9129",
             }
-            actions.edit_rg(lines)
+            actions.edit_rg(lines, make_context())
             assert_true(true)
         end)
         it("run rg file command with prepend icon", function()
@@ -274,7 +274,7 @@ describe("actions", function()
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81:goodbye",
                 "󰢱 ~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:72:91:94",
             }
-            actions.edit_rg(lines)
+            actions.edit_rg(lines, make_context())
             assert_true(true)
         end)
     end)
@@ -670,7 +670,7 @@ describe("actions", function()
         end)
     end)
     describe("[_make_edit_git_status_commands]", function()
-        it("set files", function()
+        it("open files", function()
             local lines = {
                 " M fzfx/config.lua",
                 " D fzfx/constants.lua",
@@ -687,6 +687,17 @@ describe("actions", function()
                 assert_eq(type(act), "string")
                 assert_eq(act, string.format("edit! %s", expect))
             end
+        end)
+        it("run open files", function()
+            local lines = {
+                " M fzfx/config.lua",
+                " D fzfx/constants.lua",
+                " M fzfx/line_helpers.lua",
+                " M ../test/line_helpers_spec.lua",
+                "?? ../hello",
+            }
+            local actual = actions.edit_git_status(lines, make_context())
+            assert_true(true)
         end)
     end)
 end)

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -10,6 +10,14 @@ describe("actions", function()
         vim.opt.swapfile = false
     end)
 
+    local function make_context()
+        return {
+            bufnr = vim.api.nvim_get_current_buf(),
+            winnr = vim.api.nvim_get_current_win(),
+            tabnr = vim.api.nvim_get_current_tabpage(),
+        }
+    end
+
     local DEVICONS_PATH =
         "~/github/linrongbin16/.config/nvim/lazy/nvim-web-devicons"
     require("fzfx.config").setup()
@@ -79,11 +87,11 @@ describe("actions", function()
                 "lua/fzfx/test/goodbye world/world.txt",
                 "lua/fzfx/test/hello world.txt",
             }
-            actions.edit_find(lines)
-            actions.edit_buffers(lines)
-            actions.edit_git_files(lines)
-            actions.edit(lines)
-            actions.buffer(lines)
+            actions.edit_find(lines, make_context())
+            actions.edit_buffers(lines, make_context())
+            actions.edit_git_files(lines, make_context())
+            actions.edit(lines, make_context())
+            actions.buffer(lines, make_context())
             actions.edit_ls(lines)
             assert_true(true)
         end)
@@ -97,11 +105,11 @@ describe("actions", function()
                 "󰢱 lua/fzfx/test/goodbye world/world.txt",
                 "󰢱 lua/fzfx/test/hello world.txt",
             }
-            actions.edit_find(lines)
-            actions.edit_buffers(lines)
-            actions.edit_git_files(lines)
-            actions.edit(lines)
-            actions.buffer(lines)
+            actions.edit_find(lines, make_context())
+            actions.edit_buffers(lines, make_context())
+            actions.edit_git_files(lines, make_context())
+            actions.edit(lines, make_context())
+            actions.buffer(lines, make_context())
             actions.edit_ls(lines)
             assert_true(true)
         end)

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -39,7 +39,7 @@ describe("actions", function()
             assert_eq(#actual, 5)
             for i, line in ipairs(lines) do
                 local expect = string.format(
-                    "edit %s",
+                    "edit! %s",
                     path.normalize(line, { expand = true })
                 )
                 assert_eq(actual[i], expect)
@@ -60,7 +60,7 @@ describe("actions", function()
             for i, line in ipairs(lines) do
                 local first_space_pos = utils.string_find(line, " ")
                 local expect = string.format(
-                    "edit %s",
+                    "edit! %s",
                     path.normalize(
                         line:sub(first_space_pos + 1),
                         { expand = true }
@@ -122,7 +122,7 @@ describe("actions", function()
             for i, act in ipairs(actual) do
                 if i <= #lines then
                     local expect = string.format(
-                        "edit %s",
+                        "edit! %s",
                         vim.fn.expand(
                             path.normalize(utils.string_split(lines[i], ":")[1])
                         )
@@ -149,7 +149,7 @@ describe("actions", function()
                 local line = lines[i]
                 local first_space_pos = utils.string_find(line, " ")
                 local expect = string.format(
-                    "edit %s",
+                    "edit! %s",
                     path.normalize(
                         line:sub(
                             first_space_pos + 1,
@@ -204,7 +204,7 @@ describe("actions", function()
             for i, act in ipairs(actual) do
                 if i <= #lines then
                     local expect = string.format(
-                        "edit %s",
+                        "edit! %s",
                         vim.fn.expand(
                             path.normalize(utils.string_split(lines[i], ":")[1])
                         )
@@ -231,7 +231,7 @@ describe("actions", function()
                 local line = lines[i]
                 local first_space_pos = utils.string_find(line, " ")
                 local expect = string.format(
-                    "edit %s",
+                    "edit! %s",
                     path.normalize(
                         line:sub(
                             first_space_pos + 1,
@@ -677,7 +677,7 @@ describe("actions", function()
                 local line = lines[i]
                 local expect = line_helpers.parse_git_status(line)
                 assert_eq(type(act), "string")
-                assert_eq(act, string.format("edit %s", expect))
+                assert_eq(act, string.format("edit! %s", expect))
             end
         end)
     end)

--- a/test/fzf_helpers_spec.lua
+++ b/test/fzf_helpers_spec.lua
@@ -47,7 +47,7 @@ describe("helpers", function()
     describe("[_get_visual_lines]", function()
         it("is v mode", function()
             vim.cmd([[
-            edit README.md
+            edit! README.md
             call feedkeys('V', 'n')
             ]])
             -- vim.fn.feedkeys("V", "n")
@@ -75,7 +75,7 @@ describe("helpers", function()
     describe("[_visual_select]", function()
         it("is v mode", function()
             vim.cmd([[
-            edit README.md
+            edit! README.md
             call feedkeys('V', 'n')
             ]])
             local actual = fzf_helpers._visual_select()
@@ -84,7 +84,7 @@ describe("helpers", function()
         end)
         it("is V mode", function()
             vim.cmd([[
-            edit README.md
+            edit! README.md
             call feedkeys('v', 'n')
             call feedkeys('l', 'x')
             call feedkeys('l', 'x')

--- a/test/ui_spec.lua
+++ b/test/ui_spec.lua
@@ -1,0 +1,37 @@
+local cwd = vim.fn.getcwd()
+
+describe("ui", function()
+    local assert_eq = assert.is_equal
+    local assert_true = assert.is_true
+    local assert_false = assert.is_false
+
+    before_each(function()
+        vim.api.nvim_command("cd " .. cwd)
+        vim.o.swapfile = false
+        vim.cmd([[edit README.md]])
+    end)
+
+    local ui = require("fzfx.ui")
+    describe("[confirm_discard_buffer_modified]", function()
+        it("confirm", function()
+            vim.fn.feedkeys("i", "m")
+            vim.fn.feedkeys("i", "m")
+            vim.fn.feedkeys("i", "m")
+            vim.fn.feedkeys("i", "m")
+            ui.confirm_discard_buffer_modified(0, function()
+                assert_true(true)
+            end)
+            vim.fn.feedkeys("y", "m")
+        end)
+        it("cancelled", function()
+            vim.fn.feedkeys("i", "m")
+            vim.fn.feedkeys("i", "m")
+            vim.fn.feedkeys("i", "m")
+            vim.fn.feedkeys("i", "m")
+            ui.confirm_discard_buffer_modified(0, function()
+                assert_true(true)
+            end)
+            vim.fn.feedkeys("n", "m")
+        end)
+    end)
+end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
