### PR TITLE
feat(buf live grep): use buffer previewer

### DIFF
--- a/lua/fzfx/cfg/buf_live_grep.lua
+++ b/lua/fzfx/cfg/buf_live_grep.lua
@@ -2,6 +2,7 @@ local str = require("fzfx.commons.str")
 local path = require("fzfx.commons.path")
 
 local constants = require("fzfx.lib.constants")
+local switches = require("fzfx.lib.switches")
 local bufs = require("fzfx.lib.bufs")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
@@ -145,9 +146,25 @@ M.providers = {
   provider_type = ProviderTypeEnum.COMMAND_LIST,
 }
 
+-- if you want to use fzf-builtin previewer with bat, please use below configs:
+--
+-- previewer = previewers_helper.preview_files_grep
+-- previewer_type = PreviewerTypeEnum.COMMAND_LIST
+
+-- if you want to use nvim buffer previewer, please use below configs:
+--
+-- previewer = previewers_helper.buffer_preview_files_grep
+-- previewer_type = PreviewerTypeEnum.BUFFER_FILE
+
+local previewer = switches.buffer_previewer_disabled()
+    and previewers_helper.preview_files_grep_no_filename
+  or previewers_helper.buffer_preview_files_grep_no_filename
+local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
+  or PreviewerTypeEnum.BUFFER_FILE
+
 M.previewers = {
-  previewer = previewers_helper.preview_files_grep_no_filename,
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+  previewer = previewer,
+  previewer_type = previewer_type,
   previewer_label = constants.HAS_RG and labels_helper.label_rg_no_filename
     or labels_helper.label_grep_no_filename,
 }

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -103,7 +103,7 @@ end
 
 -- preview files with nvim buffer.
 --- @param line string
---- @return table
+--- @return {filename:string}
 M.buffer_preview_files_find = function(line)
   local parsed = parsers_helper.parse_find(line)
   return { filename = parsed.filename }

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -121,6 +121,13 @@ M.preview_files_grep = function(line)
 end
 
 --- @param line string
+--- @return table
+M.buffer_preview_files_grep = function(line)
+  local parsed = parsers_helper.parse_grep(line)
+  return { filename = parsed.filename, lineno = parsed.lineno }
+end
+
+--- @param line string
 --- @param context fzfx.PipelineContext
 --- @return string[]|nil
 M.preview_files_grep_no_filename = function(line, context)
@@ -135,10 +142,17 @@ M.preview_files_grep_no_filename = function(line, context)
 end
 
 --- @param line string
---- @return table
-M.buffer_preview_files_grep = function(line)
-  local parsed = parsers_helper.parse_grep(line)
-  return { filename = parsed.filename, lineno = parsed.lineno }
+--- @param context fzfx.PipelineContext
+--- @return string[]|nil
+M.buffer_preview_files_grep_no_filename = function(line, context)
+  local bufnr = tbl.tbl_get(context, "bufnr")
+  if not num.ge(bufnr, 0) or not vim.api.nvim_buf_is_valid(bufnr) then
+    return nil
+  end
+  local filename = vim.api.nvim_buf_get_name(bufnr)
+  filename = path.normalize(filename, { double_backslash = true, expand = true })
+  local parsed = parsers_helper.parse_grep_no_filename(line)
+  return { filename = filename, lineno = parsed.lineno }
 end
 
 -- live grep }

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -121,7 +121,7 @@ M.preview_files_grep = function(line)
 end
 
 --- @param line string
---- @return table
+--- @return {filename:string,lineno:integer?}?
 M.buffer_preview_files_grep = function(line)
   local parsed = parsers_helper.parse_grep(line)
   return { filename = parsed.filename, lineno = parsed.lineno }
@@ -143,7 +143,7 @@ end
 
 --- @param line string
 --- @param context fzfx.PipelineContext
---- @return string[]|nil
+--- @return {filename:string,lineno:integer?}?
 M.buffer_preview_files_grep_no_filename = function(line, context)
   local bufnr = tbl.tbl_get(context, "bufnr")
   if not num.ge(bufnr, 0) or not vim.api.nvim_buf_is_valid(bufnr) then

--- a/spec/helper/previewers_spec.lua
+++ b/spec/helper/previewers_spec.lua
@@ -192,24 +192,18 @@ describe("helper.previewers", function()
         "3:hello",
         "4:  local i = 1",
       }
+      local ctx = make_context()
+      local filename = vim.api.nvim_buf_get_name(ctx.bufnr)
+      filename = path.normalize(filename, { double_backslash = true, expand = true })
+
       for _, line in ipairs(lines) do
-        local ctx = make_context()
         local actual = previewers.buffer_preview_files_grep_no_filename(line, ctx)
-        local expect =
-          path.normalize(str.split(line, ":")[1], { double_backslash = true, expand = true })
-        print(string.format("normalize:%s\n", vim.inspect(expect)))
+        print(string.format("filename:%s\n", vim.inspect(filename)))
         print(string.format("file previewer grep:%s\n", vim.inspect(actual)))
-        if actual[1] == constants.BAT then
-          assert_eq(actual[1], constants.BAT)
-          assert_eq(actual[2], "--style=numbers,changes")
-          assert_true(str.startswith(actual[3], "--theme="))
-          assert_eq(actual[4], "--color=always")
-          assert_eq(actual[5], "--pager=never")
-          assert_true(str.startswith(actual[6], "--highlight-line"))
-          assert_eq(actual[7], "--line-range")
-          assert_eq(actual[9], "--")
-        else
-          assert_eq(actual[1], "cat")
+        local splits = str.split(line, ":")
+        if actual then
+          assert_eq(actual.filename, filename)
+          assert_eq(actual.lineno, tonumber(splits[1]))
         end
       end
     end)

--- a/spec/helper/previewers_spec.lua
+++ b/spec/helper/previewers_spec.lua
@@ -184,6 +184,37 @@ describe("helper.previewers", function()
     end)
   end)
 
+  describe("[buffer_preview_files_grep_no_filename]", function()
+    it("test", function()
+      local lines = {
+        "1",
+        "2:1",
+        "3:hello",
+        "4:  local i = 1",
+      }
+      for _, line in ipairs(lines) do
+        local ctx = make_context()
+        local actual = previewers.buffer_preview_files_grep_no_filename(line, ctx)
+        local expect =
+          path.normalize(str.split(line, ":")[1], { double_backslash = true, expand = true })
+        print(string.format("normalize:%s\n", vim.inspect(expect)))
+        print(string.format("file previewer grep:%s\n", vim.inspect(actual)))
+        if actual[1] == constants.BAT then
+          assert_eq(actual[1], constants.BAT)
+          assert_eq(actual[2], "--style=numbers,changes")
+          assert_true(str.startswith(actual[3], "--theme="))
+          assert_eq(actual[4], "--color=always")
+          assert_eq(actual[5], "--pager=never")
+          assert_true(str.startswith(actual[6], "--highlight-line"))
+          assert_eq(actual[7], "--line-range")
+          assert_eq(actual[9], "--")
+        else
+          assert_eq(actual[1], "cat")
+        end
+      end
+    end)
+  end)
+
   describe("[get_preview_window_width]", function()
     it("test", function()
       local actual = previewers.get_preview_window_width()


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
