### PR TITLE
feat(config): enable buffer previewers 2

### DIFF
--- a/lua/fzfx/cfg/buffers.lua
+++ b/lua/fzfx/cfg/buffers.lua
@@ -2,8 +2,9 @@ local strings = require("fzfx.commons.strings")
 local apis = require("fzfx.commons.apis")
 local paths = require("fzfx.commons.paths")
 
-local consts = require("fzfx.lib.constants")
+local constants = require("fzfx.lib.constants")
 local bufs = require("fzfx.lib.bufs")
+local switches = require("fzfx.lib.switches")
 
 local parsers_helper = require("fzfx.helper.parsers")
 local actions_helper = require("fzfx.helper.actions")
@@ -93,9 +94,24 @@ M.providers = {
   provider_decorator = { module = "prepend_icon_find", builtin = true },
 }
 
+-- if you want to use fzf-builtin previewer with bat, please use below configs:
+--
+-- previewer = previewers_helper.preview_files_find
+-- previewer_type = PreviewerTypeEnum.COMMAND_LIST
+
+-- if you want to use nvim buffer previewer, please use below configs:
+--
+-- previewer = previewers_helper.buffer_preview_files_find
+-- previewer_type = PreviewerTypeEnum.BUFFER_FILE
+
+local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_find
+  or previewers_helper.buffer_preview_files_find
+local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
+  or PreviewerTypeEnum.BUFFER_FILE
+
 M.previewers = {
-  previewer = previewers_helper.preview_files_find,
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+  previewer = previewer,
+  previewer_type = previewer_type,
   previewer_label = labels_helper.label_find,
 }
 

--- a/lua/fzfx/cfg/buffers.lua
+++ b/lua/fzfx/cfg/buffers.lua
@@ -110,8 +110,8 @@ local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnu
   or PreviewerTypeEnum.BUFFER_FILE
 
 M.previewers = {
-  previewer = previewer,
-  previewer_type = previewer_type,
+  previewer = previewers_helper.preview_files_find,
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST,
   previewer_label = labels_helper.label_find,
 }
 

--- a/lua/fzfx/cfg/git_files.lua
+++ b/lua/fzfx/cfg/git_files.lua
@@ -1,10 +1,11 @@
 local tables = require("fzfx.commons.tables")
 local paths = require("fzfx.commons.paths")
 
-local consts = require("fzfx.lib.constants")
+local constants = require("fzfx.lib.constants")
 local cmds = require("fzfx.lib.commands")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
+local switches = require("fzfx.lib.switches")
 
 local actions_helper = require("fzfx.helper.actions")
 local labels_helper = require("fzfx.helper.previewer_labels")
@@ -113,15 +114,30 @@ M.providers = {
   },
 }
 
+-- if you want to use fzf-builtin previewer with bat, please use below configs:
+--
+-- previewer = previewers_helper.preview_files_find
+-- previewer_type = PreviewerTypeEnum.COMMAND_LIST
+
+-- if you want to use nvim buffer previewer, please use below configs:
+--
+-- previewer = previewers_helper.buffer_preview_files_find
+-- previewer_type = PreviewerTypeEnum.BUFFER_FILE
+
+local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_find
+  or previewers_helper.buffer_preview_files_find
+local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
+  or PreviewerTypeEnum.BUFFER_FILE
+
 M.previewers = {
   current_folder = {
-    previewer = previewers_helper.preview_files_find,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer = previewer,
+    previewer_type = previewer_type,
     previewer_label = labels_helper.label_find,
   },
   workspace = {
-    previewer = previewers_helper.preview_files_find,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer = previewer,
+    previewer_type = previewer_type,
     previewer_label = labels_helper.label_find,
   },
 }

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -920,7 +920,6 @@ end
 --- @param bang boolean
 --- @param pipeline_configs fzfx.Options
 --- @param default_pipeline fzfx.PipelineName?
---- @return fzfx.Popup
 local function general(name, query, bang, pipeline_configs, default_pipeline)
   local pipeline_size = get_pipeline_size(pipeline_configs)
 

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -1398,7 +1398,6 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
     end
     buffer_previewer_query_fzf_status_start = false
   end, use_buffer_previewer, buffer_previewer_opts)
-  return popup
 end
 
 --- @param name string

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -775,7 +775,7 @@ function BufferPopupWindow:render_file_contents(file_content, top_line, on_compl
           set_buf_lines()
         else
           vim.api.nvim_win_call(self.previewer_winnr, function()
-            vim.cmd(string.format([[call winrestview({'topline':%d})]], TOP_LINE))
+            vim.api.nvim_command(string.format([[call winrestview({'topline':%d})]], TOP_LINE))
           end)
           self._saved_previewing_file_content_context = { top_line = TOP_LINE }
           do_complete(true)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -775,7 +775,7 @@ function BufferPopupWindow:render_file_contents(file_content, top_line, on_compl
           set_buf_lines()
         else
           vim.api.nvim_win_call(self.previewer_winnr, function()
-            vim.cmd(string.format([[call winrestview({'topline':%d})]], TOP_LINE))
+            vim.cmd(string.format([[call winrestview({'topline':%d,'curswant':0})]], TOP_LINE))
           end)
           self._saved_previewing_file_content_context = { top_line = TOP_LINE }
           do_complete(true)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -326,10 +326,10 @@ end
 local function _set_default_previewer_win_options(winnr)
   apis.set_win_option(winnr, "number", true)
   apis.set_win_option(winnr, "spell", false)
-  apis.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
+  -- apis.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
   apis.set_win_option(winnr, "wrap", false)
-  apis.set_win_option(winnr, "scrolloff", 0)
-  apis.set_win_option(winnr, "sidescrolloff", 0)
+  -- apis.set_win_option(winnr, "scrolloff", 0)
+  -- apis.set_win_option(winnr, "sidescrolloff", 0)
   apis.set_win_option(winnr, "foldenable", false)
 end
 
@@ -339,8 +339,8 @@ local function _set_default_provider_win_options(winnr)
   apis.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
   apis.set_win_option(winnr, "colorcolumn", "")
   apis.set_win_option(winnr, "wrap", false)
-  apis.set_win_option(winnr, "scrolloff", 0)
-  apis.set_win_option(winnr, "sidescrolloff", 0)
+  -- apis.set_win_option(winnr, "scrolloff", 0)
+  -- apis.set_win_option(winnr, "sidescrolloff", 0)
   apis.set_win_option(winnr, "foldenable", false)
 end
 

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -326,7 +326,7 @@ end
 local function _set_default_previewer_win_options(winnr)
   apis.set_win_option(winnr, "number", true)
   apis.set_win_option(winnr, "spell", false)
-  -- apis.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
+  apis.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
   apis.set_win_option(winnr, "wrap", false)
   -- apis.set_win_option(winnr, "scrolloff", 0)
   -- apis.set_win_option(winnr, "sidescrolloff", 0)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -775,7 +775,7 @@ function BufferPopupWindow:render_file_contents(file_content, top_line, on_compl
           set_buf_lines()
         else
           vim.api.nvim_win_call(self.previewer_winnr, function()
-            vim.cmd(string.format([[call winrestview({'topline':%d,'curswant':0})]], TOP_LINE))
+            vim.cmd(string.format([[call winrestview({'topline':%d})]], TOP_LINE))
           end)
           self._saved_previewing_file_content_context = { top_line = TOP_LINE }
           do_complete(true)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
