### PR TITLE
fix(actions): fix ctrl-c abort error, improve actions error message

### DIFF
--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -33,13 +33,9 @@ local function edit_find(lines, context)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
-            local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+            local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
             if not ok then
-                log.err(
-                    "failed to run command:%s, error:%s",
-                    vim.inspect(edit_command),
-                    vim.inspect(err)
-                )
+                error(vim.inspect(result))
                 return
             end
         end
@@ -99,13 +95,9 @@ local function edit_rg(lines, context)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, edit_command)
-            local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+            local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
             if not ok then
-                log.err(
-                    "failed to run command:%s, error:%s",
-                    vim.inspect(edit_command),
-                    vim.inspect(err)
-                )
+                error(vim.inspect(result))
                 return
             end
         end
@@ -144,13 +136,9 @@ local function edit_grep(lines, context)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, edit_command)
-            local ok, err = pcall(vim.cmd, edit_command)
+            local ok, result = pcall(vim.cmd, edit_command)
             if not ok then
-                log.err(
-                    "failed to run command:%s, error:%s",
-                    vim.inspect(edit_command),
-                    vim.inspect(err)
-                )
+                error(vim.inspect(result))
                 return
             end
         end
@@ -163,13 +151,9 @@ local function edit_ls(lines)
     local edit_commands = _make_edit_find_commands(lines, { no_icon = true })
     for i, edit_command in ipairs(edit_commands) do
         log.debug("|fzfx.actions - edit_ls| [%d]:[%s]", i, edit_command)
-        local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+        local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
         if not ok then
-            log.err(
-                "failed to run command:%s, error:%s",
-                vim.inspect(edit_command),
-                vim.inspect(err)
-            )
+            error(vim.inspect(result))
             return
         end
     end
@@ -252,13 +236,10 @@ end
 --- @param lines string[]
 local function git_checkout(lines)
     local checkout_command = _make_git_checkout_command(lines) --[[@as string]]
-    local ok, err = pcall(vim.cmd --[[@as function]], checkout_command)
-    log.ensure(
-        ok,
-        "failed to run command:%s, error:%s",
-        vim.inspect(checkout_command),
-        vim.inspect(err)
-    )
+    local ok, result = pcall(vim.cmd --[[@as function]], checkout_command)
+    if not ok then
+        error(vim.inspect(result))
+    end
 end
 
 --- @param lines string[]
@@ -463,13 +444,9 @@ local function edit_git_status(lines, context)
                 i,
                 edit_command
             )
-            local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+            local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
             if not ok then
-                log.err(
-                    "failed to run command:%s, error:%s",
-                    vim.inspect(edit_command),
-                    vim.inspect(err)
-                )
+                error(vim.inspect(result))
                 return
             end
         end

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -33,7 +33,15 @@ local function edit_find(lines, context)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
-            vim.cmd(edit_command)
+            local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+            if not ok then
+                log.err(
+                    "failed to run command:%s, error:%s",
+                    vim.inspect(edit_command),
+                    vim.inspect(err)
+                )
+                return
+            end
         end
     end)
 end
@@ -87,11 +95,19 @@ end
 --- @param lines string[]
 --- @param context PipelineContext
 local function edit_rg(lines, context)
-    local vim_commands = _make_edit_rg_commands(lines)
+    local edit_commands = _make_edit_rg_commands(lines)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
-        for i, vim_command in ipairs(vim_commands) do
-            log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, vim_command)
-            vim.cmd(vim_command)
+        for i, edit_command in ipairs(edit_commands) do
+            log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, edit_command)
+            local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+            if not ok then
+                log.err(
+                    "failed to run command:%s, error:%s",
+                    vim.inspect(edit_command),
+                    vim.inspect(err)
+                )
+                return
+            end
         end
     end)
 end
@@ -124,11 +140,19 @@ end
 --- @param lines string[]
 --- @param context PipelineContext
 local function edit_grep(lines, context)
-    local vim_commands = _make_edit_grep_commands(lines)
+    local edit_commands = _make_edit_grep_commands(lines)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
-        for i, vim_command in ipairs(vim_commands) do
-            log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, vim_command)
-            vim.cmd(vim_command)
+        for i, edit_command in ipairs(edit_commands) do
+            log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, edit_command)
+            local ok, err = pcall(vim.cmd, edit_command)
+            if not ok then
+                log.err(
+                    "failed to run command:%s, error:%s",
+                    vim.inspect(edit_command),
+                    vim.inspect(err)
+                )
+                return
+            end
         end
     end)
 end
