### PR TITLE
fix(previewer): fix buffer previewer popup window size

### DIFF
--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -59,7 +59,7 @@ M._make_provider_center_opts = function(opts, buffer_previewer_opts)
     else
       width = math.max(width - fzf_preview_window_opts.size, 1)
     end
-    additional_col_offset = math.floor(math.abs(old_width - width) / 2) * sign + sign
+    additional_col_offset = (math.abs(old_width - width) / 2) * sign + sign
   elseif fzf_preview_window_opts.position == "up" or fzf_preview_window_opts.position == "down" then
     local old_height = height
     local sign = fzf_preview_window_opts.position == "down" and -1 or 1
@@ -68,7 +68,7 @@ M._make_provider_center_opts = function(opts, buffer_previewer_opts)
     else
       height = math.max(height - fzf_preview_window_opts.size, 1)
     end
-    additional_row_offset = math.floor(math.abs(old_height - height) / 2) * sign + sign
+    additional_row_offset = (math.abs(old_height - height) / 2) * sign + sign
   end
   -- log.debug(
   --   "|_make_provider_center_opts| opts:%s, fzf_preview_window_opts:%s, height:%s(%s), width:%s(%s), additional_row_offset:%s, additional_col_offset:%s",
@@ -92,8 +92,11 @@ M._make_provider_center_opts = function(opts, buffer_previewer_opts)
     "window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
     vim.inspect(opts)
   )
-  local row = popup_helpers.shift_window_pos(total_height, height, opts.row, additional_row_offset)
-  local col = popup_helpers.shift_window_pos(total_width, width, opts.col, additional_col_offset)
+  local row = math.floor(
+    popup_helpers.shift_window_pos(total_height, height, opts.row, additional_row_offset)
+  )
+  local col =
+    math.floor(popup_helpers.shift_window_pos(total_width, width, opts.col, additional_col_offset))
 
   local result = {
     anchor = "NW",
@@ -181,7 +184,7 @@ M._make_previewer_center_opts = function(opts, buffer_previewer_opts)
     else
       width = fzf_preview_window_opts.size
     end
-    additional_col_offset = math.floor(math.abs(old_width - width) / 2) * sign + sign
+    additional_col_offset = (math.abs(old_width - width) / 2) * sign + sign
   elseif fzf_preview_window_opts.position == "up" or fzf_preview_window_opts.position == "down" then
     local old_height = height
     local sign = fzf_preview_window_opts.position == "up" and -1 or 1
@@ -190,7 +193,7 @@ M._make_previewer_center_opts = function(opts, buffer_previewer_opts)
     else
       height = fzf_preview_window_opts.size
     end
-    additional_row_offset = math.floor(math.abs(old_height - height) / 2) * sign + sign
+    additional_row_offset = (math.abs(old_height - height) / 2) * sign + sign
   end
   -- log.debug(
   --   "|_make_previewer_center_opts| opts:%s, fzf_preview_window_opts:%s, height:%s(%s), width:%s(%s), additional_row_offset:%s, additional_col_offset:%s",
@@ -214,8 +217,11 @@ M._make_previewer_center_opts = function(opts, buffer_previewer_opts)
     "window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
     vim.inspect(opts)
   )
-  local row = popup_helpers.shift_window_pos(total_height, height, opts.row, additional_row_offset)
-  local col = popup_helpers.shift_window_pos(total_width, width, opts.col, additional_col_offset)
+  local row = math.floor(
+    popup_helpers.shift_window_pos(total_height, height, opts.row, additional_row_offset)
+  )
+  local col =
+    math.floor(popup_helpers.shift_window_pos(total_width, width, opts.col, additional_col_offset))
 
   local result = {
     anchor = "NW",

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -142,8 +142,8 @@ M._make_provider_center_opts_with_hidden_previewer = function(opts, buffer_previ
     "buffer provider window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
     vim.inspect(opts)
   )
-  local row = popup_helpers.shift_window_pos(total_height, height, opts.row)
-  local col = popup_helpers.shift_window_pos(total_width, width, opts.col)
+  local row = math.floor(popup_helpers.shift_window_pos(total_height, height, opts.row))
+  local col = math.floor(popup_helpers.shift_window_pos(total_width, width, opts.col))
 
   local result = {
     anchor = "NW",

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -126,12 +126,12 @@ end
 M.shift_window_pos = function(total_size, size, shift, additional_offset)
   additional_offset = additional_offset or 0
   local left_size = total_size - size
-  local half_left_size = math.floor(left_size * 0.5)
+  local half_left_size = left_size * 0.5
   if shift >= 0 then
-    local offset = shift < 1 and math.floor(left_size * shift) or shift
+    local offset = shift < 1 and (left_size * shift) or shift
     return numbers.bound(half_left_size + offset + additional_offset, 0, left_size)
   else
-    local offset = shift > -1 and math.floor(left_size * shift) or shift
+    local offset = shift > -1 and (left_size * shift) or shift
     return numbers.bound(half_left_size + offset + additional_offset, 0, left_size)
   end
 end


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
