### PR TITLE
perf(preview): fix bad performance previewer label on Windows/Linux

### DIFF
--- a/bin/general/previewer_label.lua
+++ b/bin/general/previewer_label.lua
@@ -1,0 +1,23 @@
+local SELF_PATH = vim.env._FZFX_NVIM_SELF_PATH
+if type(SELF_PATH) ~= "string" or string.len(SELF_PATH) == 0 then
+    io.write(string.format("|previewer_label| error! SELF_PATH is empty!"))
+end
+vim.opt.runtimepath:append(SELF_PATH)
+local shell_helpers = require("fzfx.shell_helpers")
+shell_helpers.setup("previewer_label")
+
+local PIPE_ADDRESS = vim.env._FZFX_NVIM_PIPE_ADDRESS
+shell_helpers.log_ensure(
+    type(PIPE_ADDRESS) == "string" and string.len(PIPE_ADDRESS) > 0,
+    "error! PIPE_ADDRESS must not be empty!"
+)
+local registry_id = _G.arg[1]
+local params = nil
+if #_G.arg >= 2 then
+    params = _G.arg[2]
+end
+shell_helpers.log_debug("PIPE_ADDRESS:%s", vim.inspect(PIPE_ADDRESS))
+shell_helpers.log_debug("registry_id:%s", vim.inspect(registry_id))
+shell_helpers.log_debug("params:%s", vim.inspect(params))
+
+shell_helpers.make_pipe_rpc_notify(registry_id, params)

--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -35,6 +35,7 @@ local function setup(options)
 
     -- rpc server
     require("fzfx.server").setup()
+    require("fzfx.pipe_server").setup()
 
     -- yank history
     require("fzfx.yank_history").setup()

--- a/lua/fzfx/log.lua
+++ b/lua/fzfx/log.lua
@@ -45,7 +45,9 @@ local function echo(level, fmt, ...)
             LogHighlights[level],
         })
     end
-    vim.api.nvim_echo(msg_chunks, false, {})
+    vim.schedule(function()
+        vim.api.nvim_echo(msg_chunks, false, {})
+    end)
 end
 
 --- @type Options

--- a/lua/fzfx/pipe_server.lua
+++ b/lua/fzfx/pipe_server.lua
@@ -190,8 +190,7 @@ local function setup()
                             vim.inspect(registry_id),
                             vim.inspect(cb)
                         )
-                        local result = cb(params) --[[@as string?]]
-                        client_handle:write(result or "")
+                        cb(params) --[[@as string?]]
                         client_handle:read_stop()
                         _close_client_handle(client_handle)
                     end

