### PR TITLE
feat(provider decorator): add lua module based provider decorator

### DIFF
--- a/bin/general/provider.lua
+++ b/bin/general/provider.lua
@@ -72,7 +72,7 @@ local function println(line)
         metaopts.prepend_icon_path_position
       )
       io.write(string.format("%s\n", rendered_line))
-    elseif tbls.tbl_not_empty(metaopts.provider_decorator) then
+    elseif metaopts.provider_decorator ~= nil then
       if strs.not_empty(tbls.tbl_get(metaopts.provider_decorator, "rtp")) then
         vim.opt.runtimepath:append(
           tbls.tbl_get(metaopts.provider_decorator, "rtp")
@@ -89,30 +89,21 @@ local function println(line)
             and metaopts.provider_decorator
           or metaopts.provider_decorator.module
         local ok, module_or_err = pcall(require, decorator_module)
-        -- shell_helpers.log_debug(
-        --   "decorator:%s, module:%s",
-        --   vim.inspect(decorator_module),
-        --   vim.inspect(module_or_err)
-        -- )
-        if ok then
-          if type(tbls.tbl_get(module_or_err, "decorate")) == "function" then
-            local rendered_ok, rendered_line =
-              pcall(module_or_err.decorate, line)
-            if rendered_ok then
-              io.write(string.format("%s\n", rendered_line))
-            end
-          else
-            shell_helpers.log_err(
-              "failed to invoke 'decorate' function in module:%s, module:%s",
-              vim.inspect(metaopts.provider_decorator),
-              vim.inspect(module_or_err)
-            )
-          end
+        shell_helpers.log_ensure(
+          ok and tbls.tbl_not_empty(module_or_err),
+          "failed to load decorator:%s, error:%s",
+          vim.inspect(metaopts.provider_decorator),
+          vim.inspect(module_or_err)
+        )
+        local rendered_ok, rendered_line_or_err =
+          pcall(module_or_err.decorate, line)
+        if rendered_ok then
+          io.write(string.format("%s\n", rendered_line_or_err))
         else
           shell_helpers.log_err(
-            "failed to load decorator:%s, error:%s",
-            vim.inspect(metaopts.provider_decorator),
-            vim.inspect(module_or_err)
+            "failed to render line with decorator:%s, error:%s",
+            vim.inspect(decorator_module),
+            vim.inspect(rendered_line_or_err)
           )
         end
       end)

--- a/bin/general/provider.lua
+++ b/bin/general/provider.lua
@@ -72,6 +72,34 @@ local function println(line)
         metaopts.prepend_icon_path_position
       )
       io.write(string.format("%s\n", rendered_line))
+    elseif tbls.tbl_not_empty(metaopts.provider_decorator) then
+      if strs.not_empty(metaopts.provider_decorator.rtp) then
+        vim.opt.runtimepath:append(metaopts.provider_decorator.rtp)
+      end
+      shell_helpers.log_ensure(
+        strs.not_empty(metaopts.provider_decorator.module),
+        "decorator module cannot be empty: %s",
+        vim.inspect(metaopts.provider_decorator)
+      )
+      local ok, module_or_err =
+        pcall(require, metaopts.provider_decorator.module)
+      if ok then
+        if type(tbls.tbl_get(module_or_err, "decorate")) == "function" then
+          local rendered_line = pcall(module_or_err.decorate, line)
+        else
+          shell_helpers.log_err(
+            "failed to invoke 'decorate' function in module:%s, module:%s",
+            vim.inspect(metaopts.provider_decorator),
+            vim.inspect(module_or_err)
+          )
+        end
+      else
+        shell_helpers.log_err(
+          "failed to load decorator:%s, error:%s",
+          vim.inspect(metaopts.provider_decorator),
+          vim.inspect(module_or_err)
+        )
+      end
     else
       io.write(string.format("%s\n", line))
     end

