### PR TITLE
feat(preview): add vim commands, keymaps previewer label

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -941,7 +941,7 @@ local function _render_vim_commands(commands, name_width, opts_width)
 
     local NAME = "Name"
     local OPTS = "Bang|Bar|Nargs|Range|Complete"
-    local DESC_OR_LOC = "Desc/Location"
+    local DEF_OR_LOC = "Definition/Location"
 
     local results = {}
     local formatter = "%-"
@@ -951,7 +951,7 @@ local function _render_vim_commands(commands, name_width, opts_width)
         .. "%-"
         .. tostring(opts_width)
         .. "s %s"
-    local header = string.format(formatter, NAME, OPTS, DESC_OR_LOC)
+    local header = string.format(formatter, NAME, OPTS, DEF_OR_LOC)
     table.insert(results, header)
     log.debug(
         "|fzfx.config - _render_vim_commands| formatter:%s, header:%s",
@@ -3278,17 +3278,17 @@ local Defaults = {
             all_commands = {
                 previewer = vim_commands_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-                previewer_label = require("fzfx.previewer_labels").vim_commands_previewer_label,
+                previewer_label = require("fzfx.previewer_labels").vim_command_previewer_label,
             },
             ex_commands = {
                 previewer = vim_commands_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-                previewer_label = require("fzfx.previewer_labels").vim_commands_previewer_label,
+                previewer_label = require("fzfx.previewer_labels").vim_command_previewer_label,
             },
             user_commands = {
                 previewer = vim_commands_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-                previewer_label = require("fzfx.previewer_labels").vim_commands_previewer_label,
+                previewer_label = require("fzfx.previewer_labels").vim_command_previewer_label,
             },
         },
         actions = {
@@ -3498,18 +3498,22 @@ local Defaults = {
             all_mode = {
                 previewer = _vim_keymaps_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_keymap_previewer_label,
             },
             n_mode = {
                 previewer = _vim_keymaps_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_keymap_previewer_label,
             },
             i_mode = {
                 previewer = _vim_keymaps_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_keymap_previewer_label,
             },
             v_mode = {
                 previewer = _vim_keymaps_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_keymap_previewer_label,
             },
         },
         actions = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -3278,14 +3278,17 @@ local Defaults = {
             all_commands = {
                 previewer = vim_commands_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_commands_previewer_label,
             },
             ex_commands = {
                 previewer = vim_commands_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_commands_previewer_label,
             },
             user_commands = {
                 previewer = vim_commands_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = require("fzfx.previewer_labels").vim_commands_previewer_label,
             },
         },
         actions = {

--- a/lua/fzfx/fzf_helpers.lua
+++ b/lua/fzfx/fzf_helpers.lua
@@ -300,6 +300,8 @@ local function send_http_post(port, body)
         "-s",
         "-S",
         "--disable",
+        "--parallel",
+        "--parallel-immediate",
         "--noproxy",
         "*",
         "-XPOST",

--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -589,7 +589,7 @@ function PreviewerSwitch:preview_label(name, line, context)
             fzf_port,
             string.format("change-preview-label(%s)", vim.trim(last_label))
         )
-    end, 0)
+    end, 50)
 
     return label
 end

--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -589,7 +589,7 @@ function PreviewerSwitch:preview_label(name, line, context)
             fzf_port,
             string.format("change-preview-label(%s)", vim.trim(last_label))
         )
-    end, 50)
+    end, 100)
 
     return label
 end

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -110,6 +110,9 @@ local M = {
     rg_previewer_label = rg_previewer_label,
     _make_grep_previewer_label = _make_grep_previewer_label,
     grep_previewer_label = grep_previewer_label,
+
+    -- commands
+    vim_commands_previewer_label = vim_commands_previewer_label,
 }
 
 return M

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -77,28 +77,43 @@ local function grep_previewer_label(line)
     return f(line)
 end
 
