### PR TITLE
perf(buffer previewer): reduce rendering latency on big file

### DIFF
--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -517,7 +517,7 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
         self:preview_file_contents(last_content, view)
       end, 10)
     end)
-  end, 20)
+  end, 10)
 end
 
 --- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
@@ -576,7 +576,7 @@ function BufferPopupWindow:preview_file_contents(file_content, content_view, on_
     end
 
     self:render_file_contents(file_content, content_view, on_complete)
-  end, 20)
+  end, 10)
 end
 
 --- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob
@@ -652,6 +652,9 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
         vim.inspect(content_view)
       )
     )
+
+    local SUPER_LARGE_FILE = LINES_COUNT > 1000
+    local LARGE_FILE = LINES_COUNT > 100
 
     local function set_buf_lines()
       vim.defer_fn(function()
@@ -740,10 +743,10 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
           do_complete(true)
           falsy_rendering()
         end
-      end, 10)
+      end, LINES_COUNT > 100 and math.max(string.len(tostring(LINES_COUNT)), 1) or 10)
     end
     set_buf_lines()
-  end, 20)
+  end, 10)
 end
 
 --- @param content_view fzfx.BufferPopupWindowPreviewContentView

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -746,7 +746,7 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
       end, LINES_COUNT > 50 and math.max(10 - string.len(tostring(LINES_COUNT)) * 2, 1) or 10)
     end
     set_buf_lines()
-  end, 10)
+  end, 20)
 end
 
 --- @param content_view fzfx.BufferPopupWindowPreviewContentView

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -743,7 +743,7 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
           do_complete(true)
           falsy_rendering()
         end
-      end, LINES_COUNT > 100 and math.max(string.len(tostring(LINES_COUNT)), 1) or 10)
+      end, LINES_COUNT > 50 and math.max(10 - string.len(tostring(LINES_COUNT)), 1) or 10)
     end
     set_buf_lines()
   end, 10)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -517,7 +517,7 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
         self:preview_file_contents(last_content, view)
       end, 10)
     end)
-  end, 10)
+  end, 20)
 end
 
 --- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
@@ -576,7 +576,7 @@ function BufferPopupWindow:preview_file_contents(file_content, content_view, on_
     end
 
     self:render_file_contents(file_content, content_view, on_complete)
-  end, 10)
+  end, 20)
 end
 
 --- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -635,13 +635,14 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
 
     local LINES = file_content.contents
     local LINES_COUNT = #LINES
+    local LARGE_FILE = LINES_COUNT > 50
     -- local TOP_LINE = content_view
     -- local BOTTOM_LINE = math.min(WIN_HEIGHT + TOP_LINE, LINES_COUNT)
     local FIRST_LINE = 1
     local LAST_LINE = LINES_COUNT
     local line_index = FIRST_LINE
     if line_step == nil then
-      line_step = LINES_COUNT > 50 and math.max(math.ceil(math.sqrt(LINES_COUNT)), 5) or 5
+      line_step = LARGE_FILE and math.max(math.ceil(math.sqrt(LINES_COUNT)), 5) or 5
     end
     log.debug(
       string.format(
@@ -652,9 +653,6 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
         vim.inspect(content_view)
       )
     )
-
-    local SUPER_LARGE_FILE = LINES_COUNT > 1000
-    local LARGE_FILE = LINES_COUNT > 100
 
     local function set_buf_lines()
       vim.defer_fn(function()
@@ -743,7 +741,7 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
           do_complete(true)
           falsy_rendering()
         end
-      end, LINES_COUNT > 50 and math.max(10 - string.len(tostring(LINES_COUNT)) * 2, 1) or 10)
+      end, LARGE_FILE and math.max(10 - string.len(tostring(LINES_COUNT)) * 2, 1) or 10)
     end
     set_buf_lines()
   end, 20)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -968,8 +968,8 @@ function BufferPopupWindow:scroll_by(percent, up)
     )
   )
 
-  if TOP_LINE == first_line and BOTTOM_LINE == last_line then
-    -- log.debug("|BufferPopupWindow:scroll_by| no change")
+  if TOP_LINE == view.top and BOTTOM_LINE == view.bottom then
+    log.debug("|BufferPopupWindow:scroll_by| no change")
     falsy_scrolling()
     return
   end

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -743,7 +743,7 @@ function BufferPopupWindow:render_file_contents(file_content, content_view, on_c
           do_complete(true)
           falsy_rendering()
         end
-      end, LINES_COUNT > 50 and math.max(10 - string.len(tostring(LINES_COUNT)), 1) or 10)
+      end, LINES_COUNT > 50 and math.max(10 - string.len(tostring(LINES_COUNT)) * 2, 1) or 10)
     end
     set_buf_lines()
   end, 10)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