--- a/lua/fzfx/cfg/files.lua
+++ b/lua/fzfx/cfg/files.lua
@@ -135,12 +135,14 @@ M.providers = {
   restricted_mode = {
     key = "ctrl-r",
     provider = restricted_provider,
-    line_opts = { prepend_icon_by_ft = true },
+    -- line_opts = { prepend_icon_by_ft = true },
+    provider_decorator = { "fzfx.helper.provider_decorators.prepend_icon_find" },
   },
   unrestricted_mode = {
     key = "ctrl-u",
     provider = unrestricted_provider,
-    line_opts = { prepend_icon_by_ft = true },
+    -- line_opts = { prepend_icon_by_ft = true },
+    provider_decorator = { "fzfx.helper.provider_decorators.prepend_icon_find" },
   },
 }
 

--- a/lua/fzfx/cfg/files.lua
+++ b/lua/fzfx/cfg/files.lua
@@ -135,18 +135,12 @@ M.providers = {
   restricted_mode = {
     key = "ctrl-r",
     provider = restricted_provider,
-    -- line_opts = { prepend_icon_by_ft = true },
-    provider_decorator = {
-      module = "fzfx.helper.provider_decorators.prepend_icon_find",
-    },
+    provider_decorator = "fzfx.helper.provider_decorators.prepend_icon_find",
   },
   unrestricted_mode = {
     key = "ctrl-u",
     provider = unrestricted_provider,
-    -- line_opts = { prepend_icon_by_ft = true },
-    provider_decorator = {
-      module = "fzfx.helper.provider_decorators.prepend_icon_find",
-    },
+    provider_decorator = "fzfx.helper.provider_decorators.prepend_icon_find",
   },
 }
 

--- a/lua/fzfx/cfg/files.lua
+++ b/lua/fzfx/cfg/files.lua
@@ -136,13 +136,17 @@ M.providers = {
     key = "ctrl-r",
     provider = restricted_provider,
     -- line_opts = { prepend_icon_by_ft = true },
-    provider_decorator = { "fzfx.helper.provider_decorators.prepend_icon_find" },
+    provider_decorator = {
+      module = "fzfx.helper.provider_decorators.prepend_icon_find",
+    },
   },
   unrestricted_mode = {
     key = "ctrl-u",
     provider = unrestricted_provider,
     -- line_opts = { prepend_icon_by_ft = true },
-    provider_decorator = { "fzfx.helper.provider_decorators.prepend_icon_find" },
+    provider_decorator = {
+      module = "fzfx.helper.provider_decorators.prepend_icon_find",
+    },
   },
 }
 

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -95,10 +95,7 @@ local function make_provider_meta_opts(pipeline, provider_config)
   end
 
   -- provider_decorator
-  if
-    tbls.tbl_get(provider_config, "provider_decorator")
-    and tbls.tbl_not_empty(provider_config.provider_decorator)
-  then
+  if tbls.tbl_get(provider_config, "provider_decorator") then
     o.provider_decorator = provider_config.provider_decorator
   end
 

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -60,9 +60,10 @@ end
 --- @class fzfx.ProviderMetaOpts
 --- @field pipeline fzfx.PipelineName
 --- @field provider_type fzfx.ProviderType
---- @field prepend_icon_by_ft boolean?
---- @field prepend_icon_path_delimiter string?
---- @field prepend_icon_path_position integer?
+--- @field prepend_icon_by_ft boolean?  -- deprecated
+--- @field prepend_icon_path_delimiter string?  -- deprecated
+--- @field prepend_icon_path_position integer?  -- deprecated
+--- @field provider_decorator fzfx.ProviderDecorator?
 
 --- @param pipeline string
 --- @param provider_config fzfx.ProviderConfig
@@ -74,30 +75,31 @@ local function make_provider_meta_opts(pipeline, provider_config)
   }
 
   -- prepend_icon_by_ft
-  if
-    type(provider_config.line_opts) == "table"
-    and type(provider_config.line_opts.prepend_icon_by_ft) == "boolean"
-  then
+  if tbls.tbl_get(provider_config, "line_opts.prepend_icon_by_ft") then
     o.prepend_icon_by_ft = provider_config.line_opts.prepend_icon_by_ft
   end
 
   -- prepend_icon_path_delimiter
   if
