### PR TITLE
perf(live_grep): remove filename for buffer mode

### DIFF
--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -253,29 +253,29 @@ M.providers = {
 --- @return fun(line:string,context:fzfx.PipelineContext):string[]|nil
 M._make_previewer = function(opts)
   if tables.tbl_get(opts, "buffer") then
-    --- @param line string
-    --- @param context fzfx.PipelineContext
-    local function impl(line, context) end
-
-    return impl
+    return previewers_helper.preview_files_grep_no_filename
   else
     return previewers_helper.preview_files_grep
   end
 end
 
+local restricted_previewer = M._make_previewer()
+local unrestricted_previewer = M._make_previewer({ unrestricted = true })
+local buffer_previewer = M._make_previewer({ buffer = true })
+
 M.previewers = {
   restricted_mode = {
-    previewer = previewers_helper.preview_files_grep,
+    previewer = restricted_previewer,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
     previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },
   unrestricted_mode = {
-    previewer = previewers_helper.preview_files_grep,
+    previewer = unrestricted_previewer,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
     previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },
   buffer_mode = {
-    previewer = previewers_helper.preview_files_grep,
+    previewer = buffer_previewer,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
     previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -161,6 +161,7 @@ M._make_provider_rg = function(opts)
       if not bufpath then
         return nil
       end
+      table.insert(args, "-I") -- no filename
       table.insert(args, payload)
       table.insert(args, bufpath)
     else
@@ -195,6 +196,7 @@ M._make_provider_grep = function(opts)
       if not bufpath then
         return nil
       end
+      table.insert(args, "-h") -- no filename
       table.insert(args, payload)
       table.insert(args, bufpath)
     else

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -4,7 +4,6 @@ local paths = require("fzfx.commons.paths")
 
 local constants = require("fzfx.lib.constants")
 local bufs = require("fzfx.lib.bufs")
-local cmds = require("fzfx.lib.commands")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
 

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -21,8 +21,6 @@ local CommandFeedEnum = require("fzfx.schema").CommandFeedEnum
 
 local M = {}
 
-local INVALID_BUFFER_ERROR = "invalid buffer(%s)."
-
 M.command = {
   name = "FzfxLiveGrep",
   desc = "Live grep",
@@ -116,7 +114,7 @@ M.variants = {
 M._get_buf_path = function(bufnr)
   local bufpath = bufs.buf_is_valid(bufnr) and paths.reduce(vim.api.nvim_buf_get_name(bufnr)) or nil
   if strings.empty(bufpath) then
-    log.echo(LogLevels.INFO, INVALID_BUFFER_ERROR, vim.inspect(bufnr))
+    log.echo(LogLevels.INFO, "invalid buffer(%s).", vim.inspect(bufnr))
     return nil
   end
   return bufpath

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -2,7 +2,7 @@ local tables = require("fzfx.commons.tables")
 local strings = require("fzfx.commons.strings")
 local paths = require("fzfx.commons.paths")
 
-local consts = require("fzfx.lib.constants")
+local constants = require("fzfx.lib.constants")
 local bufs = require("fzfx.lib.bufs")
 local cmds = require("fzfx.lib.commands")
 local log = require("fzfx.lib.log")
@@ -210,9 +210,9 @@ end
 --- @param opts {unrestricted:boolean?,buffer:boolean?}?
 --- @return fun(query:string,context:fzfx.PipelineContext):string[]|nil
 M._make_provider = function(opts)
-  if consts.HAS_RG then
+  if constants.HAS_RG then
     return M._make_provider_rg(opts)
-  elseif consts.HAS_GREP then
+  elseif constants.HAS_GREP then
     return M._make_provider_grep(opts)
   else
     --- @return nil
@@ -249,26 +249,40 @@ M.providers = {
   },
 }
 
+--- @param opts {unrestricted:boolean?,buffer:boolean?}?
+--- @return fun(line:string,context:fzfx.PipelineContext):string[]|nil
+M._make_previewer = function(opts)
+  if tables.tbl_get(opts, "buffer") then
+    --- @param line string
+    --- @param context fzfx.PipelineContext
+    local function impl(line, context) end
+
+    return impl
+  else
+    return previewers_helper.preview_files_grep
+  end
+end
+
 M.previewers = {
   restricted_mode = {
     previewer = previewers_helper.preview_files_grep,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-    previewer_label = consts.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
+    previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },
   unrestricted_mode = {
     previewer = previewers_helper.preview_files_grep,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-    previewer_label = consts.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
+    previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },
   buffer_mode = {
     previewer = previewers_helper.preview_files_grep,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-    previewer_label = consts.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
+    previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },
 }
 
-local edit = consts.HAS_RG and actions_helper.edit_rg or actions_helper.edit_grep
-local setqflist = consts.HAS_RG and actions_helper.setqflist_rg or actions_helper.setqflist_grep
+local edit = constants.HAS_RG and actions_helper.edit_rg or actions_helper.edit_grep
+local setqflist = constants.HAS_RG and actions_helper.setqflist_rg or actions_helper.setqflist_grep
 
 M.actions = {
   ["esc"] = actions_helper.nop,

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -244,7 +244,7 @@ M.providers = {
     key = "ctrl-o",
     provider = buffer_provider,
     provider_type = ProviderTypeEnum.COMMAND_LIST,
-    provider_decorator = { module = "prepend_icon_grep", builtin = true },
+    -- provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
 }
 
@@ -276,7 +276,7 @@ M.previewers = {
   buffer_mode = {
     previewer = buffer_previewer,
     previewer_type = PreviewerTypeEnum.COMMAND_LIST,
-    previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
+    -- previewer_label = constants.HAS_RG and labels_helper.label_rg or labels_helper.label_grep,
   },
 }
 

--- a/lua/fzfx/commons/fileios.lua
+++ b/lua/fzfx/commons/fileios.lua
@@ -205,10 +205,14 @@ M.asyncreadfile = function(filename, on_complete, opts)
   opts = opts or { trim = false }
   opts.trim = type(opts.trim) == "boolean" and opts.trim or false
 
-  local open_result, open_err = uv.fs_open(filename, "r", 438, function(open_err, fd)
-    if open_err then
+  local open_result, open_err = uv.fs_open(filename, "r", 438, function(open_complete_err, fd)
+    if open_complete_err then
       error(
-        string.format("failed to open(r) file %s: %s", vim.inspect(filename), vim.inspect(open_err))
+        string.format(
+          "failed to complete open(r) file %s: %s",
+          vim.inspect(filename),
+          vim.inspect(open_complete_err)
+        )
       )
       return
     end

--- a/lua/fzfx/helper/parsers.lua
+++ b/lua/fzfx/helper/parsers.lua
@@ -145,6 +145,51 @@ M.parse_rg = function(line)
   return { filename = filename, lineno = lineno, column = column, text = text }
 end
 
+-- parse lines from rg with `-I` (--no-filename) option. looks like:
+-- ```
+-- 󰢱 31:2:  local conf = require("fzfx.config")
+-- 󰢱 57:13:  local colors = require("fzfx.commons.strings")
+-- ```
+--
+-- remove the prepend icon and returns **expanded** file path, line number, column number and text.
+--
+--- @param line string
+--- @return {lineno:integer,column:integer?,text:string}
+M.parse_rg_no_filename = function(line)
+  local lineno = nil
+  local column = nil
+  local text = nil
+
+  local first_colon_pos = strings.find(line, ":")
+  assert(
+    type(first_colon_pos) == "number",
+    string.format("failed to parse rg (no filename) lines:%s", vim.inspect(line))
+  )
+  lineno = line:sub(1, first_colon_pos - 1)
+
+  local second_colon_pos = strings.find(line, ":", first_colon_pos + 1)
+  if numbers.gt(second_colon_pos, 0) then
+    column = line:sub(first_colon_pos + 1, second_colon_pos - 1)
+    text = line:sub(second_colon_pos + 1)
+  else
+    -- if failed to found the second ':', then
+    -- 1. first try to parse right hands as 'column'
+    -- 2. if failed, treat them as 'text'
+    local rhs = line:sub(first_colon_pos + 1)
+    if tonumber(rhs) == nil then
+      text = rhs
+    else
+      column = tonumber(rhs)
+    end
+  end
+
+  lineno = tonumber(lineno)
+  column = tonumber(column)
+  text = text or ""
+
+  return { lineno = lineno, column = column, text = text }
+end
+
 -- parse lines from `git status --short`. looks like:
 -- ```
 --  M lua/fzfx/helper/parsers.lua

--- a/lua/fzfx/helper/parsers.lua
+++ b/lua/fzfx/helper/parsers.lua
@@ -91,6 +91,42 @@ M.parse_grep = function(line)
   return { filename = filename, lineno = lineno, text = text }
 end
 
+-- parse lines from grep without filename. looks like:
+-- ```
+-- 󰢱 31:  local conf = require("fzfx.config")
+-- 󰢱 57:  local colors = require("fzfx.commons.strings")
+-- ```
+--
+-- remove the prepend icon and returns **expanded** file path, line number and text.
+--
+--- @param line string
+--- @return {lineno:integer?,text:string}
+M.parse_grep_no_filename = function(line)
+  local lineno = nil
+  local text = nil
+
+  local first_colon_pos = strings.find(line, ":")
+  if numbers.gt(first_colon_pos, 0) then
+    lineno = line:sub(1, first_colon_pos - 1)
+    text = line:sub(first_colon_pos + 1)
+  else
+    -- if failed to found the first ':', then
+    -- 1. first try to parse right hands as 'lineno'
+    -- 2. if failed, treat them as 'text'
+    local rhs = line:sub(first_colon_pos + 1)
+    if tonumber(rhs) == nil then
+      text = rhs
+    else
+      lineno = tonumber(rhs)
+    end
+  end
+
+  lineno = tonumber(lineno)
+  text = text or ""
+
+  return { lineno = lineno, text = text }
+end
+
 -- parse lines from rg. looks like:
 -- ```
 -- 󰢱 bin/general/provider.lua:31:2:  local conf = require("fzfx.config")

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -112,8 +112,16 @@ end
 -- live grep {
 
 --- @param line string
+--- @param opts string
 --- @return string[]
 M.preview_files_grep = function(line)
+  local parsed = parsers_helper.parse_grep(line)
+  return M.preview_files(parsed.filename, parsed.lineno)
+end
+
+--- @param line string
+--- @return string[]
+M.preview_files_grep_no_filename = function(line)
   local parsed = parsers_helper.parse_grep(line)
   return M.preview_files(parsed.filename, parsed.lineno)
 end

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -124,7 +124,7 @@ end
 M.preview_files_grep_no_filename = function(line, context)
   local parsed = parsers_helper.parse_grep_no_filename(line)
   local filename = vim.api.nvim_buf_get_name(context.bufnr)
-  return M.preview_files(filename, parsed.lineno)
+  return M.preview_files_with_line_range(filename, parsed.lineno)
 end
 
 -- live grep }

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -112,7 +112,6 @@ end
 -- live grep {
 
 --- @param line string
---- @param opts string
 --- @return string[]
 M.preview_files_grep = function(line)
   local parsed = parsers_helper.parse_grep(line)
@@ -120,10 +119,12 @@ M.preview_files_grep = function(line)
 end
 
 --- @param line string
+--- @param context fzfx.PipelineContext
 --- @return string[]
-M.preview_files_grep_no_filename = function(line)
-  local parsed = parsers_helper.parse_grep(line)
-  return M.preview_files(parsed.filename, parsed.lineno)
+M.preview_files_grep_no_filename = function(line, context)
+  local parsed = parsers_helper.parse_grep_no_filename(line)
+  local filename = vim.api.nvim_buf_get_name(context.bufnr)
+  return M.preview_files(filename, parsed.lineno)
 end
 
 -- live grep }

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -181,7 +181,6 @@ end
 --- @param lineno integer
 --- @return string[]
 M.preview_files_with_line_range = function(filename, lineno)
-  local height = vim.api.nvim_win_get_height(0)
   if constants.HAS_BAT then
     local style, theme = M._bat_style_theme()
     return {


### PR DESCRIPTION
Resolve #611 .

# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