---- @param line string?
---- @param context VimCommandsPipelineContext
---- @return string
-local function vim_commands_previewer_label(line, context)
-    if type(line) ~= "string" or string.len(line) == 0 then
-        return ""
+--- @param parser fun(line:string,context:VimCommandsPipelineContext|VimKeyMapsPipelineContext):table|string
+--- @param default_value string
+--- @return fun(line:string,context:VimCommandsPipelineContext|VimKeyMapsPipelineContext):string?
+local function _make_vim_command_previewer_label(parser, default_value)
+    --- @param line string?
+    --- @param context VimCommandsPipelineContext
+    --- @return string
+    local function impl(line, context)
+        if type(line) ~= "string" or string.len(line) == 0 then
+            return ""
+        end
+        local parsed = parser(line, context)
+        if
+            type(parsed) == "table"
+            and type(parsed.filename) == "string"
+            and string.len(parsed.filename) > 0
+            and type(parsed.lineno) == "number"
+        then
+            return string.format(
+                "%s:%d",
+                vim.fn.fnamemodify(parsed.filename, ":t"),
+                parsed.lineno
+            )
+        end
+        return default_value
     end
-    local parsed = line_helpers.parse_vim_command(line, context)
-    if
-        type(parsed) == "table"
-        and type(parsed.filename) == "string"
-        and string.len(parsed.filename) > 0
-        and type(parsed.lineno) == "number"
-    then
-        return string.format(
-            "%s:%d",
-            vim.fn.fnamemodify(parsed.filename, ":t"),
-            parsed.lineno
-        )
-    end
-    return "Description"
+    return impl
 end
