### PR TITLE
feat(preview): add label for rg/grep preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ local Defaults = {
     marker = { "fg", "Keyword" },
     spinner = { "fg", "Label" },
     header = { "fg", "Comment" },
-    preview_label = { "fg", "PreProc" },
+    preview_label = { "fg", "Label" },
   },
 
   -- icons

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ https://github.com/linrongbin16/fzfx.nvim/assets/6496887/aa5ef18c-26b4-4a93-bd0c
 - [rg](https://github.com/BurntSushi/ripgrep) (optional for **live grep**, by default use [grep](https://man7.org/linux/man-pages/man1/grep.1.html)).
 - [fd](https://github.com/sharkdp/fd) (optional for **files**, by default use [find](https://man7.org/linux/man-pages/man1/find.1.html)).
 - [bat](https://github.com/sharkdp/bat) (optional for preview files, by default use [cat](https://man7.org/linux/man-pages/man1/cat.1.html)), [curl](https://man7.org/linux/man-pages/man1/curl.1.html) (optional for preview window labels).
-- [echo](https://man7.org/linux/man-pages/man1/echo.1p.html) (mandatory for vim **commands**, **keymaps** commands, optional for preview window labels).
+- [echo](https://man7.org/linux/man-pages/man1/echo.1p.html) (mandatory for vim **commands**, **keymaps** commands).
 - [git](https://git-scm.com/) (mandatory for **git** commands), [delta](https://github.com/dandavison/delta) (optional for preview git **diff, show, blame**).
 - [lsd](https://github.com/lsd-rs/lsd)/[eza](https://github.com/eza-community/eza) (optional for **file explorer** commands, by default use [ls](https://man7.org/linux/man-pages/man1/ls.1.html)).
 

--- a/bin/rpc/notify.lua
+++ b/bin/rpc/notify.lua
@@ -1,6 +1,6 @@
 local SELF_PATH = vim.env._FZFX_NVIM_SELF_PATH
 if type(SELF_PATH) ~= "string" or string.len(SELF_PATH) == 0 then
-    io.write(string.format("|fzfx.bin.rpc.notify| error! SELF_PATH is empty!"))
+    io.write(string.format("|rpc.notify| error! SELF_PATH is empty!"))
 end
 vim.opt.runtimepath:append(SELF_PATH)
 local shell_helpers = require("fzfx.shell_helpers")

--- a/bin/rpc/request.lua
+++ b/bin/rpc/request.lua
@@ -1,6 +1,6 @@
 local SELF_PATH = vim.env._FZFX_NVIM_SELF_PATH
 if type(SELF_PATH) ~= "string" or string.len(SELF_PATH) == 0 then
-    io.write(string.format("|fzfx.bin.rpc.request| error! SELF_PATH is empty!"))
+    io.write(string.format("|rpc.request| error! SELF_PATH is empty!"))
 end
 vim.opt.runtimepath:append(SELF_PATH)
 local shell_helpers = require("fzfx.shell_helpers")

--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -23,7 +23,7 @@ local function setup(options)
     -- cache
     if vim.fn.filereadable(configs.cache.dir) > 0 then
         log.throw(
-            "error! the 'cache.dir' (%s) already exist but not a directory!",
+            "the 'cache.dir' (%s) already exist but not a directory!",
             configs.cache.dir
         )
     else

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -204,7 +204,7 @@ local function _make_live_grep_provider(opts)
         local option = parsed_query[2]
 
         local args = nil
-        if vim.fn.executable("rg") > 0 then
+        if constants.has_rg then
             if type(opts) == "table" and opts.unrestricted then
                 args = vim.deepcopy(default_unrestricted_rg)
             elseif type(opts) == "table" and opts.buffer then
@@ -2444,14 +2444,23 @@ local Defaults = {
             restricted_mode = {
                 previewer = file_previewer_grep,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = constants.has_rg
+                        and require("fzfx.previewer_labels").rg_previewer_label
+                    or require("fzfx.previewer_labels").grep_previewer_label,
             },
             unrestricted_mode = {
                 previewer = file_previewer_grep,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = constants.has_rg
+                        and require("fzfx.previewer_labels").rg_previewer_label
+                    or require("fzfx.previewer_labels").grep_previewer_label,
             },
             buffer_mode = {
                 previewer = file_previewer_grep,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = constants.has_rg
+                        and require("fzfx.previewer_labels").rg_previewer_label
+                    or require("fzfx.previewer_labels").grep_previewer_label,
             },
         },
         actions = {
@@ -3632,10 +3641,12 @@ local Defaults = {
             workspace_diagnostics = {
                 previewer = file_previewer_grep,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").rg_previewer_label,
             },
             buffer_diagnostics = {
                 previewer = file_previewer_grep,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").rg_previewer_label,
             },
         },
         actions = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -3690,6 +3690,7 @@ local Defaults = {
         previewers = {
             previewer = file_previewer_grep,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+            previewer_label = require("fzfx.previewer_labels").rg_previewer_label,
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,
@@ -3744,6 +3745,7 @@ local Defaults = {
         previewers = {
             previewer = file_previewer_grep,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+            previewer_label = require("fzfx.previewer_labels").rg_previewer_label,
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,
@@ -3798,6 +3800,7 @@ local Defaults = {
         previewers = {
             previewer = file_previewer_grep,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+            previewer_label = require("fzfx.previewer_labels").rg_previewer_label,
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,
@@ -3852,6 +3855,7 @@ local Defaults = {
         previewers = {
             previewer = file_previewer_grep,
             previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+            previewer_label = require("fzfx.previewer_labels").rg_previewer_label,
         },
         actions = {
             ["esc"] = require("fzfx.actions").nop,

--- a/lua/fzfx/fzf_helpers.lua
+++ b/lua/fzfx/fzf_helpers.lua
@@ -100,7 +100,7 @@ local function get_command_feed(opts, feed_type)
         return (y ~= nil and type(y.regtext) == "string") and y.regtext or ""
     else
         log.throw(
-            "|fzfx.fzf_helpers - get_command_feed| error! invalid command feed type! %s",
+            "|fzfx.fzf_helpers - get_command_feed| invalid command feed type! %s",
             vim.inspect(feed_type)
         )
         return ""
@@ -255,7 +255,7 @@ local function nvim_exec()
             return e
         end
     end
-    log.throw("error! failed to found executable 'nvim' on path!")
+    log.throw("failed to found executable 'nvim' on path!")
     return nil
 end
 
@@ -270,7 +270,7 @@ local function fzf_exec()
             return e
         end
     end
-    log.throw("error! failed to found executable 'fzf' on path!")
+    log.throw("failed to found executable 'fzf' on path!")
     return nil
 end
 

--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -116,7 +116,7 @@ function ProviderSwitch:new(name, pipeline, provider_configs)
         for provider_name, provider_opts in pairs(provider_configs) do
             log.ensure(
                 schema.is_provider_config(provider_opts),
-                "error! %s (%s) is not a valid provider! %s",
+                "%s (%s) is not a valid provider! %s",
                 vim.inspect(provider_name),
                 vim.inspect(name),
                 vim.inspect(provider_opts)
@@ -320,7 +320,7 @@ function ProviderSwitch:provide(name, query, context)
         end
     else
         log.throw(
-            "|fzfx.general - ProviderSwitch:provide| error! invalid provider type! %s",
+            "|fzfx.general - ProviderSwitch:provide| invalid provider type! %s",
             vim.inspect(self)
         )
     end
@@ -355,7 +355,7 @@ function PreviewerSwitch:new(name, pipeline, previewer_configs)
         for previewer_name, previewer_opts in pairs(previewer_configs) do
             log.ensure(
                 schema.is_previewer_config(previewer_opts),
-                "error! %s (%s) is not a valid previewer! %s",
+                "%s (%s) is not a valid previewer! %s",
                 vim.inspect(previewer_name),
                 vim.inspect(name),
                 vim.inspect(previewer_opts)
@@ -519,7 +519,7 @@ function PreviewerSwitch:preview(name, line, context)
         end
     else
         log.throw(
-            "|fzfx.general - PreviewerSwitch:preview| error! invalid previewer type! %s",
+            "|fzfx.general - PreviewerSwitch:preview| invalid previewer type! %s",
             vim.inspect(self)
         )
     end
@@ -553,14 +553,19 @@ function PreviewerSwitch:preview_label(name, line, context)
         vim.inspect(self.pipeline),
         vim.inspect(previewer_config)
     )
-    if type(previewer_config.previewer_label) ~= "function" then
-        return
-    end
     if not constants.has_echo or not constants.has_curl then
         return
     end
+    if type(previewer_config.previewer_label) ~= "function" then
+        return
+    end
     local label = previewer_config.previewer_label(line, context)
-    if type(label) ~= "string" or string.len(vim.trim(label)) == 0 then
+    if type(label) ~= "string" then
+        log.err(
+            "previewer label (%s) returned value must be a string: %s",
+            vim.inspect(name),
+            vim.inspect(previewer_config)
+        )
         return
     end
     self.previewer_labels[self.pipeline] = label

--- a/lua/fzfx/module.lua
+++ b/lua/fzfx/module.lua
@@ -65,7 +65,7 @@ local function setup()
     -- log.debug("|fzfx.module - setup| self path:%s", self_path)
     log.ensure(
         type(self_path) == "string" and string.len(self_path) > 0,
-        "|fzfx.module - setup| error! failed to find 'fzfx.nvim' plugin!"
+        "|fzfx.module - setup| failed to find 'fzfx.nvim' plugin!"
     )
     vim.env._FZFX_NVIM_SELF_PATH = self_path
 end

--- a/lua/fzfx/popup.lua
+++ b/lua/fzfx/popup.lua
@@ -39,18 +39,12 @@ local function _make_cursor_window_config(opts)
     local width = _make_window_size(opts.width, total_width)
     local height = _make_window_size(opts.height, total_height)
     if opts.row < 0 then
-        log.throw(
-            "error! invalid option (win_opts.row < 0): %s!",
-            vim.inspect(opts)
-        )
+        log.throw("invalid option (win_opts.row < 0): %s!", vim.inspect(opts))
     end
     local row = opts.row
 
     if opts.col < 0 then
-        log.throw(
-            "error! invalid option (win_opts.col < 0): %s!",
-            vim.inspect(opts)
-        )
+        log.throw("invalid option (win_opts.col < 0): %s!", vim.inspect(opts))
     end
     local col = opts.col
 
@@ -110,10 +104,7 @@ local function _make_center_window_config(opts)
         (opts.row > -1 and opts.row < -0.5)
         or (opts.row > 0.5 and opts.row < 1)
     then
-        log.throw(
-            "error! invalid option (win_opts.row): %s!",
-            vim.inspect(opts)
-        )
+        log.throw("invalid option (win_opts.row): %s!", vim.inspect(opts))
     end
     local row = _make_window_center_shift(total_height, height, opts.row)
     -- log.debug(
@@ -128,10 +119,7 @@ local function _make_center_window_config(opts)
         (opts.col > -1 and opts.col < -0.5)
         or (opts.col > 0.5 and opts.col < 1)
     then
-        log.throw(
-            "error! invalid option (win_opts.col): %s!",
-            vim.inspect(opts)
-        )
+        log.throw("invalid option (win_opts.col): %s!", vim.inspect(opts))
     end
     local col = _make_window_center_shift(total_width, width, opts.col)
 
@@ -167,7 +155,7 @@ local function _make_window_config(win_opts)
         return _make_center_window_config(win_opts)
     else
         log.throw(
-            "error! failed to make popup window opts, unsupport relative value %s.",
+            "failed to make popup window opts, unsupport relative value %s.",
             vim.inspect(relative)
         )
         ---@diagnostic disable-next-line: missing-return
@@ -243,7 +231,7 @@ function PopupWindow:close()
         vim.api.nvim_win_close(self.winnr, true)
         -- else
         --     log.debug(
-        --         "error! cannot close invalid popup window! %s",
+        --         "cannot close invalid popup window! %s",
         --         vim.inspect(self.winnr)
         --     )
     end
@@ -373,7 +361,7 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
 
         log.ensure(
             vim.fn.filereadable(result) > 0,
-            "|fzfx.popup - Popup:new.on_fzf_exit| error! result %s must be readable",
+            "|fzfx.popup - Popup:new.on_fzf_exit| result %s must be readable",
             vim.inspect(result)
         )
         local lines = utils.readlines(result) --[[@as table]]
@@ -393,7 +381,7 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
             local action_callback = actions[action_key]
             if type(action_callback) ~= "function" then
                 log.throw(
-                    "error! wrong action type on key: %s, must be function(%s): %s",
+                    "wrong action type on key: %s, must be function(%s): %s",
                     vim.inspect(action_key),
                     type(action_callback),
                     vim.inspect(action_callback)
@@ -402,7 +390,7 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
                 local ok, cb_err = pcall(action_callback, action_lines, context)
                 if not ok then
                     log.throw(
-                        "error! failed to run action on callback(%s) with lines(%s)! %s",
+                        "failed to run action on callback(%s) with lines(%s)! %s",
                         vim.inspect(action_callback),
                         vim.inspect(action_lines),
                         vim.inspect(cb_err)

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -8,7 +8,7 @@ local function _make_find_previewer_label(opts)
     --- @return string?
     local function impl(line)
         if type(line) ~= "string" or string.len(line) == 0 then
-            return nil
+            return ""
         end
         return vim.fn.fnamemodify(line_helpers.parse_find(line, opts), ":t")
     end
@@ -30,7 +30,7 @@ local function _make_rg_previewer_label(opts)
     --- @return string?
     local function impl(line)
         if type(line) ~= "string" or string.len(line) == 0 then
-            return nil
+            return ""
         end
         local parsed = line_helpers.parse_rg(line, opts)
         return string.format(
@@ -58,7 +58,7 @@ local function _make_grep_previewer_label(opts)
     --- @return string?
     local function impl(line)
         if type(line) ~= "string" or string.len(line) == 0 then
-            return nil
+            return ""
         end
         local parsed = line_helpers.parse_grep(line, opts)
         return string.format(

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -33,7 +33,12 @@ local function _make_rg_previewer_label(opts)
             return nil
         end
         local parsed = line_helpers.parse_rg(line, opts)
-        return vim.fn.fnamemodify(parsed.filename, ":t")
+        return string.format(
+            "%s:%d:%d",
+            vim.fn.fnamemodify(parsed.filename, ":t"),
+            parsed.lineno,
+            parsed.column
+        )
     end
     return impl
 end
@@ -56,7 +61,11 @@ local function _make_grep_previewer_label(opts)
             return nil
         end
         local parsed = line_helpers.parse_grep(line, opts)
-        return vim.fn.fnamemodify(parsed.filename, ":t")
+        return string.format(
+            "%s:%d",
+            vim.fn.fnamemodify(parsed.filename, ":t"),
+            parsed.lineno
+        )
     end
     return impl
 end

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -22,9 +22,62 @@ local function find_previewer_label(line)
     return f(line)
 end
 
+--- @package
+--- @param opts {no_icon:boolean?}?
+--- @return PreviewerLabel
+local function _make_rg_previewer_label(opts)
+    --- @param line string?
+    --- @return string?
+    local function impl(line)
+        if type(line) ~= "string" or string.len(line) == 0 then
+            return nil
+        end
+        local parsed = line_helpers.parse_rg(line, opts)
+        return vim.fn.fnamemodify(parsed.filename, ":t")
+    end
+    return impl
+end
+
+--- @param line string?
+--- @return string?
+local function rg_previewer_label(line)
+    local f = _make_rg_previewer_label()
+    return f(line)
+end
+
+--- @package
+--- @param opts {no_icon:boolean?}?
+--- @return PreviewerLabel
+local function _make_grep_previewer_label(opts)
+    --- @param line string?
+    --- @return string?
+    local function impl(line)
+        if type(line) ~= "string" or string.len(line) == 0 then
+            return nil
+        end
+        local parsed = line_helpers.parse_grep(line, opts)
+        return vim.fn.fnamemodify(parsed.filename, ":t")
+    end
+    return impl
+end
+
+--- @param line string?
+--- @return string?
+local function grep_previewer_label(line)
+    local f = _make_grep_previewer_label()
+    return f(line)
+end
+
 local M = {
+    -- find/buffers/git files
     _make_find_previewer_label = _make_find_previewer_label,
     find_previewer_label = find_previewer_label,
+
+    -- rg/grep
+    _make_rg_previewer_label = _make_rg_previewer_label,
+    rg_previewer_label = rg_previewer_label,
+    _make_grep_previewer_label = _make_grep_previewer_label,
+    grep_previewer_label = grep_previewer_label,
 }
 
 return M

--- a/lua/fzfx/server.lua
+++ b/lua/fzfx/server.lua
@@ -31,7 +31,7 @@ end
 local function _make_windows_pipe_name()
     log.ensure(
         constants.is_windows,
-        "|fzfx.server - get_windows_pipe_name| error! must use this function in Windows!"
+        "|fzfx.server - get_windows_pipe_name| must use this function in Windows!"
     )
     local result = string.format([[\\.\pipe\nvim-pipe-%s]], _make_uuid())
     return result
@@ -54,7 +54,7 @@ function RpcServer:new()
     -- )
     log.ensure(
         type(address) == "string" and string.len(address) > 0,
-        "error! failed to start socket server!"
+        "failed to start socket server!"
     )
 
     -- export socket address as environment variable
@@ -89,7 +89,7 @@ end
 function RpcServer:register(callback)
     log.ensure(
         type(callback) == "function",
-        "|fzfx.server - RpcServer:register| error! callback f(%s) must be function! %s",
+        "|fzfx.server - RpcServer:register| callback f(%s) must be function! %s",
         type(callback),
         vim.inspect(callback)
     )
@@ -103,14 +103,14 @@ end
 function RpcServer:unregister(registry_id)
     log.ensure(
         type(registry_id) == "string",
-        "|fzfx.server - RpcServer:unregister| error! registry_id(%s) must be string! %s",
+        "|fzfx.server - RpcServer:unregister| registry_id(%s) must be string! %s",
         type(registry_id),
         vim.inspect(registry_id)
     )
     local callback = self.registry[registry_id]
     log.ensure(
         type(callback) == "function",
-        "|fzfx.server - RpcServer:unregister| error! saved callback(%s) must be function! %s",
+        "|fzfx.server - RpcServer:unregister| registered callback(%s) must be function! %s",
         type(callback),
         vim.inspect(callback)
     )
@@ -123,14 +123,14 @@ end
 function RpcServer:get(registry_id)
     log.ensure(
         type(registry_id) == "string",
-        "|fzfx.server - RpcServer:get| error! registry_id(%s) must be string! %s",
+        "|fzfx.server - RpcServer:get| registry_id(%s) must be string! %s",
         type(registry_id),
         vim.inspect(registry_id)
     )
     local callback = self.registry[registry_id]
     log.ensure(
         type(callback) == "function",
-        "|fzfx.server - RpcServer:get| error! saved callback(%s) must be function! %s",
+        "|fzfx.server - RpcServer:get| registered callback(%s) must be function! %s",
         type(callback),
         vim.inspect(callback)
     )

--- a/lua/fzfx/yank_history.lua
+++ b/lua/fzfx/yank_history.lua
@@ -121,7 +121,7 @@ local function save_yank()
 
     log.ensure(
         YankHistoryInstance ~= nil,
-        "|fzfx.yank_history - save_yank| error! YankHistoryInstance must not be nil!"
+        "|fzfx.yank_history - save_yank| YankHistoryInstance must not be nil!"
     )
     ---@diagnostic disable-next-line: need-check-nil
     return YankHistoryInstance:push(y)
@@ -131,7 +131,7 @@ end
 local function get_yank()
     log.ensure(
         YankHistoryInstance ~= nil,
-        "|fzfx.yank_history - get_yank| error! YankHistoryInstance must not be nil!"
+        "|fzfx.yank_history - get_yank| YankHistoryInstance must not be nil!"
     )
     ---@diagnostic disable-next-line: need-check-nil
     return YankHistoryInstance:get()

--- a/test/general_spec.lua
+++ b/test/general_spec.lua
@@ -334,6 +334,10 @@ describe("general", function()
             assert_eq(type(ps.previewer_configs.default.previewer), "function")
             assert_eq(ps.previewer_configs.default.previewer(), "ls -1")
             assert_eq(ps.previewer_configs.default.previewer_type, "command")
+            assert_eq(
+                ps.fzfportfile,
+                general._make_cache_filename("previewer", "fzfport", "single")
+            )
             assert_eq(ps:switch("default"), nil)
         end)
         it("creates multiple command previewer", function()
@@ -369,9 +373,9 @@ describe("general", function()
     describe("[PreviewerSwitch:preview_label]", function()
         it("not previews label", function()
             local name = "label_test1"
-            local fzf_listen_port_file =
-                general._make_cache_filename("fzf", "listen", "port", name)
-            utils.writefile(fzf_listen_port_file, "12345")
+            local fzf_port_file =
+                general._make_cache_filename("previewer", "fzfport", name)
+            utils.writefile(fzf_port_file, "12345")
             local ps = general.PreviewerSwitch:new(name, "p1", {
                 p1 = {
                     previewer = function()
@@ -392,11 +396,11 @@ describe("general", function()
                 )
             )
             assert_true(
-                ps:preview_label("p1", "hello", {}, fzf_listen_port_file) == nil
+                ps:preview_label("p1", "hello", {}, fzf_port_file) == nil
             )
             ps:switch("p2")
             assert_true(
-                ps:preview_label("p2", "world", {}, fzf_listen_port_file) == nil
+                ps:preview_label("p2", "world", {}, fzf_port_file) == nil
             )
         end)
         it("previews label", function()
@@ -429,13 +433,9 @@ describe("general", function()
                     os.getenv("GITHUB_ACTIONS")
                 )
             )
-            assert_true(
-                ps:preview_label("p1", "hello", {}, fzf_listen_port_file) == nil
-            )
+            assert_true(ps:preview_label("p1", "hello", {}) == nil)
             ps:switch("p2")
-            assert_true(
-                ps:preview_label("p2", "world", {}, fzf_listen_port_file) == nil
-            )
+            assert_true(ps:preview_label("p2", "world", {}) == nil)
         end)
     end)
     describe("[_render_help]", function()

--- a/test/previewer_labels_spec.lua
+++ b/test/previewer_labels_spec.lua
@@ -11,7 +11,7 @@ describe("previewer_labels", function()
 
     local utils = require("fzfx.utils")
     local previewer_labels = require("fzfx.previewer_labels")
-    describe("[_make_find_previewer_label]", function()
+    describe("[_make_find_previewer_label/find_previewer_label]", function()
         it("makes", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil
             local lines = {
@@ -23,26 +23,69 @@ describe("previewer_labels", function()
             }
             for _, line in ipairs(lines) do
                 local f = previewer_labels._make_find_previewer_label(line)
-                local actual = f(line)
-                assert_eq(type(actual), "string")
-                assert_true(utils.string_endswith(line, actual))
+                local actual1 = f(line)
+                assert_eq(type(actual1), "string")
+                assert_true(utils.string_endswith(line, actual1))
+                local actual2 = previewer_labels.find_previewer_label(line)
+                assert_eq(type(actual2), "string")
+                assert_true(utils.string_endswith(line, actual2))
+                assert_eq(actual1, actual2)
             end
         end)
     end)
-    describe("[find_previewer_label]", function()
+    describe("[_make_rg_previewer_label/rg_previewer_label]", function()
         it("makes", function()
             vim.env._FZFX_NVIM_DEVICONS_PATH = nil
             local lines = {
-                "~/github/linrongbin16/fzfx.nvim/README.md",
-                "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
-                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua",
-                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
-                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
+                "~/github/linrongbin16/fzfx.nvim/README.md:1:1:ok",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua:1:2:hello",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua:1:3:hello world",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81: goodbye",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:71:9129",
             }
             for _, line in ipairs(lines) do
-                local actual = previewer_labels.find_previewer_label(line)
-                assert_eq(type(actual), "string")
-                assert_true(utils.string_endswith(line, actual))
+                local f = previewer_labels._make_rg_previewer_label(line)
+                local actual1 = f(line)
+                assert_eq(type(actual1), "string")
+                assert_eq(type(utils.string_find(line, actual1)), "number")
+                assert_true(utils.string_find(line, actual1) > 0)
+                local actual2 = previewer_labels.rg_previewer_label(line)
+                assert_eq(type(actual2), "string")
+                assert_eq(type(utils.string_find(line, actual2)), "number")
+                assert_true(utils.string_find(line, actual2) > 0)
+                assert_eq(actual1, actual2)
+                assert_eq(
+                    utils.string_find(line, actual1),
+                    utils.string_find(line, actual2)
+                )
+            end
+        end)
+    end)
+    describe("[_make_grep_previewer_label/grep_previewer_label]", function()
+        it("makes", function()
+            vim.env._FZFX_NVIM_DEVICONS_PATH = nil
+            local lines = {
+                "~/github/linrongbin16/fzfx.nvim/README.md:73",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua:1",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua:1:hello world",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:12:81: goodbye",
+                "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:72:9129",
+            }
+            for _, line in ipairs(lines) do
+                local f = previewer_labels._make_grep_previewer_label(line)
+                local actual1 = f(line)
+                assert_eq(type(actual1), "string")
+                assert_eq(type(utils.string_find(line, actual1)), "number")
+                assert_true(utils.string_find(line, actual1) > 0)
+                local actual2 = previewer_labels.grep_previewer_label(line)
+                assert_eq(type(actual2), "string")
+                assert_eq(type(utils.string_find(line, actual2)), "number")
+                assert_true(utils.string_find(line, actual2) > 0)
+                assert_eq(actual1, actual2)
+                assert_eq(
+                    utils.string_find(line, actual1),
+                    utils.string_find(line, actual2)
+                )
             end
         end)
     end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [x] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [x] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [x] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