@@ -139,7 +163,15 @@ local function edit_ls(lines)
     local edit_commands = _make_edit_find_commands(lines, { no_icon = true })
     for i, edit_command in ipairs(edit_commands) do
         log.debug("|fzfx.actions - edit_ls| [%d]:[%s]", i, edit_command)
-        vim.cmd(edit_command)
+        local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+        if not ok then
+            log.err(
+                "failed to run command:%s, error:%s",
+                vim.inspect(edit_command),
+                vim.inspect(err)
+            )
+            return
+        end
     end
 end
 
@@ -220,7 +252,13 @@ end
 --- @param lines string[]
 local function git_checkout(lines)
     local checkout_command = _make_git_checkout_command(lines) --[[@as string]]
-    vim.cmd(checkout_command)
+    local ok, err = pcall(vim.cmd --[[@as function]], checkout_command)
+    log.ensure(
+        ok,
+        "failed to run command:%s, error:%s",
+        vim.inspect(checkout_command),
+        vim.inspect(err)
+    )
 end
 
 --- @param lines string[]
@@ -425,7 +463,15 @@ local function edit_git_status(lines, context)
                 i,
                 edit_command
             )
-            vim.cmd(edit_command)
+            local ok, err = pcall(vim.cmd --[[@as function]], edit_command)
+            if not ok then
+                log.err(
+                    "failed to run command:%s, error:%s",
+                    vim.inspect(edit_command),
+                    vim.inspect(err)
+                )
+                return
+            end
         end
     end)
 end

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -34,10 +34,7 @@ local function edit_find(lines, context)
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_find| [%d]:[%s]", i, edit_command)
             local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
-            if not ok then
-                error(vim.inspect(result))
-                return
-            end
+            assert(ok, vim.inspect(result))
         end
     end)
 end
@@ -96,10 +93,7 @@ local function edit_rg(lines, context)
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_rg| [%d]:[%s]", i, edit_command)
             local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
-            if not ok then
-                error(vim.inspect(result))
-                return
-            end
+            assert(ok, vim.inspect(result))
         end
     end)
 end
@@ -136,11 +130,8 @@ local function edit_grep(lines, context)
     ui.confirm_discard_buffer_modified(context.bufnr, function()
         for i, edit_command in ipairs(edit_commands) do
             log.debug("|fzfx.actions - edit_grep| [%d]:[%s]", i, edit_command)
-            local ok, result = pcall(vim.cmd, edit_command)
-            if not ok then
-                error(vim.inspect(result))
-                return
-            end
+            local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
+            assert(ok, vim.inspect(result))
         end
     end)
 end
@@ -152,10 +143,7 @@ local function edit_ls(lines)
     for i, edit_command in ipairs(edit_commands) do
         log.debug("|fzfx.actions - edit_ls| [%d]:[%s]", i, edit_command)
         local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
-        if not ok then
-            error(vim.inspect(result))
-            return
-        end
+        assert(ok, vim.inspect(result))
     end
 end
 
@@ -185,7 +173,8 @@ local function bdelete(line)
         log.debug("|fzfx.actions - bdelete| bufpath:%s", vim.inspect(bufpath))
         local bufnr = list_bufpaths[bufpath]
         if type(bufnr) == "number" then
-            vim.api.nvim_buf_delete(bufnr, {})
+            local ok, result = vim.api.nvim_buf_delete(bufnr, {})
+            assert(ok, vim.inspect(result))
         end
     end
 end
@@ -237,9 +226,7 @@ end
 local function git_checkout(lines)
     local checkout_command = _make_git_checkout_command(lines) --[[@as string]]
     local ok, result = pcall(vim.cmd --[[@as function]], checkout_command)
-    if not ok then
-        error(vim.inspect(result))
-    end
+    assert(ok, vim.inspect(result))
 end
 
 --- @param lines string[]
@@ -261,7 +248,8 @@ end
 local function yank_git_commit(lines)
     local yank_command = _make_yank_git_commit_command(lines)
     if yank_command then
-        vim.api.nvim_command(yank_command)
+        local ok, result = pcall(vim.api.nvim_command, yank_command)
+        assert(ok, vim.inspect(result))
     end
 end
 
@@ -280,17 +268,12 @@ end
 local function setqflist_find(lines)
     local qflist = _make_setqflist_find_items(lines --[[@as table]])
     local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
