### PR TITLE
perf(buffer previewer): improve buffer previewer performance

### DIFF
--- a/lua/fzfx/detail/fzf_helpers.lua
+++ b/lua/fzfx/detail/fzf_helpers.lua
@@ -583,7 +583,7 @@ local function parse_fzf_preview_window_opts(opts)
     "failed to split preview window opts into list: %s",
     vim.inspect(split_opts)
   )
-  log.debug("|parse_fzf_preview_window_opts| split_opts:%s", vim.inspect(split_opts))
+  -- log.debug("|parse_fzf_preview_window_opts| split_opts:%s", vim.inspect(split_opts))
 
   local opts_alternative_layout = nil
   local opts_no_alternative_layout = {}
@@ -617,7 +617,7 @@ local function parse_fzf_preview_window_opts(opts)
       _spilt_fzf_preview_window_opts(split_alternatives)
     )
   end
-  log.debug("|parse_fzf_preview_window_opts| result:%s", vim.inspect(result))
+  -- log.debug("|parse_fzf_preview_window_opts| result:%s", vim.inspect(result))
   return result
 end
 
@@ -639,7 +639,7 @@ local FZF_PREVIEW_ACTIONS = {
 local function setup()
   vim.api.nvim_create_autocmd({ "ColorScheme" }, {
     callback = function(event)
-      log.debug("|setup| ColorScheme event:%s", vim.inspect(event))
+      -- log.debug("|setup| ColorScheme event:%s", vim.inspect(event))
       vim.schedule(function()
         update_fzf_default_opts()
       end)

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -797,19 +797,19 @@ local function mock_buffer_previewer_fzf_opts(fzf_opts, fzf_action_file)
           if type(split_pos) == "number" and split_pos > 1 then
             split_o = {}
             local o1 = strings.trim(string.sub(o --[[@as string]], 1, split_pos - 1))
-            log.debug(
-              "|general - use_buffer_previewer| o:%s, split_pos:%s, o1:%s",
-              vim.inspect(o),
-              vim.inspect(split_pos),
-              vim.inspect(o1)
-            )
+            -- log.debug(
+            --   "|general - use_buffer_previewer| o:%s, split_pos:%s, o1:%s",
+            --   vim.inspect(o),
+            --   vim.inspect(split_pos),
+            --   vim.inspect(o1)
+            -- )
             local o2 = strings.trim(string.sub(o --[[@as string]], split_pos + 1))
-            log.debug(
-              "|general - use_buffer_previewer| o:%s, split_pos:%s, o2:%s",
-              vim.inspect(o),
-              vim.inspect(split_pos),
-              vim.inspect(o2)
-            )
+            -- log.debug(
+            --   "|general - use_buffer_previewer| o:%s, split_pos:%s, o2:%s",
+            --   vim.inspect(o),
+            --   vim.inspect(split_pos),
+            --   vim.inspect(o2)
+            -- )
             table.insert(split_o, o1)
             table.insert(split_o, o2)
           end
@@ -1057,13 +1057,13 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
       buffer_previewer_actions_file,
       {},
       function(actions_fsevent_start_complete_err, actions_file, events)
-        log.debug(
-          "|general - buffer_previewer_actions_fsevent:start| complete actions fsevent, actions_file:%s, events:%s, actions_file:%s, error:%s",
-          vim.inspect(actions_file),
-          vim.inspect(events),
-          vim.inspect(buffer_previewer_actions_file),
-          vim.inspect(actions_fsevent_start_complete_err)
-        )
+        -- log.debug(
+        --   "|general - buffer_previewer_actions_fsevent:start| complete actions fsevent, actions_file:%s, events:%s, actions_file:%s, error:%s",
+        --   vim.inspect(actions_file),
+        --   vim.inspect(events),
+        --   vim.inspect(buffer_previewer_actions_file),
+        --   vim.inspect(actions_fsevent_start_complete_err)
+        -- )
         if actions_fsevent_start_complete_err then
           log.err(
             "|general - buffer_previewer_actions_fsevent:start| failed to trigger fsevent on actions_file %s, error:%s",
@@ -1080,11 +1080,11 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
         end
 
         fileios.asyncreadfile(buffer_previewer_actions_file, function(actions_data)
-          log.debug(
-            "|general - buffer_previewer_actions_fsevent:start| complete read actions_file:%s, data:%s",
-            vim.inspect(actions_file),
-            vim.inspect(actions_data)
-          )
+          -- log.debug(
+          --   "|general - buffer_previewer_actions_fsevent:start| complete read actions_file:%s, data:%s",
+          --   vim.inspect(actions_file),
+          --   vim.inspect(actions_data)
+          -- )
           if not popup or not popup:provider_is_valid() then
             return
           end

--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -253,9 +253,9 @@ function Popup:new(
   vim.env.FZF_DEFAULT_OPTS = fzf_helpers.make_fzf_default_opts()
   vim.env.FZF_DEFAULT_COMMAND = source
 
-  log.debug("|Popup:new| $FZF_DEFAULT_OPTS:%s", vim.inspect(vim.env.FZF_DEFAULT_OPTS))
-  log.debug("|Popup:new| $FZF_DEFAULT_COMMAND:%s", vim.inspect(vim.env.FZF_DEFAULT_COMMAND))
-  log.debug("|Popup:new| fzf_command:%s", vim.inspect(fzf_command))
+  -- log.debug("|Popup:new| $FZF_DEFAULT_OPTS:%s", vim.inspect(vim.env.FZF_DEFAULT_OPTS))
+  -- log.debug("|Popup:new| $FZF_DEFAULT_COMMAND:%s", vim.inspect(vim.env.FZF_DEFAULT_COMMAND))
+  -- log.debug("|Popup:new| fzf_command:%s", vim.inspect(fzf_command))
 
   -- launch
   local jobid = vim.fn.termopen(fzf_command, { on_exit = on_fzf_exit }) --[[@as integer ]]

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -576,7 +576,7 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
         contents = contents:gsub("\r\n", "\n")
       end
       table.insert(self.preview_file_contents_queue, {
-        contents = contents,
+        contents = strings.split(contents, "\n"),
         job_id = last_job.job_id,
         previewer_result = last_job.previewer_result,
         previewer_label_result = last_job.previewer_label_result,
@@ -606,7 +606,7 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
   end, 20)
 end
 
---- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string,job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
+--- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
 --- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob?
 --- @param first_line integer?
 --- @param last_line integer?
@@ -642,7 +642,7 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
       end
 
       local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
-      local LINES = strings.split(last_content.contents, "\n")
+      local LINES = last_content.contents
       local LINES_COUNT = #LINES
       local FIRST_LINE = last_content.previewer_result.lineno or 1
       local LAST_LINE = math.min(WIN_HEIGHT + 5 + FIRST_LINE, LINES_COUNT)
@@ -850,8 +850,12 @@ function BufferPopupWindow:scroll_by(percent, up)
     end)
   end
 
+  local first_lineno = vim.fn.line("w0")
+  local last_lineno = vim.fn.line("w$")
+
   local base_lineno = up and vim.fn.line("w0", self.previewer_winnr)
     or vim.fn.line("w$", self.previewer_winnr)
+
   if base_lineno == 1 and up then
     before_exit()
     return

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -860,7 +860,13 @@ function BufferPopupWindow:show_preview()
   -- restore last file preview contents
   vim.schedule(function()
     if tables.tbl_not_empty(self._saved_previewing_file_content_job) then
-      self:preview_file_contents(self._saved_previewing_file_content_job)
+      local last_content = self._saved_previewing_file_content_job
+      self._saved_previewing_file_content_context = { render_index = nil }
+      self:preview_file_contents(
+        last_content,
+        last_content.previewer_result.lineno or 1,
+        last_content.previewer_result.lineno or 1
+      )
     end
   end)
 end

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -870,15 +870,17 @@ function BufferPopupWindow:scroll_by(percent, up)
   local target_base_lineno = numbers.bound(base_lineno + shift_lines, 1, LINES_COUNT)
 
   log.debug(
-    "|scroll_by| percent:%s, up:%s, LINES_COUNT:%s, win_height:%s, first/last/base:%s/%s/%s, shift_lines:%s, target_lineno:%s",
+    "|scroll_by| percent:%s, up:%s, LINES_COUNT:%s, win_height:%s, shift_lines:%s, first/last/base:%s/%s/%s, target first/last/base:%s",
     vim.inspect(percent),
     vim.inspect(up),
     vim.inspect(LINES_COUNT),
     vim.inspect(win_height),
+    vim.inspect(shift_lines),
     vim.inspect(first_lineno),
     vim.inspect(last_lineno),
     vim.inspect(base_lineno),
-    vim.inspect(shift_lines),
+    vim.inspect(target_first_lineno),
+    vim.inspect(target_last_lineno),
     vim.inspect(target_base_lineno)
   )
 

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -614,14 +614,13 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
 end
 
 --- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
---- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob?
-function BufferPopupWindow:preview_file_contents(file_content)
-  if tables.tbl_empty(file_content) then
+--- @param last_file_content fzfx.BufferPopupWindowPreviewFileContentJob?
+function BufferPopupWindow:preview_file_contents(last_file_content)
+  if tables.tbl_empty(last_file_content) then
     return
   end
 
-  local last_content = file_content --[[@as fzfx.BufferPopupWindowPreviewFileContentJob]]
-
+  local last_content = last_file_content --[[@as fzfx.BufferPopupWindowPreviewFileContentJob]]
   pcall(vim.api.nvim_buf_set_name, self.previewer_bufnr, last_content.previewer_result.filename)
 
   vim.defer_fn(function()

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -633,8 +633,6 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
       vim.api.nvim_command([[filetype detect]])
     end)
 
-    vim.api.nvim_win_set_cursor(self.previewer_winnr, { 1, 0 })
-
     vim.defer_fn(function()
       if not self:previewer_is_valid() then
         return
@@ -646,7 +644,7 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
       local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
       local LINES = last_content.contents
       local LINES_COUNT = #LINES
-      local FIRST_LINE = last_content.previewer_result.lineno or 1
+      local FIRST_LINE = first_line or 1
       local LAST_LINE = math.min(WIN_HEIGHT + 5 + FIRST_LINE, LINES_COUNT)
 
       local SHOW_LABEL_COUNT = LAST_LINE - FIRST_LINE
@@ -659,6 +657,8 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
         vim.api.nvim_buf_set_lines(self.previewer_bufnr, 0, FIRST_LINE, false, {})
       end
       vim.api.nvim_buf_set_lines(self.previewer_bufnr, LAST_LINE, -1, false, {})
+
+      vim.api.nvim_win_set_cursor(self.previewer_winnr, { 1, 0 })
 
       local function set_win_title()
         if set_win_title_done then

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -572,11 +572,13 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
         return
       end
 
+      local lines = {}
       if strings.not_empty(contents) then
         contents = contents:gsub("\r\n", "\n")
+        lines = strings.split(contents, "\n")
       end
       table.insert(self.preview_file_contents_queue, {
-        contents = strings.split(contents, "\n"),
+        contents = lines,
         job_id = last_job.job_id,
         previewer_result = last_job.previewer_result,
         previewer_label_result = last_job.previewer_label_result,

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -852,11 +852,9 @@ function BufferPopupWindow:scroll_by(percent, up)
     end)
   end
 
-  local first_lineno = vim.fn.line("w0")
-  local last_lineno = vim.fn.line("w$")
-
-  local base_lineno = up and vim.fn.line("w0", self.previewer_winnr)
-    or vim.fn.line("w$", self.previewer_winnr)
+  local first_lineno = vim.fn.line("w0", self.previewer_winnr)
+  local last_lineno = vim.fn.line("w$", self.previewer_winnr)
+  local base_lineno = math.floor((first_lineno + last_lineno) / 2)
 
   if base_lineno == 1 and up then
     before_exit()

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -855,38 +855,36 @@ function BufferPopupWindow:scroll_by(percent, up)
     end)
   end
 
-  local first_lineno = vim.fn.line("w0", self.previewer_winnr)
-  local last_lineno = vim.fn.line("w$", self.previewer_winnr)
-  local base_lineno = math.floor((first_lineno + last_lineno) / 2)
-  local win_height = math.max(vim.api.nvim_win_get_height(self.previewer_winnr), 1)
-  local shift_lines = math.max(math.floor(win_height / 100 * percent), 0)
+  local FIRST_LINENO = vim.fn.line("w0", self.previewer_winnr)
+  local LAST_LINENO = vim.fn.line("w$", self.previewer_winnr)
+  local WIN_HEIGHT = math.max(vim.api.nvim_win_get_height(self.previewer_winnr), 1)
+  local SHIFT_LINES = math.max(math.floor(WIN_HEIGHT / 100 * percent), 0)
   if up then
-    shift_lines = -shift_lines
+    SHIFT_LINES = -SHIFT_LINES
   end
-
   local last_content = self._saved_previewing_file_content_job
   local LINES = last_content.contents
   local LINES_COUNT = #LINES
+  local TARGET_FIRST_LINENO = math.max(FIRST_LINENO + SHIFT_LINES, 1)
+  local TARGET_LAST_LINENO = math.min(LAST_LINENO + SHIFT_LINES, LINES_COUNT)
 
-  local target_first_lineno = math.max(first_lineno + shift_lines, 1)
-  local target_last_lineno = math.min(last_lineno + shift_lines, LINES_COUNT)
-  local target_base_lineno = numbers.bound(base_lineno + shift_lines, 1, LINES_COUNT)
+  local target_base_lineno = numbers.bound(base_lineno + SHIFT_LINES, 1, LINES_COUNT)
 
-  local FIRST_LINE = math.max(1, target_first_lineno - 5)
-  local LAST_LINE = math.min(target_last_lineno + 5, LINES_COUNT)
+  local FIRST_LINE = math.max(1, TARGET_FIRST_LINENO - 5)
+  local LAST_LINE = math.min(TARGET_LAST_LINENO + 5, LINES_COUNT)
 
   log.debug(
     "|BufferPopupWindow:scroll_by| percent:%s, up:%s, LINES_COUNT:%s, win_height:%s, shift_lines:%s, first/last/base:%s/%s/%s, target first/last/base:%s/%s/%s, FIRST/LAST:%s/%s",
     vim.inspect(percent),
     vim.inspect(up),
     vim.inspect(LINES_COUNT),
-    vim.inspect(win_height),
-    vim.inspect(shift_lines),
-    vim.inspect(first_lineno),
-    vim.inspect(last_lineno),
+    vim.inspect(WIN_HEIGHT),
+    vim.inspect(SHIFT_LINES),
+    vim.inspect(FIRST_LINENO),
+    vim.inspect(LAST_LINENO),
     vim.inspect(base_lineno),
-    vim.inspect(target_first_lineno),
-    vim.inspect(target_last_lineno),
+    vim.inspect(TARGET_FIRST_LINENO),
+    vim.inspect(TARGET_LAST_LINENO),
     vim.inspect(target_base_lineno),
     vim.inspect(FIRST_LINE),
     vim.inspect(LAST_LINE)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -607,29 +607,27 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
 
         self._saved_previewing_file_content_job = last_content
         self._saved_previewing_file_content_context = { render_index = nil }
-        self:preview_file_contents(last_content)
+        self:preview_file_contents(last_content, last_content.previewer_result.lineno or 1)
       end, 20)
     end)
   end, 20)
 end
 
 --- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
---- @param last_file_content fzfx.BufferPopupWindowPreviewFileContentJob?
---- @param start_line integer?
-function BufferPopupWindow:preview_file_contents(last_file_content, start_line)
-  if tables.tbl_empty(last_file_content) then
+--- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob
+--- @param start_line integer
+function BufferPopupWindow:preview_file_contents(file_content, start_line)
+  if tables.tbl_empty(file_content) then
     return
   end
 
-  start_line = start_line or 1
-  local last_content = last_file_content --[[@as fzfx.BufferPopupWindowPreviewFileContentJob]]
-  pcall(vim.api.nvim_buf_set_name, self.previewer_bufnr, last_content.previewer_result.filename)
+  pcall(vim.api.nvim_buf_set_name, self.previewer_bufnr, file_content.previewer_result.filename)
 
   vim.defer_fn(function()
     if not self:previewer_is_valid() then
       return
     end
-    if not self:is_last_previewing_file_job_id(last_content.job_id) then
+    if not self:is_last_previewing_file_job_id(file_content.job_id) then
       return
     end
 
@@ -641,14 +639,14 @@ function BufferPopupWindow:preview_file_contents(last_file_content, start_line)
       if not self:previewer_is_valid() then
         return
       end
-      if not self:is_last_previewing_file_job_id(last_content.job_id) then
+      if not self:is_last_previewing_file_job_id(file_content.job_id) then
         return
       end
 
       local ctx1 = self._saved_previewing_file_content_context
 
       local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
-      local LINES = last_content.contents
+      local LINES = file_content.contents
       local LINES_COUNT = #LINES
       local FIRST_LINE = start_line
       local LAST_LINE = math.min(WIN_HEIGHT + 5 + FIRST_LINE, LINES_COUNT)
@@ -665,18 +663,18 @@ function BufferPopupWindow:preview_file_contents(last_file_content, start_line)
         if set_win_title_done then
           return
         end
-        if strings.empty(last_content.previewer_label_result) then
+        if strings.empty(file_content.previewer_label_result) then
           return
         end
         if not self:previewer_is_valid() then
           return
         end
-        if not self:is_last_previewing_file_job_id(last_content.job_id) then
+        if not self:is_last_previewing_file_job_id(file_content.job_id) then
           return
         end
 
         local title_opts = {
-          title = last_content.previewer_label_result,
+          title = file_content.previewer_label_result,
           title_pos = "center",
         }
         vim.api.nvim_win_set_config(self.previewer_winnr, title_opts)
@@ -692,7 +690,7 @@ function BufferPopupWindow:preview_file_contents(last_file_content, start_line)
           if not self:previewer_is_valid() then
             return
           end
-          if not self:is_last_previewing_file_job_id(last_content.job_id) then
+          if not self:is_last_previewing_file_job_id(file_content.job_id) then
             return
           end
 

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -742,6 +742,9 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line)
             set_buf_lines()
           else
             vim.api.nvim_win_set_cursor(self.previewer_winnr, { start_line, 0 })
+            vim.api.nvim_win_call(self.previewer_winnr, function()
+              vim.cmd('execute "normal! zz"')
+            end)
             falsy_rendering()
           end
           if LINE_INDEX >= SHOW_LABEL_COUNT then

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -650,7 +650,7 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
       local SHOW_LABEL_COUNT = LAST_LINE - FIRST_LINE
       local SHOW_PREVIEW_LABEL_COUNT = math.min(30, SHOW_LABEL_COUNT)
       local line_index = FIRST_LINE
-      local line_count = 10
+      local line_count = 5
       local set_win_title_done = false
 
       if FIRST_LINE > 1 then
@@ -717,7 +717,7 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
           if line_index >= SHOW_PREVIEW_LABEL_COUNT then
             vim.schedule(set_win_title)
           end
-        end, 5)
+        end, 3)
       end
       set_buf_lines()
     end, 20)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -799,9 +799,7 @@ function BufferPopupWindow:render_file_contents(file_content, start_line, cursor
   end
 
   local function falsy_rendering()
-    vim.schedule(function()
-      self._rendering = false
-    end)
+    self._rendering = false
   end
 
   self._rendering = true
@@ -843,11 +841,13 @@ function BufferPopupWindow:render_file_contents(file_content, start_line, cursor
           return
         end
 
-        local LINE_INDEX = self._saved_previewing_file_content_context.render_index
+        local RENDER_START = self._saved_previewing_file_content_context.render_index
+        local RENDER_STOP = RENDER_START
         local buf_lines = {}
-        for i = LINE_INDEX, LINE_INDEX + RENDER_STEP do
+        for i = RENDER_START, RENDER_START + RENDER_STEP do
           if i <= LAST_LINE then
             table.insert(buf_lines, LINES[i])
+            RENDER_STOP = i
           else
             break
           end
@@ -855,16 +855,14 @@ function BufferPopupWindow:render_file_contents(file_content, start_line, cursor
 
         vim.api.nvim_buf_set_lines(
           self.previewer_bufnr,
-          LINE_INDEX - 1,
-          LINE_INDEX - 1 + RENDER_STEP,
+          RENDER_START - 1,
+          RENDER_STOP - 1,
           false,
           buf_lines
         )
-        self._saved_previewing_file_content_context.render_index =
-          math.min(LINE_INDEX + RENDER_STEP, LAST_LINE)
-        LINE_INDEX = self._saved_previewing_file_content_context.render_index
 
-        if LINE_INDEX <= LAST_LINE then
+        self._saved_previewing_file_content_context.render_index = RENDER_STOP + 1
+        if self._saved_previewing_file_content_context.render_index <= LAST_LINE then
           set_buf_lines()
         else
           vim.api.nvim_win_set_cursor(self.previewer_winnr, { cursor_line, 0 })

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -870,7 +870,7 @@ function BufferPopupWindow:scroll_by(percent, up)
   local target_base_lineno = numbers.bound(base_lineno + shift_lines, 1, LINES_COUNT)
 
   log.debug(
-    "|scroll_by| percent:%s, up:%s, LINES_COUNT:%s, win_height:%s, shift_lines:%s, first/last/base:%s/%s/%s, target first/last/base:%s",
+    "|BufferPopupWindow:scroll_by| percent:%s, up:%s, LINES_COUNT:%s, win_height:%s, shift_lines:%s, first/last/base:%s/%s/%s, target first/last/base:%s/%s/%s",
     vim.inspect(percent),
     vim.inspect(up),
     vim.inspect(LINES_COUNT),
@@ -884,8 +884,8 @@ function BufferPopupWindow:scroll_by(percent, up)
     vim.inspect(target_base_lineno)
   )
 
-  local FIRST_LINE = math.max(1, target_base_lineno - win_height - 5)
-  local LAST_LINE = math.min(win_height + 5 + FIRST_LINE, LINES_COUNT)
+  local FIRST_LINE = math.max(1, target_first_lineno - 5)
+  local LAST_LINE = math.min(target_last_lineno + 5, LINES_COUNT)
 
   local line_index = FIRST_LINE
   local line_count = 5
@@ -894,10 +894,12 @@ function BufferPopupWindow:scroll_by(percent, up)
     -- log.debug("|BufferPopupWindow:scroll_by| set_buf_lines")
     vim.defer_fn(function()
       if not self:previewer_is_valid() then
+        log.debug("|BufferPopupWindow:scroll_by| invalid previewer")
         before_exit()
         return
       end
       if not self:is_last_previewing_file_job_id(last_content.job_id) then
+        log.debug("|BufferPopupWindow:scroll_by| has newer previewing job")
         before_exit()
         return
       end

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -662,10 +662,6 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line, curso
         return
       end
 
-      if not self._saved_previewing_file_content_context.render_index then
-        self._saved_previewing_file_content_context.render_index = 1
-      end
-
       vim.api.nvim_buf_set_lines(self.previewer_bufnr, 0, -1, false, {})
 
       local function set_win_title()
@@ -688,6 +684,9 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line, curso
         vim.defer_fn(set_win_title, 50)
       end
 
+      if not self._saved_previewing_file_content_context.render_index then
+        self._saved_previewing_file_content_context.render_index = 1
+      end
       self:render_file_contents(file_content, start_line, cursor_line, on_complete)
     end, 20)
   end, 20)
@@ -909,9 +908,6 @@ function BufferPopupWindow:scroll_by(percent, up)
   if self._scrolling then
     return
   end
-  if self._rendering then
-    return
-  end
 
   local down = not up
   self._scrolling = true
@@ -957,7 +953,7 @@ function BufferPopupWindow:scroll_by(percent, up)
     return
   end
 
-  self:preview_file_contents(
+  self:render_file_contents(
     file_content,
     TARGET_FIRST_LINENO,
     math.floor((TARGET_FIRST_LINENO + TARGET_LAST_LINENO) / 2),

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -70,17 +70,17 @@ M._make_provider_center_opts = function(opts, buffer_previewer_opts)
     end
     additional_row_offset = math.floor(math.abs(old_height - height) / 2) * sign + sign
   end
-  log.debug(
-    "|_make_provider_center_opts| opts:%s, fzf_preview_window_opts:%s, height:%s(%s), width:%s(%s), additional_row_offset:%s, additional_col_offset:%s",
-    vim.inspect(opts),
-    vim.inspect(fzf_preview_window_opts),
-    vim.inspect(height),
-    vim.inspect(total_height),
-    vim.inspect(width),
-    vim.inspect(total_width),
-    vim.inspect(additional_row_offset),
-    vim.inspect(additional_col_offset)
-  )
+  -- log.debug(
+  --   "|_make_provider_center_opts| opts:%s, fzf_preview_window_opts:%s, height:%s(%s), width:%s(%s), additional_row_offset:%s, additional_col_offset:%s",
+  --   vim.inspect(opts),
+  --   vim.inspect(fzf_preview_window_opts),
+  --   vim.inspect(height),
+  --   vim.inspect(total_height),
+  --   vim.inspect(width),
+  --   vim.inspect(total_width),
+  --   vim.inspect(additional_row_offset),
+  --   vim.inspect(additional_col_offset)
+  -- )
 
   log.ensure(
     (opts.row >= -0.5 and opts.row <= 0.5) or opts.row <= -1 or opts.row >= 1,
@@ -107,7 +107,7 @@ M._make_provider_center_opts = function(opts, buffer_previewer_opts)
       or fzf_helpers.FZF_DEFAULT_BORDER_OPTS,
     zindex = FLOAT_WIN_DEFAULT_ZINDEX,
   }
-  log.debug("|_make_provider_center_opts| result:%s", vim.inspect(result))
+  -- log.debug("|_make_provider_center_opts| result:%s", vim.inspect(result))
   return result
 end
 
@@ -154,7 +154,7 @@ M._make_provider_center_opts_with_hidden_previewer = function(opts, buffer_previ
       or fzf_helpers.FZF_DEFAULT_BORDER_OPTS,
     zindex = FLOAT_WIN_DEFAULT_ZINDEX,
   }
-  log.debug("|_make_provider_center_opts| result:%s", vim.inspect(result))
+  -- log.debug("|_make_provider_center_opts| result:%s", vim.inspect(result))
   return result
 end
 
@@ -192,17 +192,17 @@ M._make_previewer_center_opts = function(opts, buffer_previewer_opts)
     end
     additional_row_offset = math.floor(math.abs(old_height - height) / 2) * sign + sign
   end
-  log.debug(
-    "|_make_previewer_center_opts| opts:%s, fzf_preview_window_opts:%s, height:%s(%s), width:%s(%s), additional_row_offset:%s, additional_col_offset:%s",
-    vim.inspect(opts),
-    vim.inspect(fzf_preview_window_opts),
-    vim.inspect(height),
-    vim.inspect(total_height),
-    vim.inspect(width),
-    vim.inspect(total_width),
-    vim.inspect(additional_row_offset),
-    vim.inspect(additional_col_offset)
-  )
+  -- log.debug(
+  --   "|_make_previewer_center_opts| opts:%s, fzf_preview_window_opts:%s, height:%s(%s), width:%s(%s), additional_row_offset:%s, additional_col_offset:%s",
+  --   vim.inspect(opts),
+  --   vim.inspect(fzf_preview_window_opts),
+  --   vim.inspect(height),
+  --   vim.inspect(total_height),
+  --   vim.inspect(width),
+  --   vim.inspect(total_width),
+  --   vim.inspect(additional_row_offset),
+  --   vim.inspect(additional_col_offset)
+  -- )
 
   log.ensure(
     (opts.row >= -0.5 and opts.row <= 0.5) or opts.row <= -1 or opts.row >= 1,
@@ -228,7 +228,7 @@ M._make_previewer_center_opts = function(opts, buffer_previewer_opts)
     border = fzf_preview_window_opts.border,
     zindex = FLOAT_WIN_DEFAULT_ZINDEX,
   }
-  log.debug("|_make_previewer_center_opts| result:%s", vim.inspect(result))
+  -- log.debug("|_make_previewer_center_opts| result:%s", vim.inspect(result))
   return result
 end
 
@@ -377,7 +377,7 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
     buffer = provider_bufnr,
     nested = true,
     callback = function()
-      log.debug("|BufferPopupWindow:new| enter provider buffer")
+      -- log.debug("|BufferPopupWindow:new| enter provider buffer")
       vim.cmd("startinsert")
     end,
   })
@@ -439,11 +439,11 @@ function BufferPopupWindow:resize()
       self._saved_win_opts,
       self._saved_buffer_previewer_opts
     )
-    log.debug(
-      "|BufferPopupWindow:resize| is hidden, provider - old:%s, new:%s",
-      vim.inspect(old_provider_win_confs),
-      vim.inspect(provider_win_confs)
-    )
+    -- log.debug(
+    --   "|BufferPopupWindow:resize| is hidden, provider - old:%s, new:%s",
+    --   vim.inspect(old_provider_win_confs),
+    --   vim.inspect(provider_win_confs)
+    -- )
     vim.api.nvim_win_set_config(
       self.provider_winnr,
       vim.tbl_deep_extend("force", old_provider_win_confs, provider_win_confs or {})
@@ -453,11 +453,11 @@ function BufferPopupWindow:resize()
     local old_provider_win_confs = vim.api.nvim_win_get_config(self.provider_winnr)
     local provider_win_confs =
       M.make_provider_opts(self._saved_win_opts, self._saved_buffer_previewer_opts)
-    log.debug(
-      "|BufferPopupWindow:resize| not hidden, provider - old:%s, new:%s",
-      vim.inspect(old_provider_win_confs),
-      vim.inspect(provider_win_confs)
-    )
+    -- log.debug(
+    --   "|BufferPopupWindow:resize| not hidden, provider - old:%s, new:%s",
+    --   vim.inspect(old_provider_win_confs),
+    --   vim.inspect(provider_win_confs)
+    -- )
     vim.api.nvim_win_set_config(
       self.provider_winnr,
       vim.tbl_deep_extend("force", old_provider_win_confs, provider_win_confs or {})
@@ -468,11 +468,11 @@ function BufferPopupWindow:resize()
       local old_previewer_win_confs = vim.api.nvim_win_get_config(self.previewer_winnr)
       local previewer_win_confs =
         M.make_previewer_opts(self._saved_win_opts, self._saved_buffer_previewer_opts)
-      log.debug(
-        "|BufferPopupWindow:resize| not hidden, previewer - old:%s, new:%s",
-        vim.inspect(old_previewer_win_confs),
-        vim.inspect(previewer_win_confs)
-      )
+      -- log.debug(
+      --   "|BufferPopupWindow:resize| not hidden, previewer - old:%s, new:%s",
+      --   vim.inspect(old_previewer_win_confs),
+      --   vim.inspect(previewer_win_confs)
+      -- )
       vim.api.nvim_win_set_config(
         self.previewer_winnr,
         vim.tbl_deep_extend("force", old_previewer_win_confs, previewer_win_confs or {})
@@ -530,10 +530,10 @@ end
 --- @param previewer_label_result string?
 function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_label_result)
   if strings.empty(tables.tbl_get(previewer_result, "filename")) then
-    log.debug(
-      "|BufferPopupWindow:preview_file| empty previewer_result:%s",
-      vim.inspect(previewer_result)
-    )
+    -- log.debug(
+    --   "|BufferPopupWindow:preview_file| empty previewer_result:%s",
+    --   vim.inspect(previewer_result)
+    -- )
     return
   end
 
@@ -550,14 +550,14 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
 
   vim.defer_fn(function()
     if not self:previewer_is_valid() then
-      log.debug("|BufferPopupWindow:preview_file| invalid previewer:%s", vim.inspect(self))
+      -- log.debug("|BufferPopupWindow:preview_file| invalid previewer:%s", vim.inspect(self))
       return
     end
     if #self.preview_files_queue == 0 then
-      log.debug(
-        "|BufferPopupWindow:preview_file| empty preview files queue:%s",
-        vim.inspect(self.preview_files_queue)
-      )
+      -- log.debug(
+      --   "|BufferPopupWindow:preview_file| empty preview files queue:%s",
+      --   vim.inspect(self.preview_files_queue)
+      -- )
       return
     end
 
@@ -593,10 +593,10 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
       -- show file contents by lines
       vim.defer_fn(function()
         if not self:previewer_is_valid() then
-          log.debug(
-            "|BufferPopupWindow:preview_file - asyncreadfile - done content| invalid previewer:%s",
-            vim.inspect(self)
-          )
+          -- log.debug(
+          --   "|BufferPopupWindow:preview_file - asyncreadfile - done content| invalid previewer:%s",
+          --   vim.inspect(self)
+          -- )
           return
         end
 
@@ -635,29 +635,16 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line, curso
     do_complete(false)
     return
   end
-  if self._rendering then
-    do_complete(false)
-    return
-  end
 
-  local function falsy_rendering()
-    vim.schedule(function()
-      self._rendering = false
-    end)
-  end
-
-  self._rendering = true
   pcall(vim.api.nvim_buf_set_name, self.previewer_bufnr, file_content.previewer_result.filename)
 
   vim.defer_fn(function()
     if not self:previewer_is_valid() then
       do_complete(false)
-      falsy_rendering()
       return
     end
     if not self:is_last_previewing_file_job_id(file_content.job_id) then
       do_complete(false)
-      falsy_rendering()
       return
     end
 
@@ -668,47 +655,24 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line, curso
     vim.defer_fn(function()
       if not self:previewer_is_valid() then
         do_complete(false)
-        falsy_rendering()
         return
       end
       if not self:is_last_previewing_file_job_id(file_content.job_id) then
         do_complete(false)
-        falsy_rendering()
         return
       end
-
-      local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
-      local LINES = file_content.contents
-      local LINES_COUNT = #LINES
-      local FIRST_LINE = start_line
-      local LAST_LINE = math.min(WIN_HEIGHT + 5 + FIRST_LINE, LINES_COUNT)
-
-      local SHOW_LABEL_COUNT = math.min(30, LAST_LINE - FIRST_LINE)
-      local LINE_STEP = 5
 
       if not self._saved_previewing_file_content_context.render_index then
         self._saved_previewing_file_content_context.render_index = 1
       end
 
-      local set_win_title_done = false
-
       vim.api.nvim_buf_set_lines(self.previewer_bufnr, 0, -1, false, {})
 
       local function set_win_title()
-        if set_win_title_done then
-          falsy_rendering()
-          return
-        end
-        if strings.empty(file_content.previewer_label_result) then
-          falsy_rendering()
-          return
-        end
         if not self:previewer_is_valid() then
-          falsy_rendering()
           return
         end
         if not self:is_last_previewing_file_job_id(file_content.job_id) then
-          falsy_rendering()
           return
         end
 
@@ -718,62 +682,13 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line, curso
         }
         vim.api.nvim_win_set_config(self.previewer_winnr, title_opts)
         apis.set_win_option(self.previewer_winnr, "number", true)
-        vim.schedule(function()
-          set_win_title_done = true
-        end)
       end
 
-      local function set_buf_lines()
-        -- log.debug("|BufferPopupWindow:preview_file_contents| set_buf_lines")
-        vim.defer_fn(function()
-          if not self:previewer_is_valid() then
-            do_complete(false)
-            falsy_rendering()
-            return
-          end
-          if not self:is_last_previewing_file_job_id(file_content.job_id) then
-            do_complete(false)
-            falsy_rendering()
-            return
-          end
-
-          local LINE_INDEX = self._saved_previewing_file_content_context.render_index
-          local buf_lines = {}
-          for i = LINE_INDEX, LINE_INDEX + LINE_STEP do
-            if i <= LAST_LINE then
-              table.insert(buf_lines, LINES[i])
-            else
-              break
-            end
-          end
-
-          vim.api.nvim_buf_set_lines(
-            self.previewer_bufnr,
-            LINE_INDEX - 1,
-            LINE_INDEX - 1 + LINE_STEP,
-            false,
-            buf_lines
-          )
-          self._saved_previewing_file_content_context.render_index =
-            math.min(LINE_INDEX + LINE_STEP, LAST_LINE)
-          LINE_INDEX = self._saved_previewing_file_content_context.render_index
-
-          if LINE_INDEX <= LAST_LINE then
-            set_buf_lines()
-          else
-            vim.api.nvim_win_set_cursor(self.previewer_winnr, { cursor_line, 0 })
-            vim.api.nvim_win_call(self.previewer_winnr, function()
-              vim.cmd('execute "normal! zz"')
-            end)
-            do_complete(true)
-            falsy_rendering()
-          end
-          if LINE_INDEX >= SHOW_LABEL_COUNT then
-            vim.schedule(set_win_title)
-          end
-        end, 3)
+      if strings.not_empty(file_content.previewer_label_result) then
+        vim.defer_fn(set_win_title, 50)
       end
-      set_buf_lines()
+
+      self:render_file_contents(file_content, start_line, cursor_line, on_complete)
     end, 20)
   end, 20)
 end

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -778,6 +778,146 @@ function BufferPopupWindow:preview_file_contents(file_content, start_line, curso
   end, 20)
 end
 
+--- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob
+--- @param start_line integer
+--- @param cursor_line integer
+--- @param on_complete (fun(done:boolean):any)|nil
+function BufferPopupWindow:render_file_contents(file_content, start_line, cursor_line, on_complete)
+  local function do_complete(done)
+    if type(on_complete) == "function" then
+      on_complete(done)
+    end
+  end
+
+  if tables.tbl_empty(file_content) then
+    do_complete(false)
+    return
+  end
+  if self._rendering then
+    do_complete(false)
+    return
+  end
+
+  local function falsy_rendering()
+    vim.schedule(function()
+      self._rendering = false
+    end)
+  end
+
+  self._rendering = true
+
+  vim.defer_fn(function()
+    if not self:previewer_is_valid() then
+      do_complete(false)
+      falsy_rendering()
+      return
+    end
+    if not self:is_last_previewing_file_job_id(file_content.job_id) then
+      do_complete(false)
+      falsy_rendering()
+      return
+    end
+
+    local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
+    local LINES = file_content.contents
+    local LINES_COUNT = #LINES
+    local FIRST_LINE = start_line
+    local LAST_LINE = math.min(WIN_HEIGHT + 5 + FIRST_LINE, LINES_COUNT)
+
+    local SHOW_LABEL_COUNT = math.min(30, LAST_LINE - FIRST_LINE)
+    local LINE_STEP = 5
+
+    if not self._saved_previewing_file_content_context.render_index then
+      self._saved_previewing_file_content_context.render_index = 1
+    end
+
+    local set_win_title_done = false
+
+    vim.api.nvim_buf_set_lines(self.previewer_bufnr, 0, -1, false, {})
+
+    local function set_win_title()
+      if set_win_title_done then
+        falsy_rendering()
+        return
+      end
+      if strings.empty(file_content.previewer_label_result) then
+        falsy_rendering()
+        return
+      end
+      if not self:previewer_is_valid() then
+        falsy_rendering()
+        return
+      end
+      if not self:is_last_previewing_file_job_id(file_content.job_id) then
+        falsy_rendering()
+        return
+      end
+
+      local title_opts = {
+        title = file_content.previewer_label_result,
+        title_pos = "center",
+      }
+      vim.api.nvim_win_set_config(self.previewer_winnr, title_opts)
+      apis.set_win_option(self.previewer_winnr, "number", true)
+      vim.schedule(function()
+        set_win_title_done = true
+      end)
+    end
+
+    local function set_buf_lines()
+      -- log.debug("|BufferPopupWindow:preview_file_contents| set_buf_lines")
+      vim.defer_fn(function()
+        if not self:previewer_is_valid() then
+          do_complete(false)
+          falsy_rendering()
+          return
+        end
+        if not self:is_last_previewing_file_job_id(file_content.job_id) then
+          do_complete(false)
+          falsy_rendering()
+          return
+        end
+
+        local LINE_INDEX = self._saved_previewing_file_content_context.render_index
+        local buf_lines = {}
+        for i = LINE_INDEX, LINE_INDEX + LINE_STEP do
+          if i <= LAST_LINE then
+            table.insert(buf_lines, LINES[i])
+          else
+            break
+          end
+        end
+
+        vim.api.nvim_buf_set_lines(
+          self.previewer_bufnr,
+          LINE_INDEX - 1,
+          LINE_INDEX - 1 + LINE_STEP,
+          false,
+          buf_lines
+        )
+        self._saved_previewing_file_content_context.render_index =
+          math.min(LINE_INDEX + LINE_STEP, LAST_LINE)
+        LINE_INDEX = self._saved_previewing_file_content_context.render_index
+
+        if LINE_INDEX <= LAST_LINE then
+          set_buf_lines()
+        else
+          vim.api.nvim_win_set_cursor(self.previewer_winnr, { cursor_line, 0 })
+          vim.api.nvim_win_call(self.previewer_winnr, function()
+            vim.cmd('execute "normal! zz"')
+          end)
+          do_complete(true)
+          falsy_rendering()
+        end
+        if LINE_INDEX >= SHOW_LABEL_COUNT then
+          vim.schedule(set_win_title)
+        end
+      end, 3)
+    end
+    set_buf_lines()
+  end, 20)
+end
+
 --- @param action_name string
 function BufferPopupWindow:preview_action(action_name)
   local actions_map = {

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -328,6 +328,7 @@ local function _set_default_previewer_win_options(winnr)
   apis.set_win_option(winnr, "wrap", false)
   apis.set_win_option(winnr, "scrolloff", 0)
   apis.set_win_option(winnr, "sidescrolloff", 0)
+  apis.set_win_option(winnr, "foldenable", 0)
 end
 
 local function _set_default_provider_win_options(winnr)
@@ -338,6 +339,7 @@ local function _set_default_provider_win_options(winnr)
   apis.set_win_option(winnr, "wrap", false)
   apis.set_win_option(winnr, "scrolloff", 0)
   apis.set_win_option(winnr, "sidescrolloff", 0)
+  apis.set_win_option(winnr, "foldenable", 0)
 end
 
 --- @package

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -610,9 +610,8 @@ end
 
 --- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
 --- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob?
---- @param first_line integer?
---- @param last_line integer?
-function BufferPopupWindow:preview_file_contents(file_content, first_line, last_line)
+--- @param start_line integer?
+function BufferPopupWindow:preview_file_contents(file_content, start_line)
   if tables.tbl_empty(file_content) then
     return
   end
@@ -644,20 +643,15 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
       local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
       local LINES = last_content.contents
       local LINES_COUNT = #LINES
-      local FIRST_LINE = first_line or 1
+      local FIRST_LINE = start_line or 1
       local LAST_LINE = math.min(WIN_HEIGHT + 5 + FIRST_LINE, LINES_COUNT)
 
-      local SHOW_LABEL_COUNT = LAST_LINE - FIRST_LINE
-      local SHOW_PREVIEW_LABEL_COUNT = math.min(30, SHOW_LABEL_COUNT)
+      local SHOW_LABEL_COUNT = math.min(30, LAST_LINE - FIRST_LINE)
       local line_index = FIRST_LINE
       local line_count = 5
       local set_win_title_done = false
 
-      if FIRST_LINE > 1 then
-        vim.api.nvim_buf_set_lines(self.previewer_bufnr, 0, FIRST_LINE, false, {})
-      end
-      vim.api.nvim_buf_set_lines(self.previewer_bufnr, LAST_LINE, -1, false, {})
-
+      vim.api.nvim_buf_set_lines(self.previewer_bufnr, 0, -1, false, {})
       vim.api.nvim_win_set_cursor(self.previewer_winnr, { 1, 0 })
 
       local function set_win_title()
@@ -716,7 +710,7 @@ function BufferPopupWindow:preview_file_contents(file_content, first_line, last_
             set_buf_lines()
           end
 
-          if line_index >= SHOW_PREVIEW_LABEL_COUNT then
+          if line_index >= SHOW_LABEL_COUNT then
             vim.schedule(set_win_title)
           end
         end, 3)

--- a/spec/detail/popup/buffer_popup_window_spec.lua
+++ b/spec/detail/popup/buffer_popup_window_spec.lua
@@ -230,30 +230,38 @@ describe("detail.popup.buffer_popup_window", function()
     end)
   end)
   describe("[scroll_by]", function()
-    local pw_opts = fzf_helpers.parse_fzf_preview_window_opts({
+    local PREVIEW_WINDOW_OPTS = fzf_helpers.parse_fzf_preview_window_opts({
       {
         "--preview-window",
         "right,50%",
       },
     })
+    local PREVIEWER_RESULT = {
+      filename = "README.md",
+    }
+    local PREVIEW_JOB_ID = 1
     local builtin_opts = {
-      fzf_preview_window_opts = pw_opts,
+      fzf_preview_window_opts = PREVIEW_WINDOW_OPTS,
       fzf_border_opts = "rounded",
     }
     it("scroll up 100%", function()
       local bpw = buffer_popup_window.BufferPopupWindow:new(WIN_OPTS, builtin_opts)
+      bpw:preview_file(PREVIEW_JOB_ID, PREVIEWER_RESULT)
       bpw:scroll_by(100, true)
     end)
     it("scroll down 100%", function()
       local bpw = buffer_popup_window.BufferPopupWindow:new(WIN_OPTS, builtin_opts)
+      bpw:preview_file(PREVIEW_JOB_ID, PREVIEWER_RESULT)
       bpw:scroll_by(100, false)
     end)
     it("scroll up 50%", function()
       local bpw = buffer_popup_window.BufferPopupWindow:new(WIN_OPTS, builtin_opts)
+      bpw:preview_file(PREVIEW_JOB_ID, PREVIEWER_RESULT)
       bpw:scroll_by(50, true)
     end)
     it("scroll down 100%", function()
       local bpw = buffer_popup_window.BufferPopupWindow:new(WIN_OPTS, builtin_opts)
+      bpw:preview_file(PREVIEW_JOB_ID, PREVIEWER_RESULT)
       bpw:scroll_by(50, false)
     end)
   end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
