### PR TITLE
perf(configs): support 'win_opts' as lua function

### DIFF
--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -304,6 +304,16 @@ local Configs = {}
 --- @return fzfx.Options
 M.setup = function(opts)
   Configs = vim.tbl_deep_extend("force", Defaults, opts or {})
+
+  -- support 'popup.win_opts' is lua function
+  if type(Configs.popup.win_opts) == "function" then
+    Configs.popup.win_opts = vim.tbl_deep_extend(
+      "force",
+      vim.deepcopy(Defaults.popup.win_opts),
+      Configs.popup.win_opts()
+    )
+  end
+
   return Configs
 end
 

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -1006,11 +1006,15 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
   fzf_opts = fzf_helpers.preprocess_fzf_opts(fzf_opts)
   local actions = pipeline_configs.actions
   local win_opts = nil
-  if not tables.tbl_empty(pipeline_configs.win_opts) then
+  if pipeline_configs.win_opts ~= nil then
+    local pipeline_win_opts = pipeline_configs.win_opts
+    if type(pipeline_win_opts) == "function" then
+      pipeline_win_opts = pipeline_win_opts()
+    end
     win_opts = vim.tbl_deep_extend(
       "force",
       vim.deepcopy(win_opts or {}),
-      pipeline_configs.win_opts
+      pipeline_win_opts
     )
   end
   if bang then

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -998,18 +998,34 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
   end
   table.insert(fzf_opts, fzf_start_binder:build())
 
+  -- fzf_opts
   fzf_opts = vim.list_extend(fzf_opts, vim.deepcopy(pipeline_configs.fzf_opts))
   fzf_opts = vim.list_extend(
     fzf_opts,
     vim.deepcopy(conf.get_config().override_fzf_opts or {})
   )
   fzf_opts = fzf_helpers.preprocess_fzf_opts(fzf_opts)
+
+  -- actions
   local actions = pipeline_configs.actions
+
+  -- win_opts
   local win_opts = nil
+  local cfg_win_opts = tables.tbl_get(conf.get_config(), "popup", "win_opts")
+  if cfg_win_opts ~= nil then
+    if type(cfg_win_opts) == "function" then
+      win_opts = cfg_win_opts()
+    elseif type(cfg_win_opts) == "table" then
+      win_opts = cfg_win_opts
+    end
+  end
+
   if pipeline_configs.win_opts ~= nil then
-    local pipeline_win_opts = pipeline_configs.win_opts
-    if type(pipeline_win_opts) == "function" then
-      pipeline_win_opts = pipeline_win_opts()
+    local pipeline_win_opts = nil
+    if type(pipeline_configs.win_opts) == "function" then
+      pipeline_win_opts = pipeline_configs.win_opts()
+    elseif type(pipeline_configs.win_opts) == "table" then
+      pipeline_win_opts = pipeline_configs.win_opts
     end
     win_opts = vim.tbl_deep_extend(
       "force",
@@ -1024,6 +1040,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
       { height = 1, width = 1, row = 0, col = 0 }
     )
   end