--- a/lua/fzfx/pipe_server.lua
+++ b/lua/fzfx/pipe_server.lua
@@ -1,0 +1,229 @@
+local constants = require("fzfx.constants")
+local json = require("fzfx.json")
+local log = require("fzfx.log")
+
+--- @return string
+local function _make_uuid()
+    local secs, ms = vim.loop.gettimeofday()
+    return string.format(
+        "%d-%d-%d-%d",
+        vim.loop.os_getpid(),
+        secs,
+        ms,
+        math.random(1, constants.int32_max)
+    )
+end
+
+--- @type integer
+local NextPipeRegistryId = 0
+
+--- @alias PipeRpcRegistryId string
+--- @return PipeRpcRegistryId
+local function _next_registry_id()
+    if NextPipeRegistryId >= constants.int32_max then
+        NextPipeRegistryId = 1
+    else
+        NextPipeRegistryId = NextPipeRegistryId + 1
+    end
+    return string.format("pipe%d", NextPipeRegistryId)
+end
+
+--- @return string
+local function make_pipe_name()
+    if constants.is_windows then
+        return string.format([[\\.\pipe\nvim-pipe-%s]], _make_uuid())
+    else
+        return vim.fn.tempname()
+    end
+end
+
+--- @alias PipeRpcCallback fun(params:any):string?
+--- @type table<PipeRpcRegistryId, PipeRpcCallback>
+local PipeRpcRegistries = {}
+
+--- @param cb PipeRpcCallback
+--- @return PipeRpcRegistryId
+local function register(cb)
+    log.ensure(
+        type(cb) == "function",
+        "|fzfx.pipe_server - register| callback f(%s) must be function! %s",
+        type(cb),
+        vim.inspect(cb)
+    )
+    local registry_id = _next_registry_id()
+    PipeRpcRegistries[registry_id] = cb
+    return registry_id
+end
+
+--- @param registry_id PipeRpcRegistryId
+--- @return PipeRpcCallback
+local function unregister(registry_id)
+    log.ensure(
+        type(registry_id) == "string",
+        "|fzfx.pipe_server - unregister| registry_id(%s) must be string! %s",
+        type(registry_id),
+        vim.inspect(registry_id)
+    )
+    local cb = PipeRpcRegistries[registry_id]
+    log.ensure(
+        type(cb) == "function",
+        "|fzfx.pipe_server - unregister| registered callback(%s) must be function! %s",
+        type(cb),
+        vim.inspect(cb)
+    )
+    PipeRpcRegistries[registry_id] = nil
+    return cb
+end
+
+--- @param registry_id PipeRpcRegistryId
+--- @return PipeRpcCallback
+local function get(registry_id)
+    log.ensure(
+        type(registry_id) == "string",
+        "|fzfx.pipe_server - get| registry_id(%s) must be string! %s",
+        type(registry_id),
+        vim.inspect(registry_id)
+    )
+    local cb = PipeRpcRegistries[registry_id]
+    log.ensure(
+        type(cb) == "function",
+        "|fzfx.server - get| registered callback(%s) must be function! %s",
+        type(cb),
+        vim.inspect(cb)
+    )
+    return cb
+end
+
+--- @param handle uv_pipe_t?
+local function _close_client_handle(handle)
+    if handle and not handle:is_closing() then
+        handle:shutdown()
+        handle:close()
+    end
+end
+
+local function setup()
+    local address = make_pipe_name()
+    log.debug(
+        "|fzfx.pipe_server - setup| make address:%s",
+        vim.inspect(address)
+    )
+
+    local server_handle, new_server_err = vim.loop.new_pipe(false) --[[@as uv_pipe_t]]
+    log.ensure(
+        server_handle ~= nil,
+        "|fzfx.pipe_server - setup| failed to create new server pipe: %s",
+        vim.inspect(new_server_err)
+    )
+    local bind_result, bind_err = server_handle:bind(address)
+    log.ensure(
+        bind_result ~= nil,
+        "|fzfx.pipe_server - setup| failed to bind pipe server on address: %s! error: %s",
+        vim.inspect(address),
+        vim.inspect(bind_err)
+    )
+    local listen_result, listen_err = server_handle:listen(
+        128,
+        function(listen_complete_err)
+            if listen_complete_err then
+                log.throw(
+                    "|fzfx.pipe_server - setup| failed to complete listen on pipe server: %s! error: %s",
+                    vim.inspect(address),
+                    vim.inspect(listen_complete_err)
+                )
+                return
+            end
+
+            local client_handle, new_client_err = vim.loop.new_pipe(false) --[[@as uv_pipe_t]]
+            if client_handle == nil then
+                log.err(
+                    "|fzfx.pipe_server - setup| failed to create new client pipe: %s",
+                    vim.inspect(new_client_err)
+                )
+                return
+            end
+
+            local accept_result, accept_err =
+                server_handle:accept(client_handle)
+            if accept_result == nil then
+                log.err(
+                    "|fzfx.pipe_server - setup| failed to accept new client pipe: %s",
+                    vim.inspect(accept_err)
+                )
+                _close_client_handle(client_handle)
+                return
+            end
+
+            local buffer = nil
+
+            local read_start_result, read_start_err = client_handle:read_start(
+                function(read_err, read_data)
+                    log.debug(
+                        "|fzfx.pipe_server - setup| client pipe read: %s, err: %s",
+                        vim.inspect(read_data),
+                        vim.inspect(read_err)
+                    )
+                    if read_err then
+                        log.err(
+                            "|fzfx.pipe_server - setup| failed to read on client pipe:%s, data:%s",
+                            vim.inspect(read_err),
+                            vim.inspect(read_data)
+                        )
+                        client_handle:read_stop()
+                        _close_client_handle(client_handle)
+                        return
+                    end
+
+                    if read_data then
+                        buffer = buffer and (buffer .. read_data) or read_data
+                        buffer = buffer:gsub("\r\n", "\n")
+                    else
+                        --- @alias RpcParams {["id"]:string,params:string?}
+                        --- @type RpcParams
+                        local obj = json.decode(buffer) --[[@as table]]
+                        local registry_id = obj["id"]
+                        local params = obj["params"]
+                        local cb = get(registry_id)
+                        log.ensure(
+                            type(cb) == "function",
+                            "|fzfx.pipe_server - setup| registered callbacks(%s) must be a function: %s",
+                            vim.inspect(registry_id),
+                            vim.inspect(cb)
+                        )
+                        local result = cb(params) --[[@as string?]]
+                        client_handle:write(result or "")
+                        client_handle:read_stop()
+                        _close_client_handle(client_handle)
+                    end
+                end
+            )
+            if read_start_result == nil then
+                log.err(
+                    "|fzfx.pipe_server - setup| failed to start read new client pipe: %s",
+                    vim.inspect(read_start_err)
+                )
+                _close_client_handle(client_handle)
+            end
+        end
+    )
+    log.ensure(
+        listen_result ~= nil,
+        "|fzfx.pipe_server - setup| failed to listen pipe server on address: %s! error: %s",
+        vim.inspect(address),
+        vim.inspect(listen_err)
+    )
+
+    -- export socket address as environment variable
+    vim.env._FZFX_NVIM_PIPE_ADDRESS = address
+end
+
+local M = {
+    _next_registry_id = _next_registry_id,
+    make_pipe_name = make_pipe_name,
+    setup = setup,
+    register = register,
+    unregister = unregister,
+    get = get,
+}
+
+return M

--- a/lua/fzfx/server.lua
+++ b/lua/fzfx/server.lua
@@ -14,17 +14,17 @@ local function _make_uuid()
 end
 
 --- @type integer
-local NextRegistryIntegerId = 0
+local NextRpcRegistryId = 0
 
 --- @alias RpcRegistryId string
 --- @return RpcRegistryId
 local function _next_registry_id()
-    if NextRegistryIntegerId >= constants.int32_max then
-        NextRegistryIntegerId = 1
+    if NextRpcRegistryId >= constants.int32_max then
+        NextRpcRegistryId = 1
     else
-        NextRegistryIntegerId = NextRegistryIntegerId + 1
+        NextRpcRegistryId = NextRpcRegistryId + 1
     end
-    return tostring(NextRegistryIntegerId)
+    return tostring(NextRpcRegistryId)
 end
 
 --- @return string?
@@ -33,7 +33,7 @@ local function _make_windows_pipe_name()
         constants.is_windows,
         "|fzfx.server - get_windows_pipe_name| must use this function in Windows!"
     )
-    local result = string.format([[\\.\pipe\nvim-pipe-%s]], _make_uuid())
+    local result = string.format([[\\.\pipe\nvim-rpc-%s]], _make_uuid())
     return result
 end
 


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P` variants (visual selection, cursor word, yank text).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-N`/`CTRL-P` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