+
+local vim_command_previewer_label = _make_vim_command_previewer_label(
+    line_helpers.parse_vim_command,
+    "Definition"
+)
+local vim_keymap_previewer_label = _make_vim_command_previewer_label(
+    line_helpers.parse_vim_keymap,
+    "Definition"
+)
 
 local M = {
     -- find/buffers/git files
@@ -111,8 +126,10 @@ local M = {
     _make_grep_previewer_label = _make_grep_previewer_label,
     grep_previewer_label = grep_previewer_label,
 
-    -- commands
-    vim_commands_previewer_label = vim_commands_previewer_label,
+    -- command/keymap
+    _make_vim_command_previewer_label = _make_vim_command_previewer_label,
+    vim_command_previewer_label = vim_command_previewer_label,
+    vim_keymap_previewer_label = vim_keymap_previewer_label,
 }
 
 return M

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -77,6 +77,29 @@ local function grep_previewer_label(line)
     return f(line)
 end
 
+--- @param line string?
+--- @param context VimCommandsPipelineContext
+--- @return string
+local function vim_commands_previewer_label(line, context)
+    if type(line) ~= "string" or string.len(line) == 0 then
+        return ""
+    end
+    local parsed = line_helpers.parse_vim_command(line, context)
+    if
+        type(parsed) == "table"
+        and type(parsed.filename) == "string"
+        and string.len(parsed.filename) > 0
+        and type(parsed.lineno) == "number"
+    then
+        return string.format(
+            "%s:%d",
+            vim.fn.fnamemodify(parsed.filename, ":t"),
+            parsed.lineno
+        )
+    end
+    return "Description"
+end
+
 local M = {
     -- find/buffers/git files
     _make_find_previewer_label = _make_find_previewer_label,

--- a/test/config_spec.lua
+++ b/test/config_spec.lua
@@ -666,7 +666,7 @@ describe("config", function()
             assert_eq(type(actual), "table")
             assert_eq(#actual, 3)
             assert_true(utils.string_startswith(actual[1], "Name"))
-            assert_true(utils.string_endswith(actual[1], "Desc/Location"))
+            assert_true(utils.string_endswith(actual[1], "Definition/Location"))
             assert_true(utils.string_startswith(actual[2], "FzfxGBranches"))
             local expect = string.format(
                 "%s:%d",

--- a/test/previewer_labels_spec.lua
+++ b/test/previewer_labels_spec.lua
@@ -89,4 +89,37 @@ describe("previewer_labels", function()
             end
         end)
     end)
+    describe("[vim_commands_previewer_label]", function()
+        local CONTEXT = {
+            name_width = 17,
+            opts_width = 37,
+        }
+        it("previews filename & lineno", function()
+            local lines = {
+                ":                 N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1121",
+                ":!                N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1122",
+                ":Next             N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1124",
+            }
+            for _, line in ipairs(lines) do
+                local actual =
+                    previewer_labels.vim_commands_previewer_label(line, CONTEXT)
+                assert_eq(type(actual), "string")
+                local actual_splits = utils.string_split(actual, ":")
+                assert_eq(#actual_splits, 2)
+                assert_true(utils.string_find(line, actual_splits[1]) > 0)
+                assert_true(utils.string_endswith(line, actual_splits[2]))
+            end
+        end)
+        it("previews description", function()
+            local lines = {
+                ':bdelete          N   |Y  |N/A  |N/A  |N/A              "delete buffer"',
+            }
+            for _, line in ipairs(lines) do
+                local actual =
+                    previewer_labels.vim_commands_previewer_label(line, CONTEXT)
+                assert_eq(type(actual), "string")
+                assert_eq(actual, "Description")
+            end
+        end)
+    end)
 end)

--- a/test/previewer_labels_spec.lua
+++ b/test/previewer_labels_spec.lua
@@ -94,7 +94,7 @@ describe("previewer_labels", function()
             name_width = 17,
             opts_width = 37,
         }
-        it("previews filename & lineno", function()
+        it("previews location", function()
             local lines = {
                 ":                 N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1121",
                 ":!                N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1122",
@@ -118,7 +118,42 @@ describe("previewer_labels", function()
                 local actual =
                     previewer_labels.vim_command_previewer_label(line, CONTEXT)
                 assert_eq(type(actual), "string")
-                assert_eq(actual, "Description")
+                assert_eq(actual, "Definition")
+            end
+        end)
+    end)
+    describe("[vim_keymap_previewer_label]", function()
+        local CONTEXT = {
+            key_width = 44,
+            opts_width = 26,
+        }
+        it("previews location", function()
+            local lines = {
+                "<C-F>                                            |N      |N     |N      ~/.config/nvim/lazy/nvim-cmp/lua/cmp/utils/keymap.lua:127",
+                "<CR>                                             |N      |N     |N      ~/.config/nvim/lazy/nvim-cmp/lua/cmp/utils/keymap.lua:127",
+                "<Plug>(YankyGPutAfterShiftRight)             n   |Y      |N     |Y      ~/.config/nvim/lazy/yanky.nvim/lua/yanky.lua:369",
+            }
+            for _, line in ipairs(lines) do
+                local actual =
+                    previewer_labels.vim_keymap_previewer_label(line, CONTEXT)
+                assert_eq(type(actual), "string")
+                local actual_splits = utils.string_split(actual, ":")
+                assert_eq(#actual_splits, 2)
+                assert_true(utils.string_find(line, actual_splits[1]) > 0)
+                assert_true(utils.string_endswith(line, actual_splits[2]))
+            end
+        end)
+        it("previews definition", function()
+            local lines = {
+                '%                                            n   |N      |N     |Y      "<Plug>(matchup-%)"',
+                '&                                            n   |Y      |N     |N      ":&&<CR>"',
+                '<2-LeftMouse>                                n   |N      |N     |Y      "<Plug>(matchup-double-click)"',
+            }
+            for _, line in ipairs(lines) do
+                local actual =
+                    previewer_labels.vim_keymap_previewer_label(line, CONTEXT)
+                assert_eq(type(actual), "string")
+                assert_eq(actual, "Definition")
             end
         end)
     end)

--- a/test/previewer_labels_spec.lua
+++ b/test/previewer_labels_spec.lua
@@ -89,7 +89,7 @@ describe("previewer_labels", function()
             end
         end)
     end)
-    describe("[vim_commands_previewer_label]", function()
+    describe("[vim_command_previewer_label]", function()
         local CONTEXT = {
             name_width = 17,
             opts_width = 37,
@@ -102,7 +102,7 @@ describe("previewer_labels", function()
             }
             for _, line in ipairs(lines) do
                 local actual =
-                    previewer_labels.vim_commands_previewer_label(line, CONTEXT)
+                    previewer_labels.vim_command_previewer_label(line, CONTEXT)
                 assert_eq(type(actual), "string")
                 local actual_splits = utils.string_split(actual, ":")
                 assert_eq(#actual_splits, 2)
@@ -116,7 +116,7 @@ describe("previewer_labels", function()
             }
             for _, line in ipairs(lines) do
                 local actual =
-                    previewer_labels.vim_commands_previewer_label(line, CONTEXT)
+                    previewer_labels.vim_command_previewer_label(line, CONTEXT)
                 assert_eq(type(actual), "string")
                 assert_eq(actual, "Description")
             end

--- a/test/previewer_labels_spec.lua
+++ b/test/previewer_labels_spec.lua
@@ -89,39 +89,62 @@ describe("previewer_labels", function()
             end
         end)
     end)
-    describe("[vim_command_previewer_label]", function()
-        local CONTEXT = {
-            name_width = 17,
-            opts_width = 37,
-        }
-        it("previews location", function()
-            local lines = {
-                ":                 N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1121",
-                ":!                N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1122",
-                ":Next             N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1124",
+    describe(
+        "[vim_command_previewer_label/_make_vim_command_previewer_label]",
+        function()
+            local CONTEXT = {
+                name_width = 17,
+                opts_width = 37,
             }
-            for _, line in ipairs(lines) do
-                local actual =
-                    previewer_labels.vim_command_previewer_label(line, CONTEXT)
-                assert_eq(type(actual), "string")
-                local actual_splits = utils.string_split(actual, ":")
-                assert_eq(#actual_splits, 2)
-                assert_true(utils.string_find(line, actual_splits[1]) > 0)
-                assert_true(utils.string_endswith(line, actual_splits[2]))
-            end
-        end)
-        it("previews description", function()
-            local lines = {
-                ':bdelete          N   |Y  |N/A  |N/A  |N/A              "delete buffer"',
-            }
-            for _, line in ipairs(lines) do
-                local actual =
-                    previewer_labels.vim_command_previewer_label(line, CONTEXT)
-                assert_eq(type(actual), "string")
-                assert_eq(actual, "Definition")
-            end
-        end)
-    end)
+            it("previews location", function()
+                local lines = {
+                    ":                 N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1121",
+                    ":!                N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1122",
+                    ":Next             N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1124",
+                }
+                for _, line in ipairs(lines) do
+                    local actual = previewer_labels.vim_command_previewer_label(
+                        line,
+                        CONTEXT
+                    )
+                    assert_eq(type(actual), "string")
+                    local actual_splits = utils.string_split(actual, ":")
+                    assert_eq(#actual_splits, 2)
+                    assert_true(utils.string_find(line, actual_splits[1]) > 0)
+                    assert_true(utils.string_endswith(line, actual_splits[2]))
+
+                    local f =
+                        previewer_labels._make_vim_command_previewer_label(
+                            require("fzfx.line_helpers").parse_vim_command,
+                            "Definition"
+                        )
+                    local actual2 = f(line, CONTEXT)
+                    assert_eq(actual, actual2)
+                end
+            end)
+            it("previews description", function()
+                local lines = {
+                    ':bdelete          N   |Y  |N/A  |N/A  |N/A              "delete buffer"',
+                }
+                for _, line in ipairs(lines) do
+                    local actual = previewer_labels.vim_command_previewer_label(
+                        line,
+                        CONTEXT
+                    )
+                    assert_eq(type(actual), "string")
+                    assert_eq(actual, "Definition")
+
+                    local f =
+                        previewer_labels._make_vim_command_previewer_label(
+                            require("fzfx.line_helpers").parse_vim_command,
+                            "Definition"
+                        )
+                    local actual2 = f(line, CONTEXT)
+                    assert_eq(actual, actual2)
+                end
+            end)
+        end
+    )
     describe("[vim_keymap_previewer_label]", function()
         local CONTEXT = {
             key_width = 44,
@@ -141,6 +164,13 @@ describe("previewer_labels", function()
                 assert_eq(#actual_splits, 2)
                 assert_true(utils.string_find(line, actual_splits[1]) > 0)
                 assert_true(utils.string_endswith(line, actual_splits[2]))
+
+                local f = previewer_labels._make_vim_command_previewer_label(
+                    require("fzfx.line_helpers").parse_vim_keymap,
+                    "Definition"
+                )
+                local actual2 = f(line, CONTEXT)
+                assert_eq(actual, actual2)
             end
         end)
         it("previews definition", function()
@@ -154,6 +184,13 @@ describe("previewer_labels", function()
                     previewer_labels.vim_keymap_previewer_label(line, CONTEXT)
                 assert_eq(type(actual), "string")
                 assert_eq(actual, "Definition")
+
+                local f = previewer_labels._make_vim_command_previewer_label(
+                    require("fzfx.line_helpers").parse_vim_keymap,
+                    "Definition"
+                )
+                local actual2 = f(line, CONTEXT)
+                assert_eq(actual, actual2)
             end
         end)
     end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [x] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
