### PR TITLE
feat(preview): add label for file explorer

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -2074,18 +2074,6 @@ local function _make_filename_by_file_explorer_context(line, context)
             constants.has_eza and line_helpers.parse_eza(line)
             or line_helpers.parse_ls(line)
         )
-    if
-        (
-            utils.string_startswith(target, "'")
-            and utils.string_endswith(target, "'")
-        )
-        or (
-            utils.string_startswith(target, '"')
-            and utils.string_endswith(target, '"')
-        )
-    then
-        target = target:sub(2, #target - 1)
-    end
     local p = path.join(cwd, target)
     log.debug(
         "|fzfx.config - make_filename_by_file_explorer_context| cwd:%s, target:%s, p:%s",
@@ -3984,10 +3972,24 @@ local Defaults = {
             filter_hidden = {
                 previewer = _file_explorer_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = constants.has_lsd and require(
+                    "fzfx.previewer_labels"
+                ).lsd_previewer_label or (constants.has_eza and require(
+                    "fzfx.previewer_labels"
+                ).eza_previewer_label or require(
+                    "fzfx.previewer_labels"
+                ).ls_previewer_label),
             },
             include_hidden = {
                 previewer = _file_explorer_previewer,
                 previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+                previewer_label = constants.has_lsd and require(
+                    "fzfx.previewer_labels"
+                ).lsd_previewer_label or (constants.has_eza and require(
+                    "fzfx.previewer_labels"
+                ).eza_previewer_label or require(
+                    "fzfx.previewer_labels"
+                ).ls_previewer_label),
             },
         },
         interactions = {

--- a/lua/fzfx/line_helpers.lua
+++ b/lua/fzfx/line_helpers.lua
@@ -144,7 +144,24 @@ local function _make_parse_ls(start_pos)
             end
             pos = pos + 1
         end
-        return path.normalize(vim.trim(line:sub(pos)), { expand = true })
+        local result =
+            path.normalize(vim.trim(line:sub(pos)), { expand = true })
+
+        -- remove extra single/double quotes
+        if
+            (
+                utils.string_startswith(result, "'")
+                and utils.string_endswith(result, "'")
+            )
+            or (
+                utils.string_startswith(result, '"')
+                and utils.string_endswith(result, '"')
+            )
+        then
+            result = result:sub(2, #result - 1)
+        end
+
+        return result
     end
     return impl
 end

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -115,6 +115,27 @@ local vim_keymap_previewer_label = _make_vim_command_previewer_label(
     "Definition"
 )
 
+--- @param parser fun(line:string):table|string
+--- @return fun(line:string):string?
+local function _make_file_explorer_previewer_label(parser)
+    --- @param line string
+    --- @return string?
+    local function impl(line)
+        if type(line) ~= "string" or string.len(line) == 0 then
+            return ""
+        end
+        return parser(line) --[[@as string]]
+    end
+    return impl
+end
+
+local ls_previewer_label =
+    _make_file_explorer_previewer_label(line_helpers.parse_ls)
+local lsd_previewer_label =
+    _make_file_explorer_previewer_label(line_helpers.parse_lsd)
+local eza_previewer_label =
+    _make_file_explorer_previewer_label(line_helpers.parse_eza)
+
 local M = {
     -- find/buffers/git files
     _make_find_previewer_label = _make_find_previewer_label,
@@ -130,6 +151,12 @@ local M = {
     _make_vim_command_previewer_label = _make_vim_command_previewer_label,
     vim_command_previewer_label = vim_command_previewer_label,
     vim_keymap_previewer_label = vim_keymap_previewer_label,
+
+    -- file explorer
+    _make_file_explorer_previewer_label = _make_file_explorer_previewer_label,
+    ls_previewer_label = ls_previewer_label,
+    lsd_previewer_label = lsd_previewer_label,
+    eza_previewer_label = eza_previewer_label,
 }
 
 return M

--- a/lua/fzfx/previewer_labels.lua
+++ b/lua/fzfx/previewer_labels.lua
@@ -117,7 +117,7 @@ local vim_keymap_previewer_label = _make_vim_command_previewer_label(
 
 --- @param parser fun(line:string):table|string
 --- @return fun(line:string):string?
-local function _make_file_explorer_previewer_label(parser)
+local function _make_ls_previewer_label(parser)
     --- @param line string
     --- @return string?
     local function impl(line)
@@ -129,12 +129,9 @@ local function _make_file_explorer_previewer_label(parser)
     return impl
 end
 
-local ls_previewer_label =
-    _make_file_explorer_previewer_label(line_helpers.parse_ls)
-local lsd_previewer_label =
-    _make_file_explorer_previewer_label(line_helpers.parse_lsd)
-local eza_previewer_label =
-    _make_file_explorer_previewer_label(line_helpers.parse_eza)
+local ls_previewer_label = _make_ls_previewer_label(line_helpers.parse_ls)
+local lsd_previewer_label = _make_ls_previewer_label(line_helpers.parse_lsd)
+local eza_previewer_label = _make_ls_previewer_label(line_helpers.parse_eza)
 
 local M = {
     -- find/buffers/git files
@@ -153,7 +150,7 @@ local M = {
     vim_keymap_previewer_label = vim_keymap_previewer_label,
 
     -- file explorer
-    _make_file_explorer_previewer_label = _make_file_explorer_previewer_label,
+    _make_ls_previewer_label = _make_ls_previewer_label,
     ls_previewer_label = ls_previewer_label,
     lsd_previewer_label = lsd_previewer_label,
     eza_previewer_label = eza_previewer_label,

--- a/test/line_helpers_spec.lua
+++ b/test/line_helpers_spec.lua
@@ -167,7 +167,7 @@ describe("line_helpers", function()
                 "README.md",
                 "deps",
                 "init.vim",
-                "'hello world.txt'",
+                "hello world.txt",
                 "LICENSE",
                 "README.md",
                 "autoload",


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
