### PR TITLE
fix(git_commits): fix wrong current buffer checking

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -440,7 +440,7 @@ local function _make_git_commits_provider(opts)
     local function impl(query, context)
         local git_root_cmd = cmd.GitRootCmd:run()
         if git_root_cmd:wrong() then
-            log.echo(LogLevels.INFO, default_invalid_buffer_error)
+            log.echo(LogLevels.INFO, default_git_root_error)
             return nil
         end
         if not utils.is_buf_valid(context.bufnr) then
@@ -513,7 +513,7 @@ end
 local function _git_blame_provider(query, context)
     local git_root_cmd = cmd.GitRootCmd:run()
     if git_root_cmd:wrong() then
-        log.echo(LogLevels.INFO, default_invalid_buffer_error)
+        log.echo(LogLevels.INFO, default_git_root_error)
         return nil
     end
     if not utils.is_buf_valid(context.bufnr) then
@@ -554,7 +554,7 @@ local function _make_git_status_provider(opts)
     local function impl()
         local git_root_cmd = cmd.GitRootCmd:run()
         if git_root_cmd:wrong() then
-            log.echo(LogLevels.INFO, default_invalid_buffer_error)
+            log.echo(LogLevels.INFO, default_git_root_error)
             return nil
         end
         return (type(opts) == "table" and opts.current_folder)

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -443,31 +443,33 @@ local function _make_git_commits_provider(opts)
             log.echo(LogLevels.INFO, default_git_root_error)
             return nil
         end
-        if not utils.is_buf_valid(context.bufnr) then
-            log.echo(
-                LogLevels.INFO,
-                default_invalid_buffer_error,
-                vim.inspect(context.bufnr)
-            )
-            return nil
-        end
-        return (type(opts) == "table" and opts.buffer)
-                and {
-                    "git",
-                    "log",
-                    "--pretty=" .. default_git_log_pretty,
-                    "--date=short",
-                    "--color=always",
-                    "--",
-                    vim.api.nvim_buf_get_name(context.bufnr),
-                }
-            or {
+        if type(opts) == "table" and opts.buffer then
+            if not utils.is_buf_valid(context.bufnr) then
+                log.echo(
+                    LogLevels.INFO,
+                    default_invalid_buffer_error,
+                    vim.inspect(context.bufnr)
+                )
+                return nil
+            end
+            return {
+                "git",
+                "log",
+                "--pretty=" .. default_git_log_pretty,
+                "--date=short",
+                "--color=always",
+                "--",
+                vim.api.nvim_buf_get_name(context.bufnr),
+            }
+        else
+            return {
                 "git",
                 "log",
                 "--pretty=" .. default_git_log_pretty,
                 "--date=short",
                 "--color=always",
             }
+        end
     end
     return impl
 end


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [x] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
