### PR TITLE
fix(rpc): release rpc registries after fzf exit

### DIFF
--- a/lua/fzfx/general.lua
+++ b/lua/fzfx/general.lua
@@ -773,6 +773,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         or default_context_maker
 
     local context = context_maker()
+    local rpc_registries = {}
 
     --- @param query_params string
     local function provide_rpc(query_params)
@@ -784,15 +785,15 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         previewer_switch:preview(name, line_params, context)
     end
 
-    local provide_rpc_registry_id =
-        server.get_rpc_server():register(provide_rpc)
-    local preview_rpc_registry_id =
-        server.get_rpc_server():register(preview_rpc)
+    local provide_rpc_id = server.get_rpc_server():register(provide_rpc)
+    local preview_rpc_id = server.get_rpc_server():register(preview_rpc)
+    table.insert(rpc_registries, provide_rpc_id)
+    table.insert(rpc_registries, preview_rpc_id)
 
     local query_command = string.format(
         "%s %s %s %s %s",
         fzf_helpers.make_lua_command("general", "provider.lua"),
-        provide_rpc_registry_id,
+        provide_rpc_id,
         provider_switch.metafile,
         provider_switch.resultfile,
         utils.shellescape(query)
@@ -804,7 +805,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
     local reload_query_command = string.format(
         "%s %s %s %s {q}",
         fzf_helpers.make_lua_command("general", "provider.lua"),
-        provide_rpc_registry_id,
+        provide_rpc_id,
         provider_switch.metafile,
         provider_switch.resultfile
     )
@@ -815,7 +816,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
     local preview_command = string.format(
         "%s %s %s %s {}",
         fzf_helpers.make_lua_command("general", "previewer.lua"),
-        preview_rpc_registry_id,
+        preview_rpc_id,
         previewer_switch.metafile,
         previewer_switch.resultfile
     )
@@ -830,12 +831,13 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         local function preview_label_rpc(line_params)
             previewer_switch:preview_label(name, line_params, context)
         end
-        local preview_label_rpc_registry_id =
+        local preview_label_rpc_id =
             server.get_rpc_server():register(preview_label_rpc)
+        table.insert(rpc_registries, preview_label_rpc_id)
         preview_label_command = string.format(
             "%s %s {}",
             fzf_helpers.make_lua_command("rpc", "notify.lua"),
-            preview_label_rpc_registry_id
+            preview_label_rpc_id
         )
         log.debug(
             "|fzfx.general - general| preview_label_command:%s",
@@ -888,7 +890,6 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         })
     end
 
-    local interaction_rpc_registries = {}
     -- when no interactions, no need to add help
     if type(pipeline_configs.interactions) == "table" then
         for _, interaction_opts in pairs(pipeline_configs.interactions) do
@@ -903,17 +904,14 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
                 action(line_params, context)
             end
 
-            local interaction_rpc_registry_id =
+            local interaction_rpc_id =
                 server.get_rpc_server():register(interaction_rpc)
-            table.insert(
-                interaction_rpc_registries,
-                interaction_rpc_registry_id
-            )
+            table.insert(rpc_registries, interaction_rpc_id)
 
             local action_command = string.format(
                 "%s %s {}",
                 fzf_helpers.make_lua_command("rpc", "request.lua"),
-                interaction_rpc_registry_id
+                interaction_rpc_id
             )
             local bind_builder = string.format(
                 "%s:execute-silent(%s)",
@@ -931,8 +929,6 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         end
     end
 
-    local switch_rpc_registries = {}
-
     -- when only have 1 pipeline, no need to add help for switch keys
     if pipeline_size > 1 then
         for pipeline, provider_opts in pairs(pipeline_configs.providers) do
@@ -943,14 +939,13 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
                 previewer_switch:switch(pipeline)
             end
 
-            local switch_rpc_registry_id =
-                server.get_rpc_server():register(switch_rpc)
-            table.insert(switch_rpc_registries, switch_rpc_registry_id)
+            local switch_rpc_id = server.get_rpc_server():register(switch_rpc)
+            table.insert(rpc_registries, switch_rpc_id)
 
             local switch_command = string.format(
                 "%s %s",
                 fzf_helpers.make_lua_command("rpc", "request.lua"),
-                switch_rpc_registry_id
+                switch_rpc_id
             )
             local bind_builder = string.format(
                 "%s:unbind(%s)+execute-silent(%s)+change-header(%s)+reload(%s)",
@@ -1018,11 +1013,11 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         actions,
         context,
         function()
-            server.get_rpc_server():unregister(provide_rpc_registry_id)
-            server.get_rpc_server():unregister(preview_rpc_registry_id)
-            for _, switch_registry_id in ipairs(switch_rpc_registries) do
-                server.get_rpc_server():unregister(switch_registry_id)
-            end
+            vim.schedule_wrap(function()
+                for _, rpc_id in ipairs(rpc_registries) do
+                    server:get_rpc_server():unregister(rpc_id)
+                end
+            end)
         end
     )
     return p


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
