### PR TITLE
fix(colors): fix static fzf color & icon opts

### DIFF
--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -34,6 +34,7 @@ local function setup(opts)
   require("fzfx.detail.yanks").setup()
   require("fzfx.detail.popup").setup()
   require("fzfx.detail.bat_helpers").setup()
+  require("fzfx.detail.fzf_helpers").setup()
   require("fzfx.helper.colorschemes").setup()
 
   local general = require("fzfx.detail.general")

--- a/lua/fzfx/config.lua
+++ b/lua/fzfx/config.lua
@@ -110,7 +110,7 @@ local Defaults = {
   -- the 'Users' commands
   users = nil,
 
-  -- FZF_DEFAULT_OPTS
+  -- basic fzf opts
   fzf_opts = {
     "--ansi",
     "--info=inline",

--- a/lua/fzfx/detail/fzf_helpers.lua
+++ b/lua/fzfx/detail/fzf_helpers.lua
@@ -670,7 +670,10 @@ local FZF_PREVIEW_ACTIONS = {
 local function setup()
   vim.api.nvim_create_autocmd({ "ColorScheme" }, {
     callback = function(event)
-      update_fzf_default_opts()
+      log.debug("|setup| ColorScheme event:%s", vim.inspect(event))
+      vim.schedule(function()
+        update_fzf_default_opts()
+      end)
     end,
   })
 end

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -28,7 +28,7 @@ local DEFAULT_PIPELINE = "default"
 --- @return string
 local function _make_cache_filename(...)
   if env.debug_enabled() then
-    return paths.join(config.get().cache.dir, table.concat({ ... }, "_"))
+    return paths.join(env.cache_dir(), table.concat({ ... }, "_"))
   else
     return vim.fn.tempname() --[[@as string]]
   end

--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -266,7 +266,8 @@ function Popup:new(
   -- save fzf/shell context
   local saved_shell_opts_context = popup_helpers.ShellOptsContext:save()
   local saved_fzf_default_command = vim.env.FZF_DEFAULT_COMMAND
-  vim.env.FZF_DEFAULT_OPTS = ""
+  local saved_fzf_default_opts = vim.env.FZF_DEFAULT_OPTS
+  vim.env.FZF_DEFAULT_OPTS = fzf_helpers.make_fzf_default_opts()
   vim.env.FZF_DEFAULT_COMMAND = source
 
   log.debug(
@@ -285,6 +286,7 @@ function Popup:new(
   -- restore fzf/shell context
   saved_shell_opts_context:restore()
   vim.env.FZF_DEFAULT_COMMAND = saved_fzf_default_command
+  vim.env.FZF_DEFAULT_OPTS = saved_fzf_default_opts
 
   vim.cmd([[ startinsert ]])
 

--- a/spec/detail/fzf_helpers_spec.lua
+++ b/spec/detail/fzf_helpers_spec.lua
@@ -229,7 +229,7 @@ describe("detail.fzf_helpers", function()
       print(string.format("make default opts: %s\n", vim.inspect(actual)))
       assert_eq(type(actual), "string")
       assert_true(string.len(actual --[[@as string]]) > 0)
-      assert_true(strings.find(actual, "--border") > 0)
+      assert_true(strings.find(actual, "color") > 0)
     end)
   end)
 


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