-    type(provider_config.line_opts) == "table"
-    and type(provider_config.line_opts.prepend_icon_path_delimiter) == "string"
-    and string.len(provider_config.line_opts.prepend_icon_path_delimiter) > 0
+    tbls.tbl_get(provider_config, "line_opts.prepend_icon_path_delimiter")
+    and strs.not_empty(provider_config.line_opts.prepend_icon_path_delimiter)
   then
     o.prepend_icon_path_delimiter =
       provider_config.line_opts.prepend_icon_path_delimiter
   end
 
   -- prepend_icon_path_position
-  if
-    type(provider_config.line_opts) == "table"
-    and type(provider_config.line_opts.prepend_icon_path_position) == "number"
-  then
+  if tbls.tbl_get(provider_config, "line_opts.prepend_icon_path_position") then
     o.prepend_icon_path_position =
       provider_config.line_opts.prepend_icon_path_position
+  end
+
+  -- provider_decorator
+  if
+    tbls.tbl_get(provider_config, "provider_decorator")
+    and tbls.tbl_not_empty(provider_config.provider_decorator)
+  then
+    o.provider_decorator = provider_config.provider_decorator
   end
 
   return o

--- a/lua/fzfx/helper/provider_decorators.lua
+++ b/lua/fzfx/helper/provider_decorators.lua
@@ -22,3 +22,9 @@ local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 
 local M = {}
+
+M.prepend_icon_find = function() end
+
+M.prepend_icon_grep = function() end
+
+return M

--- a/lua/fzfx/helper/provider_decorators/_prepend_icon.lua
+++ b/lua/fzfx/helper/provider_decorators/_prepend_icon.lua
@@ -1,0 +1,58 @@
+local colors = require("fzfx.lib.colors")
+local strs = require("fzfx.lib.strings")
+
+local DEVICONS_OK = nil
+local DEVICONS = nil
+if strs.not_empty(vim.env._FZFX_NVIM_DEVICONS_PATH) then
+  vim.opt.runtimepath:append(vim.env._FZFX_NVIM_DEVICONS_PATH)
+  DEVICONS_OK, DEVICONS = pcall(require, "nvim-web-devicons")
+end
+
+local M = {}
+
+--- @param line string
+--- @param delimiter string?
+--- @param index integer?
+--- @return string
+M._decorate = function(line, delimiter, index)
+  if not DEVICONS_OK or DEVICONS == nil then
+    return line
+  end
+
+  local filename = nil
+  if strs.not_empty(delimiter) and type(index) == "number" then
+    local splits = strs.split(line, delimiter --[[@as string]])
+    filename = splits[index]
+  else
+    filename = line
+  end
+  -- remove ansi color codes
+  -- see: https://stackoverflow.com/a/55324681/4438921
+  if strs.not_empty(filename) then
+    filename = colors.erase(filename)
+  end
+  local ext = vim.fn.fnamemodify(filename, ":e")
+  local icon, icon_color = DEVICONS.get_icon_color(filename, ext)
+  -- log_debug(
+  --     "|fzfx.shell_helpers - render_line_with_icon| ext:%s, icon:%s, icon_color:%s",
+  --     vim.inspect(ext),
+  --     vim.inspect(icon),
+  --     vim.inspect(icon_color)
+  -- )
+  if strs.not_empty(icon) then
+    local fmt = colors.csi(icon_color, true)
+    if fmt then
+      return string.format("[%sm%s[0m %s", fmt, icon, line)
+    else
+      return string.format("%s %s", icon, line)
+    end
+  else
+    if vim.fn.isdirectory(filename) > 0 then
+      return string.format("%s %s", vim.env._FZFX_NVIM_FILE_FOLDER_ICON, line)
+    else
+      return string.format("%s %s", vim.env._FZFX_NVIM_UNKNOWN_FILE_ICON, line)
+    end
+  end
+end
+
+return M

