### PR TITLE
perf(config): migrate to provider decorators

### DIFF
--- a/bin/general/provider.lua
+++ b/bin/general/provider.lua
@@ -77,9 +77,6 @@ if metaopts.provider_decorator ~= nil then
     vim.inspect(metaopts.provider_decorator)
   )
   local module_name = metaopts.provider_decorator.module
-  if metaopts.provider_decorator.builtin then
-    module_name = "fzfx.helper.provider_decorators." .. module_name
-  end
   local ok, module_or_err = pcall(require, module_name)
   shell_helpers.log_ensure(
     ok and tbls.tbl_not_empty(module_or_err),

--- a/lua/fzfx/cfg/buffers.lua
+++ b/lua/fzfx/cfg/buffers.lua
@@ -114,7 +114,7 @@ M.providers = {
   key = "default",
   provider = M._buffers_provider,
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = { prepend_icon_by_ft = true },
+  provider_decorator = { module = "prepend_icon_find", builtin = true },
 }
 
 M.previewers = {

--- a/lua/fzfx/cfg/git_files.lua
+++ b/lua/fzfx/cfg/git_files.lua
@@ -151,13 +151,13 @@ M.providers = {
     key = "ctrl-u",
     provider = current_folder_provider,
     provider_type = ProviderTypeEnum.COMMAND_LIST,
-    line_opts = { prepend_icon_by_ft = true },
+    provider_decorator = { module = "prepend_icon_find", builtin = true },
   },
   workspace = {
     key = "ctrl-w",
     provider = workspace_provider,
     provider_type = ProviderTypeEnum.COMMAND_LIST,
-    line_opts = { prepend_icon_by_ft = true },
+    provider_decorator = { module = "prepend_icon_find", builtin = true },
   },
 }
 

--- a/lua/fzfx/cfg/git_live_grep.lua
+++ b/lua/fzfx/cfg/git_live_grep.lua
@@ -103,11 +103,7 @@ M.providers = {
   key = "default",
   provider = M._git_live_grep_provider,
   provider_type = ProviderTypeEnum.COMMAND_LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.previewers = {

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -297,31 +297,19 @@ M.providers = {
     key = "ctrl-r",
     provider = restricted_provider,
     provider_type = ProviderTypeEnum.COMMAND_LIST,
-    line_opts = {
-      prepend_icon_by_ft = true,
-      prepend_icon_path_delimiter = ":",
-      prepend_icon_path_position = 1,
-    },
+    provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
   unrestricted_mode = {
     key = "ctrl-u",
     provider = unrestricted_provider,
     provider_type = ProviderTypeEnum.COMMAND_LIST,
-    line_opts = {
-      prepend_icon_by_ft = true,
-      prepend_icon_path_delimiter = ":",
-      prepend_icon_path_position = 1,
-    },
+    provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
   buffer_mode = {
     key = "ctrl-o",
     provider = buffer_provider,
     provider_type = ProviderTypeEnum.COMMAND_LIST,
-    line_opts = {
-      prepend_icon_by_ft = true,
-      prepend_icon_path_delimiter = ":",
-      prepend_icon_path_position = 1,
-    },
+    provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
 }
 

--- a/lua/fzfx/cfg/lsp_definitions.lua
+++ b/lua/fzfx/cfg/lsp_definitions.lua
@@ -41,11 +41,7 @@ M.providers = {
     capability = "definitionProvider",
   }),
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.fzf_opts = {

--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -288,21 +288,13 @@ M.providers = {
     key = "ctrl-w",
     provider = M._make_lsp_diagnostics_provider(),
     provider_type = ProviderTypeEnum.LIST,
-    line_opts = {
-      prepend_icon_by_ft = true,
-      prepend_icon_path_delimiter = ":",
-      prepend_icon_path_position = 1,
-    },
+    provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
   buffer_diagnostics = {
     key = "ctrl-u",
     provider = M._make_lsp_diagnostics_provider({ buffer = true }),
     provider_type = ProviderTypeEnum.LIST,
-    line_opts = {
-      prepend_icon_by_ft = true,
-      prepend_icon_path_delimiter = ":",
-      prepend_icon_path_position = 1,
-    },
+    provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
 }
 

--- a/lua/fzfx/cfg/lsp_implementations.lua
+++ b/lua/fzfx/cfg/lsp_implementations.lua
@@ -40,11 +40,7 @@ M.providers = {
     capability = "implementationProvider",
   }),
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.previewers = _lsp_locations.previewers

--- a/lua/fzfx/cfg/lsp_incoming_calls.lua
+++ b/lua/fzfx/cfg/lsp_incoming_calls.lua
@@ -40,11 +40,7 @@ M.providers = {
     capability = "callHierarchyProvider",
   }),
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.fzf_opts = {

--- a/lua/fzfx/cfg/lsp_outgoing_calls.lua
+++ b/lua/fzfx/cfg/lsp_outgoing_calls.lua
@@ -40,11 +40,7 @@ M.providers = {
     capability = "callHierarchyProvider",
   }),
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.previewers = _lsp_locations.previewers

--- a/lua/fzfx/cfg/lsp_references.lua
+++ b/lua/fzfx/cfg/lsp_references.lua
@@ -40,11 +40,7 @@ M.providers = {
     capability = "referencesProvider",
   }),
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.fzf_opts = {

--- a/lua/fzfx/cfg/lsp_type_definitions.lua
+++ b/lua/fzfx/cfg/lsp_type_definitions.lua
@@ -40,11 +40,7 @@ M.providers = {
     capability = "typeDefinitionProvider",
   }),
   provider_type = ProviderTypeEnum.LIST,
-  line_opts = {
-    prepend_icon_by_ft = true,
-    prepend_icon_path_delimiter = ":",
-    prepend_icon_path_position = 1,
-  },
+  provider_decorator = { module = "prepend_icon_grep", builtin = true },
 }
 
 M.fzf_opts = {

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -97,9 +97,9 @@ local function make_provider_meta_opts(pipeline, provider_config)
   -- provider_decorator
   if tbls.tbl_get(provider_config, "provider_decorator") then
     o.provider_decorator = vim.deepcopy(provider_config.provider_decorator)
-    if provider_config.provider_decorator.builtin then
+    if o.provider_decorator.builtin then
       o.provider_decorator.module = "fzfx.helper.provider_decorators."
-        .. provider_config.provider_decorator.module
+        .. o.provider_decorator.module
     end
   end
 

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -96,7 +96,11 @@ local function make_provider_meta_opts(pipeline, provider_config)
 
   -- provider_decorator
   if tbls.tbl_get(provider_config, "provider_decorator") then
-    o.provider_decorator = provider_config.provider_decorator
+    o.provider_decorator = vim.deepcopy(provider_config.provider_decorator)
+    if provider_config.provider_decorator.builtin then
+      o.provider_decorator.module = "fzfx.helper.provider_decorators."
+        .. provider_config.provider_decorator.module
+    end
   end
 
   return o

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -31,7 +31,7 @@ local ProviderTypeEnum = {
 -- ========== Provider Decorator ==========
 --
 --- @alias fzfx._FunctionProviderDecorator fun(line:string?):string?
---- @alias fzfx.ProviderDecorator string|{module:string,rtp:string?,builtin:boolean?}
+--- @alias fzfx.ProviderDecorator {module:string,rtp:string?,builtin:boolean?}
 --
 -- Note: in `fzfx._FunctionProviderDecorator`, the 1st parameter `line` is the raw generated line from providers.
 --


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [x] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [x] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [x] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