+
   local p = Popup:new(
     win_opts or {},
     query_command,

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -1010,16 +1010,7 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
   local actions = pipeline_configs.actions
 
   -- win_opts
-  local win_opts = nil
-  local cfg_win_opts = tables.tbl_get(conf.get_config(), "popup", "win_opts")
-  if cfg_win_opts ~= nil then
-    if type(cfg_win_opts) == "function" then
-      win_opts = cfg_win_opts()
-    elseif type(cfg_win_opts) == "table" then
-      win_opts = cfg_win_opts
-    end
-  end
-
+  local win_opts = tables.tbl_get(conf.get_config(), "popup", "win_opts")
   if pipeline_configs.win_opts ~= nil then
     local pipeline_win_opts = nil
     if type(pipeline_configs.win_opts) == "function" then

--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -1,12 +1,10 @@
-local constants = require("fzfx.lib.constants")
 local numbers = require("fzfx.commons.numbers")
 local apis = require("fzfx.commons.apis")
 local fileios = require("fzfx.commons.fileios")
+
+local constants = require("fzfx.lib.constants")
 local log = require("fzfx.lib.log")
-
 local fzf_helpers = require("fzfx.detail.fzf_helpers")
-
-local conf = require("fzfx.config")
 
 -- WindowOptsContext {
 

--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -287,7 +287,7 @@ function PopupWindow:new(win_opts)
   apis.set_buf_option(bufnr, "buflisted", false)
   apis.set_buf_option(bufnr, "filetype", "fzf")
 
-  local popup_window_config = _make_window_config(win_opts)
+  local popup_window_config = _make_window_config(win_opts or {})
 
   --- @type integer
   local winnr = vim.api.nvim_open_win(bufnr, true, popup_window_config)

--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -271,7 +271,7 @@ local PopupWindowInstances = {}
 local PopupWindow = {}
 
 --- @package
---- @param win_opts fzfx.Options?
+--- @param win_opts fzfx.Options
 --- @return fzfx.PopupWindow
 function PopupWindow:new(win_opts)
   -- check executable: nvim, fzf
@@ -289,12 +289,7 @@ function PopupWindow:new(win_opts)
   apis.set_buf_option(bufnr, "buflisted", false)
   apis.set_buf_option(bufnr, "filetype", "fzf")
 
-  local merged_win_opts = vim.tbl_deep_extend(
-    "force",
-    vim.deepcopy(conf.get_config().popup.win_opts),
-    vim.deepcopy(win_opts or {})
-  )
-  local popup_window_config = _make_window_config(merged_win_opts)
+  local popup_window_config = _make_window_config(win_opts)
 
   --- @type integer
   local winnr = vim.api.nvim_open_win(bufnr, true, popup_window_config)
@@ -311,7 +306,7 @@ function PopupWindow:new(win_opts)
     window_opts_context = window_opts_context,
     bufnr = bufnr,
     winnr = winnr,
-    _saved_win_opts = merged_win_opts,
+    _saved_win_opts = win_opts,
     _resizing = false,
   }
   setmetatable(o, self)
@@ -414,7 +409,7 @@ local function _make_fzf_command(fzf_opts, actions, result)
 end
 
 --- @alias fzfx.OnPopupExit fun(last_query:string):nil
---- @param win_opts fzfx.Options?
+--- @param win_opts fzfx.Options
 --- @param source string
 --- @param fzf_opts fzfx.Options
 --- @param actions fzfx.Options

--- a/test/detail/popup_spec.lua
+++ b/test/detail/popup_spec.lua
@@ -18,8 +18,16 @@ describe("detail.popup", function()
   local strings = require("fzfx.commons.strings")
   local fzf_helpers = require("fzfx.detail.fzf_helpers")
   local popup = require("fzfx.detail.popup")
-
   require("fzfx.config").setup()
+
+  local WIN_OPTS = {
+    height = 0.85,
+    width = 0.85,
+    row = 0,
+    col = 0,
+    border = "none",
+    zindex = 51,
+  }
 
   describe("[_make_window_size]", function()
     it("is in range of [0, 1]", function()
@@ -66,14 +74,6 @@ describe("detail.popup", function()
     end)
   end)
   describe("[_make_cursor_window_config]", function()
-    local WIN_OPTS = {
-      height = 0.85,
-      width = 0.85,
-      row = 0,
-      col = 0,
-      border = "none",
-      zindex = 51,
-    }
     it("makes cursor config", function()
       local actual = popup._make_cursor_window_config(WIN_OPTS)
       print(string.format("make cursor config:%s\n", vim.inspect(actual)))
@@ -95,14 +95,6 @@ describe("detail.popup", function()
     end)
   end)
   describe("[_make_center_window_config]", function()
-    local WIN_OPTS = {
-      height = 0.85,
-      width = 0.85,
-      row = 0,
-      col = 0,
-      border = "none",
-      zindex = 51,
-    }
     it("makes center config", function()
       local actual = popup._make_center_window_config(WIN_OPTS)
       print(string.format("make center config:%s\n", vim.inspect(actual)))
@@ -132,14 +124,6 @@ describe("detail.popup", function()
     end)
   end)
   describe("[_make_window_config]", function()
-    local WIN_OPTS = {
-      height = 0.85,
-      width = 0.85,
-      row = 0,
-      col = 0,
-      border = "none",
-      zindex = 51,
-    }
     it("makes center config", function()
       local actual1 = popup._make_window_config(WIN_OPTS)
       local actual2 = popup._make_center_window_config(WIN_OPTS)
@@ -166,7 +150,7 @@ describe("detail.popup", function()
       popup._remove_all_popup_window_instances()
       assert_eq(type(popup._get_all_popup_window_instances()), "table")
       assert_true(tables.tbl_empty(popup._get_all_popup_window_instances()))
-      local pw = popup.PopupWindow:new()
+      local pw = popup.PopupWindow:new(WIN_OPTS)
       assert_eq(type(popup._get_all_popup_window_instances()), "table")
       assert_false(tables.tbl_empty(popup._get_all_popup_window_instances()))
       local instances = popup._get_all_popup_window_instances()
@@ -186,12 +170,12 @@ describe("detail.popup", function()
       assert_eq(type(popup._get_all_popup_window_instances()), "table")
       assert_true(tables.tbl_empty(popup._get_all_popup_window_instances()))
       assert_eq(popup._count_all_popup_window_instances(), 0)
-      local pw = popup.PopupWindow:new()
+      local pw = popup.PopupWindow:new(WIN_OPTS)
       assert_eq(popup._count_all_popup_window_instances(), 1)
       pw:close()
       assert_eq(popup._count_all_popup_window_instances(), 0)
-      local pw1 = popup.PopupWindow:new()
-      local pw2 = popup.PopupWindow:new()
+      local pw1 = popup.PopupWindow:new(WIN_OPTS)
+      local pw2 = popup.PopupWindow:new(WIN_OPTS)
       assert_eq(popup._count_all_popup_window_instances(), 2)
       pw1:close()
       pw2:close()
@@ -200,7 +184,7 @@ describe("detail.popup", function()
   end)
   describe("[PopupWindow]", function()
     it("creates new", function()
-      local pw = popup.PopupWindow:new()
+      local pw = popup.PopupWindow:new(WIN_OPTS)
       assert_eq(type(pw), "table")
       assert_eq(type(pw.window_opts_context), "table")
       assert_eq(type(pw.window_opts_context.bufnr), "number")
@@ -218,7 +202,7 @@ describe("detail.popup", function()
       assert_false(pw._resizing)
     end)
     it("resize", function()
-      local pw = popup.PopupWindow:new()
+      local pw = popup.PopupWindow:new(WIN_OPTS)
       pw:resize()
     end)
   end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
