### PR TITLE
perf(config): migrate to 'cfg.lsp_definitions'

### DIFF
--- a/lua/fzfx/cfg/_lsp.lua
+++ b/lua/fzfx/cfg/_lsp.lua
@@ -1,0 +1,253 @@
+local consts = require("fzfx.lib.constants")
+local strs = require("fzfx.lib.strings")
+local nvims = require("fzfx.lib.nvims")
+local cmds = require("fzfx.lib.commands")
+local colors = require("fzfx.lib.colors")
+local paths = require("fzfx.lib.paths")
+local fs = require("fzfx.lib.filesystems")
+local tbls = require("fzfx.lib.tables")
+local log = require("fzfx.lib.log")
+local LogLevels = require("fzfx.lib.log").LogLevels
+
+local contexts_helper = require("fzfx.helper.contexts")
+local parsers_helper = require("fzfx.helper.parsers")
+local queries_helper = require("fzfx.helper.queries")
+local actions_helper = require("fzfx.helper.actions")
+local labels_helper = require("fzfx.helper.previewer_labels")
+local providers_helper = require("fzfx.helper.providers")
+local previewers_helper = require("fzfx.helper.previewers")
+
+local ProviderTypeEnum = require("fzfx.schema").ProviderTypeEnum
+local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
+local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
+
+local M = {}
+
+-- simulate rg's filepath color, see:
+-- * https://github.com/BurntSushi/ripgrep/discussions/2605#discussioncomment-6881383
+-- * https://github.com/BurntSushi/ripgrep/blob/d596f6ebd035560ee5706f7c0299c4692f112e54/crates/printer/src/color.rs#L14
+M.LSP_FILENAME_COLOR = consts.IS_WINDOWS and colors.cyan or colors.magenta
+
+--- @alias fzfx.LspRangeStart {line:integer,character:integer}
+--- @alias fzfx.LspRangeEnd {line:integer,character:integer}
+--- @alias fzfx.LspRange {start:fzfx.LspRangeStart,end:fzfx.LspRangeEnd}
+--- @alias fzfx.LspLocation {uri:string,range:fzfx.LspRange}
+--- @alias fzfx.LspLocationLink {originSelectionRange:fzfx.LspRange,targetUri:string,targetRange:fzfx.LspRange,targetSelectionRange:fzfx.LspRange}
+
+--- @param r fzfx.LspRange?
+--- @return boolean
+M._is_lsp_range = function(r)
+  return type(r) == "table"
+    and type(r.start) == "table"
+    and type(r.start.line) == "number"
+    and type(r.start.character) == "number"
+    and type(r["end"]) == "table"
+    and type(r["end"].line) == "number"
+    and type(r["end"].character) == "number"
+end
+
+--- @param loc fzfx.LspLocation|fzfx.LspLocationLink|nil
+M._is_lsp_location = function(loc)
+  return type(loc) == "table"
+    and type(loc.uri) == "string"
+    and M._is_lsp_range(loc.range)
+end
+
+--- @param loc fzfx.LspLocation|fzfx.LspLocationLink|nil
+M._is_lsp_locationlink = function(loc)
+  return type(loc) == "table"
+    and type(loc.targetUri) == "string"
+    and M._is_lsp_range(loc.targetRange)
+end
+
+--- @param line string
+--- @param range fzfx.LspRange
+--- @param color_renderer fun(text:string):string
+--- @return string?
+M._lsp_range_render_line = function(line, range, color_renderer)
+  -- log.debug(
+  --   "|fzfx.config - _lsp_location_render_line| range:%s, line:%s",
+  --   vim.inspect(range),
+  --   vim.inspect(line)
+  -- )
+  local line_start = range.start.character + 1
+  local line_end = range["end"].line ~= range.start.line and #line
+    or math.min(range["end"].character, #line)
+  local p1 = ""
+  if line_start > 1 then
+    p1 = line:sub(1, line_start - 1)
+  end
+  local p2 = ""
+  if line_start <= line_end then
+    p2 = color_renderer(line:sub(line_start, line_end))
+  end
+  local p3 = ""
+  if line_end + 1 <= #line then
+    p3 = line:sub(line_end + 1, #line)
+  end
+  local result = p1 .. p2 .. p3
+  return result
+end
+
+--- @param loc fzfx.LspLocation|fzfx.LspLocationLink
+--- @return string?
+M._render_lsp_location_line = function(loc)
+  log.debug(
+    "|fzfx.config - _render_lsp_location_line| loc:%s",
+    vim.inspect(loc)
+  )
+  local filename = nil
+  --- @type fzfx.LspRange
+  local range = nil
+  if M._is_lsp_location(loc) then
+    filename = paths.reduce(vim.uri_to_fname(loc.uri))
+    range = loc.range
+    log.debug(
+      "|fzfx.config - _render_lsp_location_line| location filename:%s, range:%s",
+      vim.inspect(filename),
+      vim.inspect(range)
+    )
+  elseif M._is_lsp_locationlink(loc) then
+    filename = paths.reduce(vim.uri_to_fname(loc.targetUri))
+    range = loc.targetRange
+    log.debug(
+      "|fzfx.config - _render_lsp_location_line| locationlink filename:%s, range:%s",
+      vim.inspect(filename),
+      vim.inspect(range)
+    )
+  end
+  if not M._is_lsp_range(range) then
+    return nil
+  end
+  if type(filename) ~= "string" or vim.fn.filereadable(filename) <= 0 then
+    return nil
+  end
+  local filelines = fs.readlines(filename)
+  if type(filelines) ~= "table" or #filelines < range.start.line + 1 then
+    return nil
+  end
+  local loc_line =
+    M._lsp_range_render_line(filelines[range.start.line + 1], range, colors.red)
+  log.debug(
+    "|fzfx.config - _render_lsp_location_line| range:%s, loc_line:%s",
+    vim.inspect(range),
+    vim.inspect(loc_line)
+  )
+  local line = string.format(
+    "%s:%s:%s:%s",
+    M.LSP_FILENAME_COLOR(vim.fn.fnamemodify(filename, ":~:.")),
+    colors.green(tostring(range.start.line + 1)),
+    tostring(range.start.character + 1),
+    loc_line
+  )
+  -- log.debug(
+  --   "|fzfx.config - _render_lsp_location_line| line:%s",
+  --   vim.inspect(line)
+  -- )
+  return line
+end
+
+-- lsp methods: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp/protocol.lua#L1028
+-- lsp capabilities: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp.lua#L39
+--
+--- @alias fzfx.LspMethod "textDocument/definition"|"textDocument/type_definition"|"textDocument/references"|"textDocument/implementation"|"callHierarchy/incomingCalls"|"callHierarchy/outgoingCalls"|"textDocument/prepareCallHierarchy"
+--- @alias fzfx.LspServerCapability "definitionProvider"|"typeDefinitionProvider"|"referencesProvider"|"implementationProvider"|"callHierarchyProvider"
+---
+--- @param opts {method:fzfx.LspMethod,capability:fzfx.LspServerCapability,timeout:integer?}
+--- @return fun(query:string,context:fzfx.LspLocationPipelineContext):string[]|nil
+M.make_lsp_locations_provider = function(opts)
+  --- @param query string
+  --- @param context fzfx.LspLocationPipelineContext
+  --- @return string[]|nil
+  local function impl(query, context)
+    local lsp_clients = vim.lsp.get_active_clients({ bufnr = context.bufnr })
+    if tbls.tbl_empty(lsp_clients) then
+      log.echo(LogLevels.INFO, "no active lsp clients.")
+      return nil
+    end
+    -- log.debug(
+    --   "|fzfx.config - make_lsp_locations_provider| lsp_clients:%s",
+    --   vim.inspect(lsp_clients)
+    -- )
+    local supported = false
+    for _, lsp_client in ipairs(lsp_clients) do
+      if lsp_client.server_capabilities[opts.capability] then
+        supported = true
+        break
+      end
+    end
+    if not supported then
+      log.echo(LogLevels.INFO, "%s not supported.", vim.inspect(opts.method))
+      return nil
+    end
+    local response, err = vim.lsp.buf_request_sync(
+      context.bufnr,
+      opts.method,
+      context.position_params,
+      opts.timeout or 3000
+    )
+    -- log.debug(
+    --   "|fzfx.config - make_lsp_locations_provider| opts:%s, lsp_results:%s, lsp_err:%s",
+    --   vim.inspect(opts),
+    --   vim.inspect(response),
+    --   vim.inspect(err)
+    -- )
+    if err then
+      log.echo(LogLevels.ERROR, err)
+      return nil
+    end
+    if tbls.tbl_empty(response) then
+      log.echo(LogLevels.INFO, "no lsp locations found.")
+      return nil
+    end
+
+    local results = {}
+    for client_id, client_response in
+      pairs(response --[[@as table]])
+    do
+      if
+        client_id ~= nil
+        and tbls.tbl_not_empty(tbls.tbl_get(client_response, "result"))
+      then
+        local lsp_loc = client_response.result
+        if M._is_lsp_location(lsp_loc) then
+          local line = M._render_lsp_location_line(lsp_loc)
+          if type(line) == "string" and string.len(line) > 0 then
+            table.insert(results, line)
+          end
+        else
+          for _, loc in ipairs(lsp_loc) do
+            local line = M._render_lsp_location_line(loc)
+            if type(line) == "string" and string.len(line) > 0 then
+              table.insert(results, line)
+            end
+          end
+        end
+      end
+    end
+
+    if tbls.tbl_empty(results) then
+      log.echo(LogLevels.INFO, "no lsp locations found.")
+      return nil
+    end
+
+    return results
+  end
+  return impl
+end
+
+--- @alias fzfx.LspLocationPipelineContext {bufnr:integer,winnr:integer,tabnr:integer,position_params:any}
+--- @return fzfx.LspLocationPipelineContext
+M.lsp_position_context_maker = function()
+  local context = {
+    bufnr = vim.api.nvim_get_current_buf(),
+    winnr = vim.api.nvim_get_current_win(),
+    tabnr = vim.api.nvim_get_current_tabpage(),
+  }
+  context.position_params =
+    vim.lsp.util.make_position_params(context.winnr, nil)
+  context.position_params.context = {
+    includeDeclaration = true,
+  }
+  return context
+end

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -150,7 +150,7 @@ end
 ---
 --- @param opts {method:fzfx.LspMethod,capability:fzfx.LspServerCapability,timeout:integer?}
 --- @return fun(query:string,context:fzfx.LspLocationPipelineContext):string[]|nil
-M.make_lsp_locations_provider = function(opts)
+M._make_lsp_locations_provider = function(opts)
   --- @param query string
   --- @param context fzfx.LspLocationPipelineContext
   --- @return string[]|nil
@@ -161,7 +161,7 @@ M.make_lsp_locations_provider = function(opts)
       return nil
     end
     -- log.debug(
-    --   "|fzfx.config - make_lsp_locations_provider| lsp_clients:%s",
+    --   "|fzfx.config - _make_lsp_locations_provider| lsp_clients:%s",
     --   vim.inspect(lsp_clients)
     -- )
     local supported = false
@@ -182,7 +182,7 @@ M.make_lsp_locations_provider = function(opts)
       opts.timeout or 3000
     )
     -- log.debug(
-    --   "|fzfx.config - make_lsp_locations_provider| opts:%s, lsp_results:%s, lsp_err:%s",
+    --   "|fzfx.config - _make_lsp_locations_provider| opts:%s, lsp_results:%s, lsp_err:%s",
     --   vim.inspect(opts),
     --   vim.inspect(response),
     --   vim.inspect(err)
@@ -233,7 +233,7 @@ end
 
 --- @alias fzfx.LspLocationPipelineContext {bufnr:integer,winnr:integer,tabnr:integer,position_params:any}
 --- @return fzfx.LspLocationPipelineContext
-M.lsp_position_context_maker = function()
+M._lsp_position_context_maker = function()
   local context = {
     bufnr = vim.api.nvim_get_current_buf(),
     winnr = vim.api.nvim_get_current_win(),

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -59,7 +59,7 @@ end
 --- @param range fzfx.LspRange
 --- @param color_renderer fun(text:string):string
 --- @return string?
-M._lsp_range_render_line = function(line, range, color_renderer)
+M._colorize_lsp_range = function(line, range, color_renderer)
   -- log.debug(
   --   "|fzfx.config - _lsp_location_render_line| range:%s, line:%s",
   --   vim.inspect(range),
@@ -122,7 +122,7 @@ M._render_lsp_location_line = function(loc)
     return nil
   end
   local loc_line =
-    M._lsp_range_render_line(filelines[range.start.line + 1], range, colors.red)
+    M._colorize_lsp_range(filelines[range.start.line + 1], range, colors.red)
   log.debug(
     "|fzfx.config - _render_lsp_location_line| range:%s, loc_line:%s",
     vim.inspect(range),

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -23,11 +23,6 @@ local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 
 local M = {}
 
--- simulate rg's filepath color, see:
--- * https://github.com/BurntSushi/ripgrep/discussions/2605#discussioncomment-6881383
--- * https://github.com/BurntSushi/ripgrep/blob/d596f6ebd035560ee5706f7c0299c4692f112e54/crates/printer/src/color.rs#L14
-M.LSP_FILENAME_COLOR = consts.IS_WINDOWS and colors.cyan or colors.magenta
-
 --- @alias fzfx.LspRangeStart {line:integer,character:integer}
 --- @alias fzfx.LspRangeEnd {line:integer,character:integer}
 --- @alias fzfx.LspRange {start:fzfx.LspRangeStart,end:fzfx.LspRangeEnd}
@@ -135,7 +130,7 @@ M._render_lsp_location_line = function(loc)
   )
   local line = string.format(
     "%s:%s:%s:%s",
-    M.LSP_FILENAME_COLOR(vim.fn.fnamemodify(filename, ":~:.")),
+    providers_helper.LSP_FILENAME_COLOR(vim.fn.fnamemodify(filename, ":~:.")),
     colors.green(tostring(range.start.line + 1)),
     tostring(range.start.character + 1),
     loc_line
@@ -251,3 +246,5 @@ M.lsp_position_context_maker = function()
   }
   return context
 end
+
+return M

--- a/lua/fzfx/cfg/lsp_definitions.lua
+++ b/lua/fzfx/cfg/lsp_definitions.lua
@@ -1,0 +1,85 @@
+local consts = require("fzfx.lib.constants")
+local strs = require("fzfx.lib.strings")
+local nvims = require("fzfx.lib.nvims")
+local cmds = require("fzfx.lib.commands")
+local colors = require("fzfx.lib.colors")
+local paths = require("fzfx.lib.paths")
+local fs = require("fzfx.lib.filesystems")
+local tbls = require("fzfx.lib.tables")
+local log = require("fzfx.lib.log")
+local LogLevels = require("fzfx.lib.log").LogLevels
+
+local contexts_helper = require("fzfx.helper.contexts")
+local parsers_helper = require("fzfx.helper.parsers")
+local queries_helper = require("fzfx.helper.queries")
+local actions_helper = require("fzfx.helper.actions")
+local labels_helper = require("fzfx.helper.previewer_labels")
+local providers_helper = require("fzfx.helper.providers")
+local previewers_helper = require("fzfx.helper.previewers")
+
+local ProviderTypeEnum = require("fzfx.schema").ProviderTypeEnum
+local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
+local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
+
+local _lsp_cfg = require("fzfx.cfg._lsp")
+
+local M = {}
+
+M.commands = {
+  name = "FzfxLspDefinitions",
+  feed = CommandFeedEnum.ARGS,
+  opts = {
+    bang = true,
+    desc = "Search lsp definitions",
+  },
+}
+
+M.providers = {
+  key = "default",
+  provider = _lsp_cfg.make_lsp_locations_provider({
+    method = "textDocument/definition",
+    capability = "definitionProvider",
+  }),
+  provider_type = ProviderTypeEnum.LIST,
+  line_opts = {
+    prepend_icon_by_ft = true,
+    prepend_icon_path_delimiter = ":",
+    prepend_icon_path_position = 1,
+  },
+}
+
+M.previewers = {
+  previewer = previewers_helper.preview_files_grep,
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+  previewer_label = labels_helper.label_rg,
+}
+
+M.actions = {
+  ["esc"] = actions_helper.nop,
+  ["enter"] = actions_helper.edit_rg,
+  ["double-click"] = actions_helper.edit_rg,
+}
+
+M.fzf_opts = {
+  consts.FZF_OPTS.MULTI,
+  consts.FZF_OPTS.LSP_PREVIEW_WINDOW,
+  consts.FZF_OPTS.DELIMITER,
+  "--border=none",
+  { "--prompt", "Definitions > " },
+}
+
+M.win_opts = {
+  relative = "cursor",
+  height = 0.45,
+  width = 1,
+  row = 1,
+  col = 0,
+  border = "none",
+  zindex = 51,
+}
+
+M.other_opts = {
+  context_maker = _lsp_cfg.lsp_position_context_maker,
+}
+
+return M

--- a/lua/fzfx/cfg/lsp_definitions.lua
+++ b/lua/fzfx/cfg/lsp_definitions.lua
@@ -36,7 +36,7 @@ M.commands = {
 
 M.providers = {
   key = "default",
-  provider = _lsp_locations.make_lsp_locations_provider({
+  provider = _lsp_locations._make_lsp_locations_provider({
     method = "textDocument/definition",
     capability = "definitionProvider",
   }),
@@ -79,7 +79,7 @@ M.win_opts = {
 }
 
 M.other_opts = {
-  context_maker = _lsp_locations.lsp_position_context_maker,
+  context_maker = _lsp_locations._lsp_position_context_maker,
 }
 
 return M

--- a/lua/fzfx/cfg/lsp_definitions.lua
+++ b/lua/fzfx/cfg/lsp_definitions.lua
@@ -21,7 +21,7 @@ local ProviderTypeEnum = require("fzfx.schema").ProviderTypeEnum
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 
-local _lsp_cfg = require("fzfx.cfg._lsp")
+local _lsp_locations = require("fzfx.cfg._lsp_locations")
 
 local M = {}
 
@@ -36,7 +36,7 @@ M.commands = {
 
 M.providers = {
   key = "default",
-  provider = _lsp_cfg.make_lsp_locations_provider({
+  provider = _lsp_locations.make_lsp_locations_provider({
     method = "textDocument/definition",
     capability = "definitionProvider",
   }),
@@ -79,7 +79,7 @@ M.win_opts = {
 }
 
 M.other_opts = {
-  context_maker = _lsp_cfg.lsp_position_context_maker,
+  context_maker = _lsp_locations.lsp_position_context_maker,
 }
 
 return M

--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -20,8 +20,6 @@ local ProviderTypeEnum = require("fzfx.schema").ProviderTypeEnum
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 
-local _lsp_cfg = require("fzfx.cfg._lsp")
-
 local M = {}
 
 M.commands = {
@@ -272,7 +270,7 @@ M._make_lsp_diagnostics_provider = function(opts)
         )
         local line = string.format(
           "%s:%s:%s:%s",
-          _lsp_cfg.LSP_FILENAME_COLOR(diag.filename),
+          providers_helper.LSP_FILENAME_COLOR(diag.filename),
           colors.green(tostring(diag.lnum)),
           tostring(diag.col),
           builder

--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -20,6 +20,8 @@ local ProviderTypeEnum = require("fzfx.schema").ProviderTypeEnum
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 
+local _lsp_cfg = require("fzfx.cfg._lsp")
+
 local M = {}
 
 M.commands = {
@@ -176,12 +178,6 @@ local LSP_DIAGNOSTICS_SIGNS = {
   },
 }
 
--- simulate rg's filepath color, see:
--- * https://github.com/BurntSushi/ripgrep/discussions/2605#discussioncomment-6881383
--- * https://github.com/BurntSushi/ripgrep/blob/d596f6ebd035560ee5706f7c0299c4692f112e54/crates/printer/src/color.rs#L14
-local LSP_DIAGNOSTICS_FILENAME_COLOR = consts.IS_WINDOWS and colors.cyan
-  or colors.magenta
-
 --- @return {severity:integer,name:string,text:string,texthl:string,textcolor:string}[]
 M._make_lsp_diagnostic_signs = function()
   local results = {}
@@ -276,7 +272,7 @@ M._make_lsp_diagnostics_provider = function(opts)
         )
         local line = string.format(
           "%s:%s:%s:%s",
-          LSP_DIAGNOSTICS_FILENAME_COLOR(diag.filename),
+          _lsp_cfg.LSP_FILENAME_COLOR(diag.filename),
           colors.green(tostring(diag.lnum)),
           tostring(diag.col),
           builder

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -2328,99 +2328,72 @@ end
 --- @type fzfx.Options
 local Defaults = {
   -- the 'Files' commands
+  --
+  --- @type fzfx.GroupConfig
   files = require("fzfx.cfg.files"),
 
   -- the 'Live Grep' commands
+  --
+  --- @type fzfx.GroupConfig
   live_grep = require("fzfx.cfg.live_grep"),
 
   -- the 'Buffers' commands
+  --
+  --- @type fzfx.GroupConfig
   buffers = require("fzfx.cfg.buffers"),
 
   -- the 'Git Files' commands
+  --
+  --- @type fzfx.GroupConfig
   git_files = require("fzfx.cfg.git_files"),
 
   -- the 'Git Live Grep' commands
+  --
+  --- @type fzfx.GroupConfig
   git_live_grep = require("fzfx.cfg.git_live_grep"),
 
   -- the 'Git Status' commands
+  --
+  --- @type fzfx.GroupConfig
   git_status = require("fzfx.cfg.git_status"),
 
   -- the 'Git Branches' commands
+  --
+  --- @type fzfx.GroupConfig
   git_branches = require("fzfx.cfg.git_branches"),
 
   -- the 'Git Commits' commands
+  --
+  --- @type fzfx.GroupConfig
   git_commits = require("fzfx.cfg.git_commits"),
 
   -- the 'Git Blame' command
+  --
+  --- @type fzfx.GroupConfig
   git_blame = require("fzfx.cfg.git_blame"),
 
   -- the 'Vim Commands' commands
+  --
+  --- @type fzfx.GroupConfig
   vim_commands = require("fzfx.cfg.vim_commands"),
 
   -- the 'Vim KeyMaps' commands
+  --
   --- @type fzfx.GroupConfig
   vim_keymaps = require("fzfx.cfg.vim_keymaps"),
 
   -- the 'Lsp Diagnostics' command
+  --
   --- @type fzfx.GroupConfig
   lsp_diagnostics = require("fzfx.cfg.lsp_diagnostics"),
 
   -- the 'Lsp Definitions' command
+  --
   --- @type fzfx.GroupConfig
-  lsp_definitions = {
-    commands = {
-      name = "FzfxLspDefinitions",
-      feed = CommandFeedEnum.ARGS,
-      opts = {
-        bang = true,
-        desc = "Search lsp definitions",
-      },
-    },
-    providers = {
-      key = "default",
-      provider = _make_lsp_locations_provider({
-        method = "textDocument/definition",
-        capability = "definitionProvider",
-      }),
-      provider_type = ProviderTypeEnum.LIST,
-      line_opts = {
-        prepend_icon_by_ft = true,
-        prepend_icon_path_delimiter = ":",
-        prepend_icon_path_position = 1,
-      },
-    },
-    previewers = {
-      previewer = _file_previewer_grep,
-      previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-      previewer_label = labels_helper.label_rg,
-    },
-    actions = {
-      ["esc"] = actions_helper.nop,
-      ["enter"] = actions_helper.edit_rg,
-      ["double-click"] = actions_helper.edit_rg,
-    },
-    fzf_opts = {
-      default_fzf_options.multi,
-      default_fzf_options.lsp_preview_window,
-      "--border=none",
-      { "--delimiter", ":" },
-      { "--prompt", "Definitions > " },
-    },
-    win_opts = {
-      relative = "cursor",
-      height = 0.45,
-      width = 1,
-      row = 1,
-      col = 0,
-      border = "none",
-      zindex = 51,
-    },
-    other_opts = {
-      context_maker = _lsp_position_context_maker,
-    },
-  },
+  lsp_definitions = require("fzfx.cfg.lsp_definitions"),
 
   -- the 'Lsp Type Definitions' command
+  --
   --- @type fzfx.GroupConfig
   lsp_type_definitions = {
     commands = {

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -760,12 +760,6 @@ end
 
 -- lsp locations {
 
---- @alias fzfx.LspRangeStart {line:integer,character:integer}
---- @alias fzfx.LspRangeEnd {line:integer,character:integer}
---- @alias fzfx.LspRange {start:fzfx.LspRangeStart,end:fzfx.LspRangeEnd}
---- @alias fzfx.LspLocation {uri:string,range:fzfx.LspRange}
---- @alias fzfx.LspLocationLink {originSelectionRange:fzfx.LspRange,targetUri:string,targetRange:fzfx.LspRange,targetSelectionRange:fzfx.LspRange}
-
 --- @param r fzfx.LspRange?
 --- @return boolean
 local function _is_lsp_range(r)
@@ -821,7 +815,6 @@ local function _lsp_range_render_line(line, range, color_renderer)
   return result
 end
 
---- @alias fzfx.LspLocationPipelineContext {bufnr:integer,winnr:integer,tabnr:integer,position_params:any}
 --- @return fzfx.LspLocationPipelineContext
 local function _lsp_position_context_maker()
   local context = {
@@ -898,10 +891,7 @@ end
 local default_no_lsp_locations_error = "no lsp locations found."
 
 -- lsp methods: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp/protocol.lua#L1028
---- @alias fzfx.LspMethod "textDocument/definition"|"textDocument/type_definition"|"textDocument/references"|"textDocument/implementation"|"callHierarchy/incomingCalls"|"callHierarchy/outgoingCalls"|"textDocument/prepareCallHierarchy"
----
 -- lsp capabilities: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp.lua#L39
---- @alias fzfx.LspServerCapability "definitionProvider"|"typeDefinitionProvider"|"referencesProvider"|"implementationProvider"|"callHierarchyProvider"
 ---
 --- @param opts {method:fzfx.LspMethod,capability:fzfx.LspServerCapability,timeout:integer?}
 --- @return fun(query:string,context:fzfx.LspLocationPipelineContext):string[]|nil

--- a/lua/fzfx/helper/providers.lua
+++ b/lua/fzfx/helper/providers.lua
@@ -125,4 +125,13 @@ M.UNRESTRICTED_GREP = {
 
 -- live grep }
 
+-- lsp {
+
+-- simulate rg's filepath color, see:
+-- * https://github.com/BurntSushi/ripgrep/discussions/2605#discussioncomment-6881383
+-- * https://github.com/BurntSushi/ripgrep/blob/d596f6ebd035560ee5706f7c0299c4692f112e54/crates/printer/src/color.rs#L14
+M.LSP_FILENAME_COLOR = consts.IS_WINDOWS and colors.cyan or colors.magenta
+
+-- lsp }
+
 return M

--- a/test/cfg/_lsp_locations_spec.lua
+++ b/test/cfg/_lsp_locations_spec.lua
@@ -1,0 +1,124 @@
+---@diagnostic disable: undefined-field, unused-local, missing-fields, need-check-nil, param-type-mismatch, assign-type-mismatch
+local cwd = vim.fn.getcwd()
+
+describe("cfg._lsp_locations", function()
+  local assert_eq = assert.is_equal
+  local assert_true = assert.is_true
+  local assert_false = assert.is_false
+
+  before_each(function()
+    vim.api.nvim_command("cd " .. cwd)
+    vim.o.swapfile = false
+    vim.cmd([[edit README.md]])
+  end)
+
+  local github_actions = os.getenv("GITHUB_ACTIONS") == "true"
+
+  local tbls = require("fzfx.lib.tables")
+  local consts = require("fzfx.lib.constants")
+  local strs = require("fzfx.lib.strings")
+  local paths = require("fzfx.lib.paths")
+  local colors = require("fzfx.lib.colors")
+
+  local contexts = require("fzfx.helper.contexts")
+  local providers = require("fzfx.helper.providers")
+  local fzf_helpers = require("fzfx.detail.fzf_helpers")
+
+  local _lsp_locations = require("fzfx.cfg._lsp_locations")
+
+  describe("_lsp_locations", function()
+    local RANGE = {
+      start = { line = 1, character = 10 },
+      ["end"] = { line = 10, character = 31 },
+    }
+    local LOCATION = {
+      uri = "file:///usr/home/github/linrongbin16/fzfx.nvim",
+      range = RANGE,
+    }
+    local LOCATIONLINK = {
+      targetUri = "file:///usr/home/github/linrongbin16/fzfx.nvim",
+      targetRange = RANGE,
+    }
+    it("_is_lsp_range", function()
+      assert_false(_lsp_locations._is_lsp_range(nil))
+      assert_false(_lsp_locations._is_lsp_range({}))
+      assert_true(_lsp_locations._is_lsp_range(RANGE))
+    end)
+    it("_is_lsp_location", function()
+      assert_false(_lsp_locations._is_lsp_location("asdf"))
+      assert_false(_lsp_locations._is_lsp_location({}))
+      assert_true(_lsp_locations._is_lsp_location(LOCATION))
+    end)
+    it("_is_lsp_locationlink", function()
+      assert_false(_lsp_locations._is_lsp_locationlink("hello"))
+      assert_false(_lsp_locations._is_lsp_locationlink({}))
+      assert_true(_lsp_locations._is_lsp_locationlink(LOCATIONLINK))
+    end)
+    it("_lsp_location_render_line", function()
+      local r = {
+        start = { line = 1, character = 20 },
+        ["end"] = { line = 1, character = 26 },
+      }
+      local loc = _lsp_locations._lsp_location_render_line(
+        'describe("_lsp_location_render_line", function()',
+        r,
+        colors.red
+      )
+      -- print(string.format("lsp render line:%s\n", vim.inspect(loc)))
+      assert_eq(type(loc), "string")
+      assert_true(strs.startswith(loc, "describe"))
+      assert_true(strs.endswith(loc, "function()"))
+    end)
+    it("renders location", function()
+      local actual = _lsp_locations._render_lsp_location_line(LOCATION)
+      -- print(
+      --     string.format("render lsp location:%s\n", vim.inspect(actual))
+      -- )
+      assert_true(actual == nil or type(actual) == "string")
+    end)
+    it("renders locationlink", function()
+      local actual = _lsp_locations._render_lsp_location_line(LOCATIONLINK)
+      -- print(
+      --     string.format(
+      --         "render lsp locationlink:%s\n",
+      --         vim.inspect(actual)
+      --     )
+      -- )
+      assert_true(actual == nil or type(actual) == "string")
+    end)
+    it("_lsp_position_context_maker", function()
+      local ctx = _lsp_locations._lsp_position_context_maker()
+      -- print(string.format("lsp position context:%s\n", vim.inspect(ctx)))
+      assert_true(ctx.bufnr > 0)
+      assert_true(ctx.winnr > 0)
+      assert_true(ctx.tabnr > 0)
+      assert_eq(type(ctx.position_params), "table")
+      assert_eq(type(ctx.position_params.context), "table")
+      assert_eq(type(ctx.position_params.position), "table")
+      assert_true(ctx.position_params.position.character >= 0)
+      assert_true(ctx.position_params.position.line >= 0)
+      assert_eq(type(ctx.position_params.textDocument), "table")
+      assert_eq(type(ctx.position_params.textDocument.uri), "string")
+      assert_true(
+        strs.endswith(ctx.position_params.textDocument.uri, "README.md")
+      )
+    end)
+    it("_make_lsp_locations_provider", function()
+      local ctx = _lsp_locations._lsp_position_context_maker()
+      local f = _lsp_locations._make_lsp_locations_provider({
+        method = "textDocument/definition",
+        capability = "definitionProvider",
+      })
+      assert_eq(type(f), "function")
+      local actual = f("", ctx)
+      if actual ~= nil then
+        assert_eq(type(actual), "table")
+        assert_true(#actual >= 0)
+        for _, act in ipairs(actual) do
+          assert_eq(type(act), "string")
+          assert_true(string.len(act) > 0)
+        end
+      end
+    end)
+  end)
+end)

--- a/test/cfg/_lsp_locations_spec.lua
+++ b/test/cfg/_lsp_locations_spec.lua
@@ -54,12 +54,12 @@ describe("cfg._lsp_locations", function()
       assert_false(_lsp_locations._is_lsp_locationlink({}))
       assert_true(_lsp_locations._is_lsp_locationlink(LOCATIONLINK))
     end)
-    it("_lsp_location_render_line", function()
+    it("_colorize_lsp_range", function()
       local r = {
         start = { line = 1, character = 20 },
         ["end"] = { line = 1, character = 26 },
       }
-      local loc = _lsp_locations._lsp_location_render_line(
+      local loc = _lsp_locations._colorize_lsp_range(
         'describe("_lsp_location_render_line", function()',
         r,
         colors.red


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