-    if not ok then
-        error(result)
-        return
-    end
+    assert(ok, vim.inspect(result))
     ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
-    if not ok then
-        error(result)
-    end
+    assert(ok, vim.inspect(result))
 end
 
 --- @param lines string[]
@@ -313,17 +296,12 @@ end
 local function setqflist_rg(lines)
     local qflist = _make_setqflist_rg_items(lines)
     local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
-    if not ok then
-        error(result)
-        return
-    end
+    assert(ok, vim.inspect(result))
     ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
-    if not ok then
-        error(result)
-    end
+    assert(ok, vim.inspect(result))
 end
 
 --- @param lines string[]
@@ -346,17 +324,12 @@ end
 local function setqflist_grep(lines)
     local qflist = _make_setqflist_grep_items(lines)
     local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
-    if not ok then
-        error(result)
-        return
-    end
+    assert(ok, vim.inspect(result))
     ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
-    if not ok then
-        error(result)
-    end
+    assert(ok, vim.inspect(result))
 end
 
 --- @param lines string[]
@@ -374,17 +347,12 @@ end
 local function setqflist_git_status(lines)
     local qflist = _make_setqflist_git_status_items(lines --[[@as table]])
     local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
-    if not ok then
-        error(result)
-        return
-    end
+    assert(ok, vim.inspect(result))
     ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
-    if not ok then
-        error(result)
-    end
+    assert(ok, vim.inspect(result))
 end
 
 --- @package
@@ -401,9 +369,7 @@ end
 local function feed_vim_command(lines)
     local input, mode = _make_feed_vim_command_params(lines)
     local ok, result = pcall(vim.fn.feedkeys, input, mode)
-    if not ok then
-        error(result)
-    end
+    assert(ok, vim.inspect(result))
 end
 
 --- @package
@@ -441,18 +407,14 @@ local function feed_vim_key(lines)
     local feedtype, input, mode = _make_feed_vim_key_params(lines)
     if feedtype == "cmd" and type(input) == "string" then
         local ok, result = pcall(vim.cmd --[[@as function]], input)
-        if not ok then
-            error(result)
-        end
+        assert(ok, vim.inspect(result))
     elseif
         feedtype == "feedkeys"
         and type(input) == "string"
         and type(mode) == "string"
     then
         local ok, result = pcall(vim.fn.feedkeys, input, mode)
-        if not ok then
-            error(result)
-        end
+        assert(ok, vim.inspect(result))
     end
 end
 
@@ -482,10 +444,7 @@ local function edit_git_status(lines, context)
                 edit_command
             )
             local ok, result = pcall(vim.cmd --[[@as function]], edit_command)
-            if not ok then
-                error(vim.inspect(result))
-                return
-            end
+            assert(ok, vim.inspect(result))
         end
     end)
 end

--- a/lua/fzfx/actions.lua
+++ b/lua/fzfx/actions.lua
@@ -279,11 +279,18 @@ end
 --- @param lines string[]
 local function setqflist_find(lines)
     local qflist = _make_setqflist_find_items(lines --[[@as table]])
