### PR TITLE
perf(rpc): uv pipe based rpc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: LuaLs Annotation Typecheck
+      - name: LuaLs Typecheck
         uses: stevearc/nvim-typecheck-action@v1
         with:
           path: lua

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,4 +1,4 @@
 {
   "diagnostics.globals": ["vim", "describe", "before_each", "it"],
-  "workspace.checkThirdParty": false
+  "workspace.checkThirdParty": "Disable"
 }

--- a/bin/general/previewer.lua
+++ b/bin/general/previewer.lua
@@ -25,29 +25,31 @@ shell_helpers.log_debug("metafile:[%s]", metafile)
 shell_helpers.log_debug("resultfile:[%s]", resultfile)
 shell_helpers.log_debug("line:[%s]", vim.inspect(line))
 
-local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
--- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
--- shell_helpers.log_ensure(
---     channel_id > 0,
---     "failed to connect socket on SOCKET_ADDRESS:%s",
---     vim.inspect(SOCKET_ADDRESS)
+-- local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
+-- -- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
+-- -- shell_helpers.log_ensure(
+-- --     channel_id > 0,
+-- --     "failed to connect socket on SOCKET_ADDRESS:%s",
+-- --     vim.inspect(SOCKET_ADDRESS)
+-- -- )
+-- vim.rpcrequest(
+--     channel_id,
+--     "nvim_exec_lua",
+--     ---@diagnostic disable-next-line: param-type-mismatch
+--     [[
+--     local luaargs = {...}
+--     local registry_id = luaargs[1]
+--     local line = luaargs[2]
+--     return require("fzfx.rpc_helpers").call(registry_id, line)
+--     ]],
+--     {
+--         registry_id,
+--         line,
+--     }
 -- )
-vim.rpcrequest(
-    channel_id,
-    "nvim_exec_lua",
-    ---@diagnostic disable-next-line: param-type-mismatch
-    [[
-    local luaargs = {...}
-    local registry_id = luaargs[1]
-    local line = luaargs[2]
-    return require("fzfx.rpc_helpers").call(registry_id, line)
-    ]],
-    {
-        registry_id,
-        line,
-    }
-)
-vim.fn.chanclose(channel_id)
+-- vim.fn.chanclose(channel_id)
+
+shell_helpers.make_rpc_call(registry_id, line)
 
 local metajsonstring = shell_helpers.readfile(metafile) --[[@as string]]
 shell_helpers.log_ensure(

--- a/bin/general/provider.lua
+++ b/bin/general/provider.lua
@@ -20,29 +20,31 @@ shell_helpers.log_debug("metafile:[%s]", metafile)
 shell_helpers.log_debug("resultfile:[%s]", resultfile)
 shell_helpers.log_debug("query:[%s]", query)
 
-local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
--- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
--- shell_helpers.log_ensure(
---     channel_id > 0,
---     "failed to connect socket on SOCKET_ADDRESS:%s",
---     vim.inspect(SOCKET_ADDRESS)
+-- local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
+-- -- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
+-- -- shell_helpers.log_ensure(
+-- --     channel_id > 0,
+-- --     "failed to connect socket on SOCKET_ADDRESS:%s",
+-- --     vim.inspect(SOCKET_ADDRESS)
+-- -- )
+-- vim.rpcrequest(
+--     channel_id,
+--     "nvim_exec_lua",
+--     ---@diagnostic disable-next-line: param-type-mismatch
+--     [[
+--     local luaargs = {...}
+--     local registry_id = luaargs[1]
+--     local query = luaargs[2]
+--     return require("fzfx.rpc_helpers").call(registry_id, query)
+--     ]],
+--     {
+--         registry_id,
+--         query,
+--     }
 -- )
-vim.rpcrequest(
-    channel_id,
-    "nvim_exec_lua",
-    ---@diagnostic disable-next-line: param-type-mismatch
-    [[
-    local luaargs = {...}
-    local registry_id = luaargs[1]
-    local query = luaargs[2]
-    return require("fzfx.rpc_helpers").call(registry_id, query)
-    ]],
-    {
-        registry_id,
-        query,
-    }
-)
-vim.fn.chanclose(channel_id)
+-- vim.fn.chanclose(channel_id)
+
+shell_helpers.make_rpc_call(registry_id, query)
 
 local metajsonstring = shell_helpers.readfile(metafile) --[[@as string]]
 shell_helpers.log_ensure(

--- a/bin/rpc/client.lua
+++ b/bin/rpc/client.lua
@@ -20,26 +20,28 @@ shell_helpers.log_debug("SOCKET_ADDRESS:%s", vim.inspect(SOCKET_ADDRESS))
 shell_helpers.log_debug("registry_id:%s", vim.inspect(registry_id))
 shell_helpers.log_debug("params:%s", vim.inspect(params))
 
-local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
-shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
-shell_helpers.log_ensure(
-    channel_id > 0,
-    "|fzfx.bin.rpc.client| error! failed to connect socket on SOCKET_ADDRESS:%s",
-    vim.inspect(SOCKET_ADDRESS)
-)
-vim.rpcrequest(
-    channel_id,
-    "nvim_exec_lua",
-    ---@diagnostic disable-next-line: param-type-mismatch
-    [[
-    local luaargs = {...}
-    local registry_id = luaargs[1]
-    local params = nil
-    if #luaargs >= 2 then
-        params = luaargs[2]
-    end
-    require("fzfx.rpc_helpers").call(registry_id, params)
-    ]],
-    params == nil and { registry_id } or { registry_id, params }
-)
-vim.fn.chanclose(channel_id)
+-- local channel_id = vim.fn.sockconnect("pipe", SOCKET_ADDRESS, { rpc = true })
+-- shell_helpers.log_debug("channel_id:%s", vim.inspect(channel_id))
+-- shell_helpers.log_ensure(
+--     channel_id > 0,
+--     "|fzfx.bin.rpc.client| error! failed to connect socket on SOCKET_ADDRESS:%s",
+--     vim.inspect(SOCKET_ADDRESS)
+-- )
+-- vim.rpcrequest(
+--     channel_id,
+--     "nvim_exec_lua",
+--     ---@diagnostic disable-next-line: param-type-mismatch
+--     [[
+--     local luaargs = {...}
+--     local registry_id = luaargs[1]
+--     local params = nil
+--     if #luaargs >= 2 then
+--         params = luaargs[2]
+--     end
+--     require("fzfx.rpc_helpers").call(registry_id, params)
+--     ]],
+--     params == nil and { registry_id } or { registry_id, params }
+-- )
+-- vim.fn.chanclose(channel_id)
+
+shell_helpers.make_rpc_call(registry_id, params)

--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -36,7 +36,7 @@ local function setup(options)
     require("fzfx.module").setup()
 
     -- rpc server
-    require("fzfx.server").setup()
+    -- require("fzfx.server").setup()
     require("fzfx.rpc_server").setup()
 
     -- yank history

--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -37,6 +37,7 @@ local function setup(options)
 
     -- rpc server
     require("fzfx.server").setup()
+    require("fzfx.rpc_server").setup()
 
     -- yank history
     require("fzfx.yank_history").setup()

--- a/lua/fzfx/constants.lua
+++ b/lua/fzfx/constants.lua
@@ -9,6 +9,8 @@ local is_linux = not is_windows
     and not is_bsd
     and (vim.fn.has("linux") > 0 or vim.fn.has("unix") > 0)
 
+local int32_max = 2 ^ 31 - 1
+
 local path_separator = is_windows and "\\" or "/"
 
 local has_bat = vim.fn.executable("batcat") > 0 or vim.fn.executable("bat") > 0
@@ -39,6 +41,7 @@ local M = {
     is_macos = is_macos,
     is_bsd = is_bsd,
     is_linux = is_linux,
+    int32_max = int32_max,
 
     -- path
     path_separator = path_separator,

--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -1,7 +1,8 @@
 local log = require("fzfx.log")
 local Popup = require("fzfx.popup").Popup
 local fzf_helpers = require("fzfx.fzf_helpers")
-local server = require("fzfx.server")
+-- local server = require("fzfx.server")
+local rpc_server = require("fzfx.rpc_server")
 local color = require("fzfx.color")
 local utils = require("fzfx.utils")
 local env = require("fzfx.env")
@@ -148,12 +149,12 @@ end
 --- @param context PipelineContext?
 function ProviderSwitch:provide(name, query, context)
     local provider_config = self.provider_configs[self.pipeline]
-    log.debug(
-        "|fzfx.general - ProviderSwitch:provide| pipeline:%s, provider_config:%s, context:%s",
-        vim.inspect(self.pipeline),
-        vim.inspect(provider_config),
-        vim.inspect(context)
-    )
+    -- log.debug(
+    --     "|fzfx.general - ProviderSwitch:provide| pipeline:%s, provider_config:%s, context:%s",
+    --     vim.inspect(self.pipeline),
+    --     vim.inspect(provider_config),
+    --     vim.inspect(context)
+    -- )
     log.ensure(
         type(provider_config) == "table",
         "invalid provider config in %s! pipeline: %s, provider config: %s",
@@ -710,10 +711,8 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         previewer_switch:preview(name, line_params, context)
     end
 
-    local provide_rpc_registry_id =
-        server:get_rpc_server():register(provide_rpc)
-    local preview_rpc_registry_id =
-        server:get_rpc_server():register(preview_rpc)
+    local provide_rpc_registry_id = rpc_server.register(provide_rpc)
+    local preview_rpc_registry_id = rpc_server.register(preview_rpc)
 
     local query_command = string.format(
         "%s %s %s %s %s",
@@ -780,7 +779,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
             end
 
             local interaction_rpc_registry_id =
-                server.get_rpc_server():register(interaction_rpc)
+                rpc_server.register(interaction_rpc)
             table.insert(
                 interaction_rpc_registries,
                 interaction_rpc_registry_id
@@ -819,8 +818,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
                 previewer_switch:switch(pipeline)
             end
 
-            local switch_rpc_registry_id =
-                server.get_rpc_server():register(switch_rpc)
+            local switch_rpc_registry_id = rpc_server.register(switch_rpc)
             table.insert(switch_rpc_registries, switch_rpc_registry_id)
 
             local switch_command = string.format(
@@ -892,10 +890,10 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         actions,
         context,
         function()
-            server.get_rpc_server():unregister(provide_rpc_registry_id)
-            server.get_rpc_server():unregister(preview_rpc_registry_id)
+            rpc_server.unregister(provide_rpc_registry_id)
+            rpc_server.unregister(preview_rpc_registry_id)
             for _, switch_registry_id in ipairs(switch_rpc_registries) do
-                server.get_rpc_server():unregister(switch_registry_id)
+                rpc_server.unregister(switch_registry_id)
             end
         end
     )

--- a/lua/fzfx/log.lua
+++ b/lua/fzfx/log.lua
@@ -45,7 +45,9 @@ local function echo(level, fmt, ...)
             LogHighlights[level],
         })
     end
-    vim.api.nvim_echo(msg_chunks, false, {})
+    vim.defer_fn(function()
+        vim.api.nvim_echo(msg_chunks, false, {})
+    end, 0)
 end
 
 --- @type Options

--- a/lua/fzfx/rpc_server.lua
+++ b/lua/fzfx/rpc_server.lua
@@ -1,0 +1,148 @@
+local log = require("fzfx.log")
+local constants = require("fzfx.constants")
+
+--- @type integer
+local NextRegistryIntegerId = 0
+
+--- @alias RpcRegistryId string
+--- @return RpcRegistryId
+local function _next_registry_id()
+    if NextRegistryIntegerId >= constants.int32_max then
+        NextRegistryIntegerId = 1
+    else
+        NextRegistryIntegerId = NextRegistryIntegerId + 1
+    end
+    local secs, ms = vim.loop.gettimeofday()
+    return string.format("%d-%d-%d", NextRegistryIntegerId, secs, ms)
+end
+
+--- @return string
+local function make_pipe_name()
+    if constants.is_windows then
+        local secs, ms = vim.loop.gettimeofday()
+        local result = string.format(
+            [[\\.\pipe\nvim-pipe-%d-%d-%d]],
+            vim.fn.getpid(),
+            secs,
+            ms
+        )
+        log.debug(
+            "|fzfx.rpc_server - make_pipe_name| result:%s",
+            vim.inspect(result)
+        )
+        return result
+    else
+        return vim.fn.tempname()
+    end
+end
+
+--- @alias RpcCallback fun(params:any):string?
+--- @type table<RpcRegistryId, RpcCallback>
+local RpcRegistries = {}
+
+--- @param cb RpcCallback
+--- @return RpcRegistryId
+local function register(cb)
+    log.ensure(
+        type(cb) == "function",
+        "|fzfx.rpc_server - register| callback f(%s) must be function! %s",
+        type(cb),
+        vim.inspect(cb)
+    )
+    local registry_id = _next_registry_id()
+    RpcRegistries[registry_id] = cb
+    return registry_id
+end
+
+--- @param registry_id RpcRegistryId
+--- @return RpcCallback
+local function unregister(registry_id)
+    log.ensure(
+        type(registry_id) == "string",
+        "|fzfx.rpc_server - unregister| registry_id(%s) must be string! %s",
+        type(registry_id),
+        vim.inspect(registry_id)
+    )
+    local cb = RpcRegistries[registry_id]
+    log.ensure(
+        type(cb) == "function",
+        "|fzfx.rpc_server - unregister| registered callback(%s) must be function! %s",
+        type(cb),
+        vim.inspect(cb)
+    )
+    RpcRegistries[registry_id] = nil
+    return cb
+end
+
+--- @param registry_id RpcRegistryId
+--- @return RpcCallback
+local function get(registry_id)
+    log.ensure(
+        type(registry_id) == "string",
+        "|fzfx.rpc_server - get| registry_id(%s) must be string! %s",
+        type(registry_id),
+        vim.inspect(registry_id)
+    )
+    local cb = RpcRegistries[registry_id]
+    log.ensure(
+        type(cb) == "function",
+        "|fzfx.server - get| registered callback(%s) must be function! %s",
+        type(cb),
+        vim.inspect(cb)
+    )
+    return cb
+end
+
+local function setup()
+    local address = make_pipe_name()
+    log.debug("|fzfx.rpc_server - setup| make address:%s", vim.inspect(address))
+
+    local server_handle, new_server_err = vim.loop.new_pipe(false) --[[@as uv_pipe_t]]
+    log.ensure(
+        server_handle ~= nil,
+        "|fzfx.rpc_server - setup| failed to create new server pipe: %s",
+        vim.inspect(new_server_err)
+    )
+    local bind_result, bind_err = server_handle:bind(address)
+    log.ensure(
+        bind_result ~= nil,
+        "|fzfx.rpc_server - setup| failed to bind pipe server on address: %s! error: %s",
+        vim.inspect(address),
+        vim.inspect(bind_err)
+    )
+    local listen_result, listen_err = server_handle:listen(
+        128,
+        function(listen_complete_err)
+            if listen_complete_err then
+                log.throw(
+                    "|fzfx.rpc_server - setup| failed to complete listen on pipe server: %s! error: %s",
+                    vim.inspect(address),
+                    vim.inspect(listen_complete_err)
+                )
+                return
+            end
+        end
+    )
+
+    -- export socket address as environment variable
+    vim.env._FZFX_NVIM_SOCKET_ADDRESS = address
+
+    local o = {
+        address = address,
+        registry = {},
+    }
+    setmetatable(o, self)
+    self.__index = self
+    return o
+end
+
+local M = {
+    _next_registry_id = _next_registry_id,
+    make_pipe_name = make_pipe_name,
+    setup = setup,
+    register = register,
+    unregister = unregister,
+    get = get,
+}
+
+return M

--- a/lua/fzfx/spawn.lua
+++ b/lua/fzfx/spawn.lua
@@ -1,5 +1,6 @@
 -- No Setup Need
 
+local constants = require("fzfx.constants")
 local utils = require("fzfx.utils")
 
 --- @alias SpawnLineConsumer fun(line:string):any
@@ -180,8 +181,7 @@ function Spawn:run()
     end)
     vim.loop.run()
 
-    local max_timeout = 2 ^ 31
-    vim.wait(max_timeout, function()
+    vim.wait(constants.int32_max, function()
         return self._close_count == 3
     end)
 end


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