--- a/lua/fzfx/helper/provider_decorators/prepend_icon_find.lua
+++ b/lua/fzfx/helper/provider_decorators/prepend_icon_find.lua
@@ -1,0 +1,11 @@
+local _prepend_icon = require("fzfx.helper.provider_decorators._prepend_icon")
+
+local M = {}
+
+--- @param line string
+--- @return string
+M.decorate = function(line)
+  return _prepend_icon._decorate(line)
+end
+
+return M

--- a/lua/fzfx/helper/provider_decorators/prepend_icon_grep.lua
+++ b/lua/fzfx/helper/provider_decorators/prepend_icon_grep.lua
@@ -1,0 +1,11 @@
+local _prepend_icon = require("fzfx.helper.provider_decorators._prepend_icon")
+
+local M = {}
+
+--- @param line string
+--- @return string
+M.decorate = function(line)
+  return _prepend_icon._decorate(line, ":", 1)
+end
+
+return M

--- a/lua/fzfx/lib/log.lua
+++ b/lua/fzfx/lib/log.lua
@@ -48,7 +48,9 @@ M.echo = function(level, fmt, ...)
       LogHighlights[level],
     })
   end
-  vim.api.nvim_echo(msg_chunks, false, {})
+  vim.schedule(function()
+    vim.api.nvim_echo(msg_chunks, false, {})
+  end)
 end
 
 --- @type fzfx.Options

--- a/lua/fzfx/lib/tables.lua
+++ b/lua/fzfx/lib/tables.lua
@@ -15,7 +15,7 @@ end
 -- retrieve value from table like json field indexing via dot `.` delimiter.
 -- for example when parameter `t = { a = { b = 1 } }` and `field = 'a.b'`, it will return `1`.
 --
---- @param t table?
+--- @param t any?
 --- @param field string
 --- @return any
 M.tbl_get = function(t, field)

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -31,7 +31,7 @@ local ProviderTypeEnum = {
 -- ========== Provider Decorator ==========
 --
 --- @alias fzfx._FunctionProviderDecorator fun(line:string?,context:fzfx.PipelineContext?):string?
---- @alias fzfx.ProviderDecorator {module:string,rtp:string?}
+--- @alias fzfx.ProviderDecorator string|{module:string,rtp:string?}
 --
 -- Note: the 1st parameter `line` (in `fzfx._FunctionProviderDecorator`) is the raw generated line from providers.
 -- Note: the `module` must returns the lua table contains the lua function named `decorate`, the `rtp` is optional (since fzfx itself is already been added into environment).

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -28,6 +28,15 @@ local ProviderTypeEnum = {
 -- Note: the 1st parameter 'query' is the user input query in fzf prompt.
 --
 --
+-- ========== Provider Decorator ==========
+--
+--- @alias fzfx._FunctionProviderDecorator fun(line:string?,context:fzfx.PipelineContext?):string?
+--- @alias fzfx.ProviderDecorator {module:string,rtp:string?}
+--
+-- Note: the 1st parameter `line` (in `fzfx._FunctionProviderDecorator`) is the raw generated line from providers.
+-- Note: the `module` must returns the lua table contains the lua function named `decorate`, the `rtp` is optional (since fzfx itself is already been added into environment).
+--
+--
 -- ========== Previewer ==========
 --
 --- @alias fzfx.CommandPreviewer fun(line:string?,context:fzfx.PipelineContext?):string?
@@ -102,6 +111,7 @@ local CommandFeedEnum = {
 --
 -- ========== Config ==========
 --
+--- @deprecated
 --- @class fzfx.ProviderConfigLineOpts
 --- @field prepend_icon_by_ft boolean?
 --- @field prepend_icon_path_delimiter string? -- working with `prepend_icon_by_ft=true`
@@ -111,7 +121,8 @@ local CommandFeedEnum = {
 --- @field key fzfx.ActionKey
 --- @field provider fzfx.Provider
 --- @field provider_type fzfx.ProviderType? by default "plain"
---- @field line_opts fzfx.ProviderConfigLineOpts?
+--- @field line_opts fzfx.ProviderConfigLineOpts?  -- deprecated
+--- @field provider_decorator fzfx.ProviderDecorator?
 
 --- @class fzfx.PreviewerConfig
 --- @field previewer fzfx.Previewer


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