-    vim.cmd([[ :copen ]])
-    vim.fn.setqflist({}, " ", {
+    local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
+    if not ok then
+        error(result)
+        return
+    end
+    ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
+    if not ok then
+        error(result)
+    end
 end
 
 --- @param lines string[]
@@ -305,11 +312,18 @@ end
 --- @param lines string[]
 local function setqflist_rg(lines)
     local qflist = _make_setqflist_rg_items(lines)
-    vim.cmd([[ :copen ]])
-    vim.fn.setqflist({}, " ", {
+    local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
+    if not ok then
+        error(result)
+        return
+    end
+    ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
+    if not ok then
+        error(result)
+    end
 end
 
 --- @param lines string[]
@@ -331,11 +345,18 @@ end
 --- @param lines string[]
 local function setqflist_grep(lines)
     local qflist = _make_setqflist_grep_items(lines)
-    vim.cmd([[ :copen ]])
-    vim.fn.setqflist({}, " ", {
+    local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
+    if not ok then
+        error(result)
+        return
+    end
+    ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
+    if not ok then
+        error(result)
+    end
 end
 
 --- @param lines string[]
@@ -352,11 +373,18 @@ end
 --- @param lines string[]
 local function setqflist_git_status(lines)
     local qflist = _make_setqflist_git_status_items(lines --[[@as table]])
-    vim.cmd([[ :copen ]])
-    vim.fn.setqflist({}, " ", {
+    local ok, result = pcall(vim.cmd --[[@as function]], ":copen")
+    if not ok then
+        error(result)
+        return
+    end
+    ok, result = pcall(vim.fn.setqflist, {}, " ", {
         nr = "$",
         items = qflist,
     })
+    if not ok then
+        error(result)
+    end
 end
 
 --- @package
@@ -372,7 +400,10 @@ end
 --- @param lines string[]
 local function feed_vim_command(lines)
     local input, mode = _make_feed_vim_command_params(lines)
-    vim.fn.feedkeys(input, mode)
+    local ok, result = pcall(vim.fn.feedkeys, input, mode)
+    if not ok then
+        error(result)
+    end
 end
 
 --- @package
@@ -409,13 +440,19 @@ end
 local function feed_vim_key(lines)
     local feedtype, input, mode = _make_feed_vim_key_params(lines)
     if feedtype == "cmd" and type(input) == "string" then
-        vim.cmd(input)
+        local ok, result = pcall(vim.cmd --[[@as function]], input)
+        if not ok then
+            error(result)
+        end
     elseif
         feedtype == "feedkeys"
         and type(input) == "string"
         and type(mode) == "string"
     then
-        vim.fn.feedkeys(input, mode)
+        local ok, result = pcall(vim.fn.feedkeys, input, mode)
+        if not ok then
+            error(result)
+        end
     end
 end
 

--- a/lua/fzfx/popup.lua
+++ b/lua/fzfx/popup.lua
@@ -372,7 +372,6 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
             vim.inspect(lines)
         )
         if exitcode == 130 and #lines == 0 then
-            log.echo(LogLevels.INFO, "cancelled.")
             return
         end
         local last_query = vim.trim(lines[1])

--- a/lua/fzfx/popup.lua
+++ b/lua/fzfx/popup.lua
@@ -1,4 +1,5 @@
 local log = require("fzfx.log")
+local LogLevels = require("fzfx.log").LogLevels
 local conf = require("fzfx.config")
 local utils = require("fzfx.utils")
 local fzf_helpers = require("fzfx.fzf_helpers")
@@ -330,17 +331,18 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
     local popup_window = PopupWindow:new(win_opts)
 
     local function on_fzf_exit(jobid2, exitcode, event)
-        -- log.debug(
-        --     "|fzfx.popup - Popup:new.on_fzf_exit| jobid2:%s, exitcode:%s, event:%s",
-        --     vim.inspect(jobid2),
-        --     vim.inspect(exitcode),
-        --     vim.inspect(event)
-        -- )
+        log.debug(
+            "|fzfx.popup - Popup:new| fzf exit, jobid2:%s, exitcode:%s, event:%s",
+            vim.inspect(jobid2),
+            vim.inspect(exitcode),
+            vim.inspect(event)
+        )
         if exitcode > 1 and (exitcode ~= 130 and exitcode ~= 129) then
             log.err(
-                "command '%s' running with exit code %d",
-                fzf_command,
-                exitcode
+                "command '%s' exit with code: %d, event: %s",
+                vim.inspect(fzf_command),
+                vim.inspect(exitcode),
+                vim.inspect(event)
             )
             return
         end
@@ -364,11 +366,15 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
             vim.inspect(result)
         )
         local lines = utils.readlines(result) --[[@as table]]
-        -- log.debug(
-        --     "|fzfx.popup - Popup:new.on_fzf_exit| result:%s, result_lines:%s",
-        --     vim.inspect(result),
-        --     vim.inspect(lines)
-        -- )
+        log.debug(
+            "|fzfx.popup - Popup:new| fzf exit, result:%s, lines:%s",
+            vim.inspect(result),
+            vim.inspect(lines)
+        )
+        if exitcode == 130 and #lines == 0 then
+            log.echo(LogLevels.INFO, "cancelled.")
+            return
+        end
         local last_query = vim.trim(lines[1])
         local action_key = vim.trim(lines[2])
         local action_lines = vim.list_slice(lines, 3)

--- a/lua/fzfx/popup.lua
+++ b/lua/fzfx/popup.lua
@@ -371,7 +371,7 @@ function Popup:new(win_opts, source, fzf_opts, actions, context, on_popup_exit)
             vim.inspect(result),
             vim.inspect(lines)
         )
-        if exitcode == 130 and #lines == 0 then
+        if (exitcode == 130 or exitcode == 129) and #lines == 0 then
             return
         end
         local last_query = vim.trim(lines[1])


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
