### PR TITLE
refactor(popup): refactor cursor relative window layout

### DIFF
--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -14,12 +14,17 @@ local FLOAT_WIN_DEFAULT_ZINDEX = 60
 local FLOAT_WIN_DEFAULT_STYLE = "minimal"
 
 --- @alias fzfx.BufferFilePreviewerOpts {fzf_preview_window_opts:fzfx.FzfPreviewWindowOpts,fzf_border_opts:string}
+--- @param win_opts fzfx.WindowOpts
+--- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param relative_winnr integer?
+--- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
+M._make_cursor_opts = function(win_opts, buffer_previewer_opts, relative_winnr) end
 
 --- @param win_opts fzfx.WindowOpts
 --- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
 --- @param relative_winnr integer?
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
-M.make_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
+M._make_center_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
   local opts = vim.deepcopy(win_opts)
   opts.relative = opts.relative or "editor"
   local layout = popup_helpers.make_layout(opts, buffer_previewer_opts.fzf_preview_window_opts)
@@ -68,6 +73,22 @@ M.make_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
   end
   -- log.debug("|make_opts| result:%s", vim.inspect(result))
   return result
+end
+
+--- @param win_opts fzfx.WindowOpts
+--- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param relative_winnr integer?
+--- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
+M.make_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
+  local opts = vim.deepcopy(win_opts)
+  opts.relative = opts.relative or "editor"
+  log.ensure(
+    opts.relative == "cursor" or opts.relative == "editor" or opts.relative == "win",
+    string.format("window relative (%s) must be editor/win/cursor", vim.inspect(opts))
+  )
+  return opts.relative == "cursor"
+      and M._make_cursor_opts(opts, buffer_previewer_opts, relative_winnr)
+    or M._make_center_opts(opts, buffer_previewer_opts, relative_winnr)
 end
 
 -- BufferPopupWindow {

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -19,10 +19,52 @@ local FLOAT_WIN_DEFAULT_STYLE = "minimal"
 --- @param relative_winnr integer?
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_cursor_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
-  local layout = popup_helpers.make_layout(win_opts, buffer_previewer_opts.fzf_preview_window_opts)
+  local layout =
+    popup_helpers.make_center_layout(win_opts, buffer_previewer_opts.fzf_preview_window_opts)
   local relative = win_opts.relative
   local border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
     or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+
+  local result = {
+    anchor = "NW",
+    relative = relative,
+    width = layout.width,
+    height = layout.height,
+    row = layout.start_row,
+    col = layout.start_col,
+    style = FLOAT_WIN_DEFAULT_STYLE,
+    border = border,
+    zindex = FLOAT_WIN_DEFAULT_ZINDEX,
+  }
+  result.provider = {
+    anchor = "NW",
+    relative = relative,
+    width = layout.provider.width,
+    height = layout.provider.height,
+    row = layout.provider.start_row,
+    col = layout.provider.start_col,
+    style = FLOAT_WIN_DEFAULT_STYLE,
+    border = border,
+    zindex = FLOAT_WIN_DEFAULT_ZINDEX,
+  }
+  result.previewer = {
+    anchor = "NW",
+    relative = relative,
+    width = layout.previewer.width,
+    height = layout.previewer.height,
+    row = layout.previewer.start_row,
+    col = layout.previewer.start_col,
+    style = FLOAT_WIN_DEFAULT_STYLE,
+    border = border,
+    zindex = FLOAT_WIN_DEFAULT_ZINDEX,
+  }
+
+  if relative ~= "editor" and type(relative_winnr) == "number" then
+    result.provider.win = relative_winnr
+    result.previewer.win = relative_winnr
+  end
+  -- log.debug("|make_opts| result:%s", vim.inspect(result))
+  return result
 end
 
 --- @param win_opts fzfx.WindowOpts
@@ -30,7 +72,8 @@ end
 --- @param relative_winnr integer?
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_center_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
-  local layout = popup_helpers.make_layout(win_opts, buffer_previewer_opts.fzf_preview_window_opts)
+  local layout =
+    popup_helpers.make_center_layout(win_opts, buffer_previewer_opts.fzf_preview_window_opts)
   local relative = win_opts.relative
   local border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
     or fzf_helpers.FZF_DEFAULT_BORDER_OPTS

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -18,18 +18,20 @@ local FLOAT_WIN_DEFAULT_STYLE = "minimal"
 --- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
 --- @param relative_winnr integer?
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
-M._make_cursor_opts = function(win_opts, buffer_previewer_opts, relative_winnr) end
+M._make_cursor_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
+  local layout = popup_helpers.make_layout(win_opts, buffer_previewer_opts.fzf_preview_window_opts)
+  local relative = win_opts.relative
+  local border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
+    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+end
 
 --- @param win_opts fzfx.WindowOpts
 --- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
 --- @param relative_winnr integer?
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_center_opts = function(win_opts, buffer_previewer_opts, relative_winnr)
-  local opts = vim.deepcopy(win_opts)
-  opts.relative = opts.relative or "editor"
-  local layout = popup_helpers.make_layout(opts, buffer_previewer_opts.fzf_preview_window_opts)
-
-  local relative = opts.relative
+  local layout = popup_helpers.make_layout(win_opts, buffer_previewer_opts.fzf_preview_window_opts)
+  local relative = win_opts.relative
   local border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
     or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 

--- a/lua/fzfx/detail/popup/fzf_popup_window.lua
+++ b/lua/fzfx/detail/popup/fzf_popup_window.lua
@@ -13,7 +13,7 @@ local FLOAT_WIN_DEFAULT_ZINDEX = 60
 M._make_cursor_opts = function(win_opts)
   local opts = vim.deepcopy(win_opts)
   opts.relative = opts.relative or "cursor"
-  local layout = popup_helpers.make_center_layout(opts)
+  local layout = popup_helpers.make_cursor_layout(opts)
   log.debug("|_make_cursor_opts| layout:" .. vim.inspect(layout))
 
   return {

--- a/lua/fzfx/detail/popup/fzf_popup_window.lua
+++ b/lua/fzfx/detail/popup/fzf_popup_window.lua
@@ -13,7 +13,7 @@ local FLOAT_WIN_DEFAULT_ZINDEX = 60
 M._make_cursor_opts = function(win_opts)
   local opts = vim.deepcopy(win_opts)
   opts.relative = opts.relative or "cursor"
-  local layout = popup_helpers.make_layout(opts)
+  local layout = popup_helpers.make_center_layout(opts)
   log.debug("|_make_cursor_opts| layout:" .. vim.inspect(layout))
 
   return {
@@ -34,7 +34,7 @@ end
 M._make_center_opts = function(win_opts)
   local opts = vim.deepcopy(win_opts)
   opts.relative = opts.relative or "editor"
-  local layout = popup_helpers.make_layout(opts)
+  local layout = popup_helpers.make_center_layout(opts)
   log.debug("|_make_center_opts| layout:%s" .. vim.inspect(layout))
 
   return {

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -129,15 +129,15 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
   log.ensure(
     (win_opts.row >= -0.5 and win_opts.row <= 0.5) or win_opts.row <= -1 or win_opts.row >= 1,
     string.format(
-      "buffer provider window row (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
-      vim.inspect(win_opts)
+      "popup window row (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
+      vim.inspect(win_opts.row)
     )
   )
   log.ensure(
     (win_opts.col >= -0.5 and win_opts.col <= 0.5) or win_opts.col <= -1 or win_opts.col >= 1,
     string.format(
-      "buffer provider window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
-      vim.inspect(win_opts)
+      "popup window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
+      vim.inspect(win_opts.col)
     )
   )
 
@@ -227,15 +227,15 @@ M.make_cursor_layout = function(win_opts, fzf_preview_window_opts)
   log.ensure(
     (win_opts.row >= -0.5 and win_opts.row <= 0.5) or win_opts.row <= -1 or win_opts.row >= 1,
     string.format(
-      "buffer provider window row (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
-      vim.inspect(win_opts)
+      "popup window row (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
+      vim.inspect(win_opts.row)
     )
   )
   log.ensure(
     (win_opts.col >= -0.5 and win_opts.col <= 0.5) or win_opts.col <= -1 or win_opts.col >= 1,
     string.format(
-      "buffer provider window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
-      vim.inspect(win_opts)
+      "popup window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
+      vim.inspect(win_opts.col)
     )
   )
 

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -1,4 +1,5 @@
 local num = require("fzfx.commons.num")
+local tbl = require("fzfx.commons.tbl")
 
 local constants = require("fzfx.lib.constants")
 local log = require("fzfx.lib.log")
@@ -199,6 +200,8 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
   local end_col = bound_col(math.floor(center_col + (width / 2)))
 
   local result = {
+    total_height = total_height,
+    total_width = total_width,
     height = height,
     width = width,
     start_row = start_row,
@@ -207,6 +210,123 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
     end_col = end_col,
   }
   -- log.debug("|get_layout| result-1:%s", vim.inspect(result))
+
+  local internal_layout = M._make_internal_layout(result, fzf_preview_window_opts)
+  result.provider = tbl.tbl_get(internal_layout, "provider")
+  result.previewer = tbl.tbl_get(internal_layout, "previewer")
+
+  return result
+end
+
+--- @param win_opts {relative:"editor"|"win"|"cursor",height:number,width:number,row:number,col:number}
+--- @param fzf_preview_window_opts fzfx.FzfPreviewWindowOpts?
+--- @return {height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer,provider:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?,previewer:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?}
+M.make_cursor_layout = function(win_opts, fzf_preview_window_opts)
+  local total_width = win_opts.relative == "editor" and vim.o.columns
+    or vim.api.nvim_win_get_width(0)
+  local total_height = win_opts.relative == "editor" and vim.o.lines
+    or vim.api.nvim_win_get_height(0)
+
+  local width = num.bound(
+    win_opts.width > 1 and win_opts.width or math.floor(win_opts.width * total_width),
+    1,
+    total_width
+  )
+  local height = num.bound(
+    win_opts.height > 1 and win_opts.height or math.floor(win_opts.height * total_height),
+    1,
+    total_height
+  )
+
+  log.ensure(
+    (win_opts.row >= -0.5 and win_opts.row <= 0.5) or win_opts.row <= -1 or win_opts.row >= 1,
+    string.format(
+      "buffer provider window row (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
+      vim.inspect(win_opts)
+    )
+  )
+  log.ensure(
+    (win_opts.col >= -0.5 and win_opts.col <= 0.5) or win_opts.col <= -1 or win_opts.col >= 1,
+    string.format(
+      "buffer provider window col (%s) opts must in range [-0.5, 0.5] or (-inf, -1] or [1, +inf]",
+      vim.inspect(win_opts)
+    )
+  )
+
+  --- @param v number
+  --- @return number
+  local function bound_row(v)
+    return num.bound(v, 0, total_height - 1)
+  end
+
+  --- @param v number
+  --- @return number
+  local function bound_col(v)
+    return num.bound(v, 0, total_width - 1)
+  end
+
+  --- @param v number
+  --- @return number
+  local function bound_height(v)
+    return num.bound(v, 1, height)
+  end
+
+  --- @param v number
+  --- @return number
+  local function bound_width(v)
+    return num.bound(v, 1, width)
+  end
+
+  local start_row = bound_row(win_opts.row)
+  local end_row = bound_row(start_row + height)
+  local start_col = bound_col(win_opts.col)
+  local end_col = bound_col(start_col + width)
+
+  local result = {
+    total_height = total_height,
+    total_width = total_width,
+    height = height,
+    width = width,
+    start_row = start_row,
+    end_row = end_row,
+    start_col = start_col,
+    end_col = end_col,
+  }
+
+  local internal_layout = M._make_internal_layout(result, fzf_preview_window_opts)
+  result.provider = tbl.tbl_get(internal_layout, "provider")
+  result.previewer = tbl.tbl_get(internal_layout, "previewer")
+
+  return result
+end
+
+--- @param base_layout {total_height:integer,total_width:integer,height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}
+--- @param fzf_preview_window_opts fzfx.FzfPreviewWindowOpts?
+--- @return {provider:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?,previewer:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?}?
+M._make_internal_layout = function(base_layout, fzf_preview_window_opts)
+  --- @param v number
+  --- @return number
+  local function bound_row(v)
+    return num.bound(v, 0, base_layout.total_height - 1)
+  end
+
+  --- @param v number
+  --- @return number
+  local function bound_col(v)
+    return num.bound(v, 0, base_layout.total_width - 1)
+  end
+
+  --- @param v number
+  --- @return number
+  local function bound_height(v)
+    return num.bound(v, 1, base_layout.height)
+  end
+
+  --- @param v number
+  --- @return number
+  local function bound_width(v)
+    return num.bound(v, 1, base_layout.width)
+  end
 
   if type(fzf_preview_window_opts) == "table" then
     local provider_layout = {}
@@ -217,13 +337,13 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
     then
       if fzf_preview_window_opts.size_is_percent then
         previewer_layout.width =
-          bound_width(math.floor((width / 100 * fzf_preview_window_opts.size) - 1))
+          bound_width(math.floor((base_layout.width / 100 * fzf_preview_window_opts.size) - 1))
       else
         previewer_layout.width = bound_width(fzf_preview_window_opts.size - 1)
       end
-      provider_layout.width = bound_width(width - previewer_layout.width - 2)
-      provider_layout.height = height
-      previewer_layout.height = height
+      provider_layout.width = bound_width(base_layout.width - previewer_layout.width - 2)
+      provider_layout.height = base_layout.height
+      previewer_layout.height = base_layout.height
 
       -- the layout looks like
       --
@@ -232,34 +352,34 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
       -- |      |       |
 
       if fzf_preview_window_opts.position == "left" then
-        previewer_layout.start_col = start_col
-        previewer_layout.end_col = bound_col(start_col + previewer_layout.width)
-        provider_layout.start_col = bound_col(end_col - provider_layout.width)
-        provider_layout.end_col = end_col
+        previewer_layout.start_col = base_layout.start_col
+        previewer_layout.end_col = bound_col(base_layout.start_col + previewer_layout.width)
+        provider_layout.start_col = bound_col(base_layout.end_col - provider_layout.width)
+        provider_layout.end_col = base_layout.end_col
       else
         -- | provider | previewer |
-        provider_layout.start_col = start_col
-        provider_layout.end_col = bound_col(start_col + provider_layout.width)
-        previewer_layout.start_col = bound_col(end_col - previewer_layout.width)
-        previewer_layout.end_col = end_col
+        provider_layout.start_col = base_layout.start_col
+        provider_layout.end_col = bound_col(base_layout.start_col + provider_layout.width)
+        previewer_layout.start_col = bound_col(base_layout.end_col - previewer_layout.width)
+        previewer_layout.end_col = base_layout.end_col
       end
-      provider_layout.start_row = start_row
-      provider_layout.end_row = end_row
-      previewer_layout.start_row = start_row
-      previewer_layout.end_row = end_row
+      provider_layout.start_row = base_layout.start_row
+      provider_layout.end_row = base_layout.end_row
+      previewer_layout.start_row = base_layout.start_row
+      previewer_layout.end_row = base_layout.end_row
     elseif
       fzf_preview_window_opts
       and (fzf_preview_window_opts.position == "up" or fzf_preview_window_opts.position == "down")
     then
       if fzf_preview_window_opts.size_is_percent then
         previewer_layout.height =
-          bound_height(math.floor(height / 100 * fzf_preview_window_opts.size) - 1)
+          bound_height(math.floor(base_layout.height / 100 * fzf_preview_window_opts.size) - 1)
       else
         previewer_layout.height = bound_height(fzf_preview_window_opts.size - 1)
       end
-      provider_layout.height = bound_height(height - previewer_layout.height - 2)
-      provider_layout.width = width
-      previewer_layout.width = width
+      provider_layout.height = bound_height(base_layout.height - previewer_layout.height - 2)
+      provider_layout.width = base_layout.width
+      previewer_layout.width = base_layout.width
 
       -- the layout looks like
       --
@@ -270,27 +390,26 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
       -- ---------
 
       if fzf_preview_window_opts.position == "up" then
-        previewer_layout.start_row = start_row
-        previewer_layout.end_row = bound_row(start_row + previewer_layout.height)
-        provider_layout.start_row = bound_row(end_row - provider_layout.height)
-        provider_layout.end_row = end_row
+        previewer_layout.start_row = base_layout.start_row
+        previewer_layout.end_row = bound_row(base_layout.start_row + previewer_layout.height)
+        provider_layout.start_row = bound_row(base_layout.end_row - provider_layout.height)
+        provider_layout.end_row = base_layout.end_row
       else
-        provider_layout.start_row = start_row
-        provider_layout.end_row = bound_row(start_row + provider_layout.height)
-        previewer_layout.start_row = bound_row(end_row - previewer_layout.height)
-        previewer_layout.end_row = end_row
+        provider_layout.start_row = base_layout.start_row
+        provider_layout.end_row = bound_row(base_layout.start_row + provider_layout.height)
+        previewer_layout.start_row = bound_row(base_layout.end_row - previewer_layout.height)
+        previewer_layout.end_row = base_layout.end_row
       end
-      provider_layout.start_col = start_col
-      provider_layout.end_col = end_col
-      previewer_layout.start_col = start_col
-      previewer_layout.end_col = end_col
+      provider_layout.start_col = base_layout.start_col
+      provider_layout.end_col = base_layout.end_col
+      previewer_layout.start_col = base_layout.start_col
+      previewer_layout.end_col = base_layout.end_col
     end
-    result.provider = provider_layout
-    result.previewer = previewer_layout
     -- log.debug("|get_layout| result-2:%s", vim.inspect(result))
+    return { provider = provider_layout, previewer = previewer_layout }
   end
 
-  return result
+  return nil
 end
 
 return M

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -108,7 +108,7 @@ M.ShellOptsContext = ShellOptsContext
 --- @param win_opts {relative:"editor"|"win"|"cursor",height:number,width:number,row:number,col:number}
 --- @param fzf_preview_window_opts fzfx.FzfPreviewWindowOpts?
 --- @return {height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer,provider:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?,previewer:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?}
-M.make_layout = function(win_opts, fzf_preview_window_opts)
+M.make_center_layout = function(win_opts, fzf_preview_window_opts)
   local total_width = win_opts.relative == "editor" and vim.o.columns
     or vim.api.nvim_win_get_width(0)
   local total_height = win_opts.relative == "editor" and vim.o.lines

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -182,18 +182,6 @@ M.make_center_layout = function(win_opts, fzf_preview_window_opts)
     return num.bound(v, 0, total_width - 1)
   end
 
-  --- @param v number
-  --- @return number
-  local function bound_height(v)
-    return num.bound(v, 1, height)
-  end
-
-  --- @param v number
-  --- @return number
-  local function bound_width(v)
-    return num.bound(v, 1, width)
-  end
-
   local start_row = bound_row(math.floor(center_row - (height / 2)))
   local end_row = bound_row(math.floor(center_row + (height / 2)))
   local start_col = bound_col(math.floor(center_col - (width / 2)))
@@ -222,10 +210,8 @@ end
 --- @param fzf_preview_window_opts fzfx.FzfPreviewWindowOpts?
 --- @return {height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer,provider:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?,previewer:{height:integer,width:integer,start_row:integer,end_row:integer,start_col:integer,end_col:integer}?}
 M.make_cursor_layout = function(win_opts, fzf_preview_window_opts)
-  local total_width = win_opts.relative == "editor" and vim.o.columns
-    or vim.api.nvim_win_get_width(0)
-  local total_height = win_opts.relative == "editor" and vim.o.lines
-    or vim.api.nvim_win_get_height(0)
+  local total_width = vim.api.nvim_win_get_width(0)
+  local total_height = vim.api.nvim_win_get_height(0)
 
   local width = num.bound(
     win_opts.width > 1 and win_opts.width or math.floor(win_opts.width * total_width),
@@ -263,18 +249,6 @@ M.make_cursor_layout = function(win_opts, fzf_preview_window_opts)
   --- @return number
   local function bound_col(v)
     return num.bound(v, 0, total_width - 1)
-  end
-
-  --- @param v number
-  --- @return number
-  local function bound_height(v)
-    return num.bound(v, 1, height)
-  end
-
-  --- @param v number
-  --- @return number
-  local function bound_width(v)
-    return num.bound(v, 1, width)
   end
 
   local start_row = bound_row(win_opts.row)

--- a/minimal_init/buffers_autosize_init.lua
+++ b/minimal_init/buffers_autosize_init.lua
@@ -1,0 +1,72 @@
+vim.o.number = true
+vim.o.autoread = true
+vim.o.autowrite = true
+vim.o.swapfile = false
+vim.o.confirm = true
+vim.o.termguicolors = true
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable", -- latest stable release
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup({
+  {
+    "linrongbin16/fzfx.nvim",
+    dev = true,
+    opts = {
+      buffers = {
+        fzf_opts = {
+          "--info=hidden --header= --padding=0",
+        },
+        win_opts = function()
+          local bufs_fn_len = {}
+          local max_len = 0
+          for _, buf_nr in ipairs(vim.api.nvim_list_bufs()) do
+            if vim.api.nvim_buf_is_valid(buf_nr) then
+              local buf = vim.api.nvim_buf_get_name(buf_nr)
+              local buf_nm = vim.fn.expand(buf)
+              if buf_nm ~= "" then
+                buf_nm = vim.fn.substitute(buf_nm, vim.fn.getcwd(), "", "g")
+                buf_nm = vim.fn.substitute(buf_nm, vim.fn.expand("$HOME"), "~", "g")
+                buf_nm = vim.fs.basename(buf_nm)
+                table.insert(bufs_fn_len, string.len(buf_nm))
+              end
+            end
+          end
+          for _, len in ipairs(bufs_fn_len) do
+            max_len = math.max(max_len, len)
+          end
+          return {
+            height = #bufs_fn_len + 4,
+            width = max_len + 7,
+            relative = "win",
+            zindex = 51,
+          }
+        end,
+      },
+    },
+    dependencies = {
+      "folke/tokyonight.nvim",
+      "nvim-tree/nvim-web-devicons",
+      {
+        "junegunn/fzf",
+        build = function()
+          vim.fn["fzf#install"]()
+        end,
+      },
+    },
+  },
+}, { dev = { path = "~/github/linrongbin16" }, defaults = { lazy = false } })
+
+require("lazy").sync({ wait = true, show = false })
+
+vim.cmd([[colorscheme tokyonight]])

--- a/minimal_init/fzf_color_opts_init.lua
+++ b/minimal_init/fzf_color_opts_init.lua
@@ -3,7 +3,6 @@ vim.o.autoread = true
 vim.o.autowrite = true
 vim.o.swapfile = false
 vim.o.confirm = true
-vim.o.termguicolors = true
 
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.loop.fs_stat(lazypath) then
@@ -20,30 +19,15 @@ vim.opt.rtp:prepend(lazypath)
 
 require("lazy").setup({
   {
-    "linrongbin16/fzfx.nvim",
+    dir = "linrongbin16/fzfx.nvim",
     dev = true,
     opts = {
-      override_fzf_opts = {
-        { "--preview-window", "top,75%" },
-      },
-      buffers = {
-        fzf_opts = {
-          { "--prompt", "Buffers > " },
-          { "--delimiter", ":" },
-          { "--preview-window", "top,75%,+{2}-/2" },
-        },
-      },
-      files = {
-        fzf_opts = {
-          { "--prompt", "Files > " },
-          { "--delimiter", ":" },
-          { "--preview-window", "top,50%,+{2}-/2" },
-        },
+      icon = {
+        enable = false,
       },
     },
     dependencies = {
       "folke/tokyonight.nvim",
-      "nvim-tree/nvim-web-devicons",
       {
         "junegunn/fzf",
         build = function()

--- a/minimal_init/preview_window_opts_init.lua
+++ b/minimal_init/preview_window_opts_init.lua
@@ -1,0 +1,65 @@
+vim.o.number = true
+vim.o.autoread = true
+vim.o.autowrite = true
+vim.o.swapfile = false
+vim.o.confirm = true
+vim.o.termguicolors = true
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable", -- latest stable release
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+local opts = {
+  defaults = { lazy = false },
+}
+
+require("lazy").setup({
+  {
+    dir = "~/github/linrongbin16/fzfx.nvim",
+    dev = true,
+    opts = {
+      override_fzf_opts = {
+        { "--preview-window", "top,75%" },
+      },
+      buffers = {
+        fzf_opts = {
+          { "--prompt", "Buffers > " },
+          { "--delimiter", ":" },
+          { "--preview-window", "top,75%,+{2}-/2" },
+        },
+      },
+      files = {
+        fzf_opts = {
+          { "--prompt", "Files > " },
+          { "--delimiter", ":" },
+          { "--preview-window", "top,50%,+{2}-/2" },
+        },
+      },
+    },
+    dependencies = {
+      "folke/tokyonight.nvim",
+      "nvim-tree/nvim-web-devicons",
+      {
+        "junegunn/fzf",
+        build = function()
+          vim.fn["fzf#install"]()
+        end,
+      },
+    },
+  },
+}, { dev = { path = "~/github/linrongbin16" }, defaults = { lazy = false } })
+
+require("lazy").sync({ wait = true, show = false })
+
+vim.cmd([[
+colorscheme tokyonight
+]])

--- a/spec/detail/popup/popup_helpers_spec.lua
+++ b/spec/detail/popup/popup_helpers_spec.lua
@@ -56,11 +56,11 @@ describe("detail.popup.popup_helpers", function()
       ctx:restore()
     end)
   end)
-  for i = min_test_height, max_test_height, 2 do
-    for j = min_test_width, max_test_width, 3 do
-      test_height = i
-      test_width = j
-      describe("[make_center_layout]", function()
+  describe("[make_center_layout]", function()
+    for i = min_test_height, max_test_height, 2 do
+      for j = min_test_width, max_test_width, 3 do
+        test_height = i
+        test_width = j
         local function isclose(a, b)
           if github_actions then
             return math.abs(math.abs(a) - math.abs(b)) <= 3.5
@@ -312,7 +312,7 @@ describe("detail.popup.popup_helpers", function()
           assert_eq(actual.previewer.start_col, actual.start_col)
           assert_eq(actual.previewer.end_col, actual.end_col)
         end)
-      end)
+      end
     end
-  end
+  end)
 end)

--- a/spec/detail/popup/popup_helpers_spec.lua
+++ b/spec/detail/popup/popup_helpers_spec.lua
@@ -315,4 +315,263 @@ describe("detail.popup.popup_helpers", function()
       end
     end
   end)
+  describe("[make_cursor_layout]", function()
+    for i = min_test_height, max_test_height, 2 do
+      for j = min_test_width, max_test_width, 3 do
+        test_height = i
+        test_width = j
+        local function isclose(a, b)
+          if github_actions then
+            return math.abs(math.abs(a) - math.abs(b)) <= 3.5
+          else
+            return math.abs(a - b) <= 2.5
+          end
+        end
+
+        it("test1 without fzf_preview_window_opts", function()
+          local actual = popup_helpers.make_center_layout({
+            relative = "editor",
+            height = 0.75,
+            width = 0.85,
+            row = 0,
+            col = 0,
+          })
+          print(string.format("make_layout-1:%s\n", vim.inspect(actual)))
+          local total_width = vim.o.columns
+          local total_height = vim.o.lines
+          local width = total_width * 0.85
+          local height = total_height * 0.75
+          local center_row = total_height / 2
+          local center_col = total_width / 2
+          assert_true(isclose(actual.width, width))
+          assert_true(isclose(actual.height, height))
+          assert_true(isclose(2 * (center_row - actual.start_row), height))
+          assert_true(isclose(2 * (actual.end_row - center_row), height))
+          assert_true(isclose(2 * (center_col - actual.start_col), width))
+          assert_true(isclose(2 * (actual.end_col - center_col), width))
+        end)
+        it("test2 without fzf_preview_window_opts", function()
+          local actual = popup_helpers.make_center_layout({
+            relative = "win",
+            height = 0.47,
+            width = 0.71,
+            row = 0,
+            col = 0,
+          })
+          local total_height = vim.api.nvim_win_get_height(0)
+          local total_width = vim.api.nvim_win_get_width(0)
+          local width = total_width * 0.71
+          local height = total_height * 0.47
+          local center_row = total_height / 2
+          local center_col = total_width / 2
+          print(
+            string.format(
+              "make_layout-2:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              vim.inspect(actual),
+              vim.inspect(total_height),
+              vim.inspect(total_width),
+              vim.inspect(center_row),
+              vim.inspect(center_col)
+            )
+          )
+          assert_true(isclose(actual.width, width))
+          assert_true(isclose(actual.height, height))
+          assert_true(isclose(2 * (center_row - actual.start_row), height))
+          assert_true(isclose(2 * (actual.end_row - center_row), height))
+          assert_true(isclose(2 * (center_col - actual.start_col), width))
+          assert_true(isclose(2 * (actual.end_col - center_col), width))
+        end)
+        it("test3 without fzf_preview_window_opts", function()
+          local actual = popup_helpers.make_center_layout({
+            relative = "editor",
+            height = 0.77,
+            width = 0.81,
+            row = -1,
+            col = 2,
+          })
+          local total_width = vim.o.columns
+          local total_height = vim.o.lines
+          local width = total_width * 0.81
+          local height = total_height * 0.77
+          local center_row = total_height / 2 - 1
+          local center_col = total_width / 2 + 2
+          print(
+            string.format(
+              "make_layout-3:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              vim.inspect(actual),
+              vim.inspect(total_height),
+              vim.inspect(total_width),
+              vim.inspect(center_row),
+              vim.inspect(center_col)
+            )
+          )
+          assert_true(isclose(actual.width, width))
+          assert_true(isclose(actual.height, height))
+          assert_true(isclose(2 * (center_row - actual.start_row), height))
+          assert_true(isclose(2 * (actual.end_row - center_row), height))
+          assert_true(isclose(2 * (center_col - actual.start_col), width))
+          assert_true(isclose(2 * (actual.end_col - center_col), width))
+        end)
+        it("test4 with fzf_preview_window_opts", function()
+          local actual = popup_helpers.make_center_layout({
+            relative = "editor",
+            height = 0.75,
+            width = 0.85,
+            row = 0,
+            col = 0,
+          }, { position = "left", size = 35, size_is_percent = true })
+          local total_width = vim.o.columns
+          local total_height = vim.o.lines
+          local width = total_width * 0.85
+          local height = total_height * 0.75
+          local center_row = total_height / 2
+          local center_col = total_width / 2
+
+          print(
+            string.format(
+              "make_layout-4, actual:%s, total(height/width):%s/%s, center(row/col):%s/%s, height/width:%s/%s\n",
+              vim.inspect(actual),
+              vim.inspect(total_height),
+              vim.inspect(total_width),
+              vim.inspect(center_row),
+              vim.inspect(center_col),
+              vim.inspect(height),
+              vim.inspect(width)
+            )
+          )
+
+          assert_true(isclose(actual.width, width))
+          assert_true(isclose(actual.height, height))
+          assert_true(isclose(2 * (center_row - actual.start_row), height))
+          assert_true(isclose(2 * (actual.end_row - center_row), height))
+          assert_true(isclose(2 * (center_col - actual.start_col), width))
+          assert_true(isclose(2 * (actual.end_col - center_col), width))
+
+          assert_true(isclose(actual.provider.width, width * 0.65 - 1))
+          assert_true(isclose(actual.provider.height, height))
+          assert_eq(actual.provider.start_row, actual.start_row)
+          assert_eq(actual.provider.end_row, actual.end_row)
+          assert_eq(actual.provider.start_col, actual.start_col + actual.previewer.width + 2)
+          assert_eq(actual.provider.end_col, actual.end_col)
+
+          assert_true(isclose(actual.previewer.width, width * 0.35 - 1))
+          assert_true(isclose(actual.previewer.height, height))
+          assert_eq(actual.previewer.start_row, actual.start_row)
+          assert_eq(actual.previewer.end_row, actual.end_row)
+          assert_eq(actual.previewer.start_col, actual.start_col)
+          assert_eq(actual.previewer.end_col, actual.start_col + actual.previewer.width)
+        end)
+        it("test5 with fzf_preview_window_opts", function()
+          local actual = popup_helpers.make_center_layout({
+            relative = "editor",
+            height = 1,
+            width = 1,
+            row = 0,
+            col = 0,
+          }, { position = "up", size = 15 })
+          local total_height = vim.o.lines
+          local total_width = vim.o.columns
+          local width = total_width
+          local height = total_height
+          local center_row = total_height / 2
+          local center_col = total_width / 2
+          print(
+            string.format(
+              "make_layout-5:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              vim.inspect(actual),
+              vim.inspect(total_height),
+              vim.inspect(total_width),
+              vim.inspect(center_row),
+              vim.inspect(center_col)
+            )
+          )
+
+          assert_true(isclose(actual.width, width))
+          assert_true(isclose(actual.height, height))
+          assert_true(isclose(2 * (center_row - actual.start_row), height))
+          assert_true(isclose(2 * (actual.end_row - center_row), height))
+          assert_true(isclose(2 * (center_col - actual.start_col), width))
+          assert_true(isclose(2 * (actual.end_col - center_col), width))
+
+          assert_true(isclose(actual.provider.height, height - 15 - 1))
+          assert_eq(actual.provider.width, width)
+          assert_eq(actual.provider.start_row, actual.start_row + actual.previewer.height + 1)
+          assert_eq(actual.provider.end_row, actual.end_row)
+          assert_eq(actual.provider.start_col, actual.start_col)
+          assert_eq(actual.provider.end_col, actual.end_col)
+
+          assert_true(isclose(actual.previewer.height, 15 - 1))
+          assert_eq(actual.previewer.width, width)
+          assert_eq(actual.previewer.start_row, actual.start_row)
+          assert_eq(actual.previewer.end_row, actual.start_row + actual.previewer.height)
+          assert_eq(actual.previewer.start_col, actual.start_col)
+          assert_eq(actual.previewer.end_col, actual.end_col)
+        end)
+        it("test6 with fzf_preview_window_opts", function()
+          local actual = popup_helpers.make_center_layout({
+            relative = "win",
+            height = 0.9,
+            width = 0.85,
+            row = 1,
+            col = -2,
+          }, { position = "up", size = 15 })
+          local total_height = vim.api.nvim_win_get_height(0)
+          local total_width = vim.api.nvim_win_get_width(0)
+          local width = total_width * 0.85
+          local height = total_height * 0.9
+          local center_row = total_height / 2 + 1
+          local center_col = total_width / 2 - 2
+          print(
+            string.format(
+              "make_layout-6:%s, total(height/width):%s/%s, height/width:%s/%s, center(row/col):%s/%s\n",
+              vim.inspect(actual),
+              vim.inspect(total_height),
+              vim.inspect(total_width),
+              vim.inspect(height),
+              vim.inspect(width),
+              vim.inspect(center_row),
+              vim.inspect(center_col)
+            )
+          )
+
+          assert_true(isclose(actual.width, width))
+          assert_true(isclose(actual.height, height))
+          assert_true(isclose(2 * (center_row - actual.start_row), height))
+          print(
+            string.format(
+              "make_layout-6, (end_row(%s) - center_row(%s)) * 2 (%s) == height:%s: %s",
+              vim.inspect(actual.end_row),
+              vim.inspect(center_row),
+              vim.inspect(2 * (actual.end_row - center_row)),
+              vim.inspect(height),
+              vim.inspect(isclose(2 * (actual.end_row - center_row), height))
+            )
+          )
+          assert_true(isclose(2 * (actual.end_row - center_row), height))
+          assert_true(isclose(2 * (center_col - actual.start_col), width))
+          assert_true(isclose(2 * (actual.end_col - center_col), width))
+
+          if total_height > 20 then
+            assert_true(isclose(actual.provider.height, height - 15 - 1))
+          end
+          assert_true(isclose(actual.provider.width, width))
+          assert_true(
+            isclose(actual.provider.start_row, actual.start_row + actual.previewer.height + 1)
+          )
+          assert_eq(actual.provider.end_row, actual.end_row)
+          assert_eq(actual.provider.start_col, actual.start_col)
+          assert_eq(actual.provider.end_col, actual.end_col)
+
+          if total_height > 20 then
+            assert_true(isclose(actual.previewer.height, 15 - 1))
+          end
+          assert_true(isclose(actual.previewer.width, width))
+          assert_eq(actual.previewer.start_row, actual.start_row)
+          assert_true(isclose(actual.previewer.end_row, actual.start_row + actual.previewer.height))
+          assert_eq(actual.previewer.start_col, actual.start_col)
+          assert_eq(actual.previewer.end_col, actual.end_col)
+        end)
+      end
+    end
+  end)
 end)

--- a/spec/detail/popup/popup_helpers_spec.lua
+++ b/spec/detail/popup/popup_helpers_spec.lua
@@ -60,8 +60,7 @@ describe("detail.popup.popup_helpers", function()
     for j = min_test_width, max_test_width, 3 do
       test_height = i
       test_width = j
-
-      describe("[make_layout]", function()
+      describe("[make_center_layout]", function()
         local function isclose(a, b)
           if github_actions then
             return math.abs(math.abs(a) - math.abs(b)) <= 3.5
@@ -71,7 +70,7 @@ describe("detail.popup.popup_helpers", function()
         end
 
         it("test1 without fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_layout({
+          local actual = popup_helpers.make_center_layout({
             relative = "editor",
             height = 0.75,
             width = 0.85,
@@ -93,7 +92,7 @@ describe("detail.popup.popup_helpers", function()
           assert_true(isclose(2 * (actual.end_col - center_col), width))
         end)
         it("test2 without fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_layout({
+          local actual = popup_helpers.make_center_layout({
             relative = "win",
             height = 0.47,
             width = 0.71,
@@ -124,7 +123,7 @@ describe("detail.popup.popup_helpers", function()
           assert_true(isclose(2 * (actual.end_col - center_col), width))
         end)
         it("test3 without fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_layout({
+          local actual = popup_helpers.make_center_layout({
             relative = "editor",
             height = 0.77,
             width = 0.81,
@@ -155,7 +154,7 @@ describe("detail.popup.popup_helpers", function()
           assert_true(isclose(2 * (actual.end_col - center_col), width))
         end)
         it("test4 with fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_layout({
+          local actual = popup_helpers.make_center_layout({
             relative = "editor",
             height = 0.75,
             width = 0.85,
@@ -204,7 +203,7 @@ describe("detail.popup.popup_helpers", function()
           assert_eq(actual.previewer.end_col, actual.start_col + actual.previewer.width)
         end)
         it("test5 with fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_layout({
+          local actual = popup_helpers.make_center_layout({
             relative = "editor",
             height = 1,
             width = 1,
@@ -250,7 +249,7 @@ describe("detail.popup.popup_helpers", function()
           assert_eq(actual.previewer.end_col, actual.end_col)
         end)
         it("test6 with fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_layout({
+          local actual = popup_helpers.make_center_layout({
             relative = "win",
             height = 0.9,
             width = 0.85,

--- a/spec/detail/popup/popup_helpers_spec.lua
+++ b/spec/detail/popup/popup_helpers_spec.lua
@@ -77,7 +77,7 @@ describe("detail.popup.popup_helpers", function()
             row = 0,
             col = 0,
           })
-          print(string.format("make_layout-1:%s\n", vim.inspect(actual)))
+          print(string.format("make_center_layout-1:%s\n", vim.inspect(actual)))
           local total_width = vim.o.columns
           local total_height = vim.o.lines
           local width = total_width * 0.85
@@ -107,7 +107,7 @@ describe("detail.popup.popup_helpers", function()
           local center_col = total_width / 2
           print(
             string.format(
-              "make_layout-2:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              "make_center_layout-2:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
@@ -138,7 +138,7 @@ describe("detail.popup.popup_helpers", function()
           local center_col = total_width / 2 + 2
           print(
             string.format(
-              "make_layout-3:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              "make_center_layout-3:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
@@ -170,7 +170,7 @@ describe("detail.popup.popup_helpers", function()
 
           print(
             string.format(
-              "make_layout-4, actual:%s, total(height/width):%s/%s, center(row/col):%s/%s, height/width:%s/%s\n",
+              "make_center_layout-4, actual:%s, total(height/width):%s/%s, center(row/col):%s/%s, height/width:%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
@@ -218,7 +218,7 @@ describe("detail.popup.popup_helpers", function()
           local center_col = total_width / 2
           print(
             string.format(
-              "make_layout-5:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              "make_center_layout-5:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
@@ -264,7 +264,7 @@ describe("detail.popup.popup_helpers", function()
           local center_col = total_width / 2 - 2
           print(
             string.format(
-              "make_layout-6:%s, total(height/width):%s/%s, height/width:%s/%s, center(row/col):%s/%s\n",
+              "make_center_layout-6:%s, total(height/width):%s/%s, height/width:%s/%s, center(row/col):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
@@ -280,7 +280,7 @@ describe("detail.popup.popup_helpers", function()
           assert_true(isclose(2 * (center_row - actual.start_row), height))
           print(
             string.format(
-              "make_layout-6, (end_row(%s) - center_row(%s)) * 2 (%s) == height:%s: %s",
+              "make_center_layout-6, (end_row(%s) - center_row(%s)) * 2 (%s) == height:%s: %s",
               vim.inspect(actual.end_row),
               vim.inspect(center_row),
               vim.inspect(2 * (actual.end_row - center_row)),
@@ -329,30 +329,22 @@ describe("detail.popup.popup_helpers", function()
         end
 
         it("test1 without fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_center_layout({
-            relative = "editor",
+          local actual = popup_helpers.make_cursor_layout({
             height = 0.75,
             width = 0.85,
             row = 0,
             col = 0,
           })
-          print(string.format("make_layout-1:%s\n", vim.inspect(actual)))
-          local total_width = vim.o.columns
-          local total_height = vim.o.lines
+          print(string.format("make_cursor_layout-1:%s\n", vim.inspect(actual)))
+          local total_width = vim.api.nvim_win_get_width(0)
+          local total_height = vim.api.nvim_win_get_height(0)
           local width = total_width * 0.85
           local height = total_height * 0.75
-          local center_row = total_height / 2
-          local center_col = total_width / 2
           assert_true(isclose(actual.width, width))
           assert_true(isclose(actual.height, height))
-          assert_true(isclose(2 * (center_row - actual.start_row), height))
-          assert_true(isclose(2 * (actual.end_row - center_row), height))
-          assert_true(isclose(2 * (center_col - actual.start_col), width))
-          assert_true(isclose(2 * (actual.end_col - center_col), width))
         end)
         it("test2 without fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_center_layout({
-            relative = "win",
+          local actual = popup_helpers.make_cursor_layout({
             height = 0.47,
             width = 0.71,
             row = 0,
@@ -362,79 +354,57 @@ describe("detail.popup.popup_helpers", function()
           local total_width = vim.api.nvim_win_get_width(0)
           local width = total_width * 0.71
           local height = total_height * 0.47
-          local center_row = total_height / 2
-          local center_col = total_width / 2
           print(
             string.format(
-              "make_layout-2:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              "make_cursor_layout-2:%s, total(height/width):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
-              vim.inspect(total_width),
-              vim.inspect(center_row),
-              vim.inspect(center_col)
+              vim.inspect(total_width)
             )
           )
           assert_true(isclose(actual.width, width))
           assert_true(isclose(actual.height, height))
-          assert_true(isclose(2 * (center_row - actual.start_row), height))
-          assert_true(isclose(2 * (actual.end_row - center_row), height))
-          assert_true(isclose(2 * (center_col - actual.start_col), width))
-          assert_true(isclose(2 * (actual.end_col - center_col), width))
         end)
         it("test3 without fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_center_layout({
-            relative = "editor",
+          local actual = popup_helpers.make_cursor_layout({
             height = 0.77,
             width = 0.81,
             row = -1,
             col = 2,
           })
-          local total_width = vim.o.columns
-          local total_height = vim.o.lines
+          local total_height = vim.api.nvim_win_get_height(0)
+          local total_width = vim.api.nvim_win_get_width(0)
           local width = total_width * 0.81
           local height = total_height * 0.77
-          local center_row = total_height / 2 - 1
-          local center_col = total_width / 2 + 2
           print(
             string.format(
-              "make_layout-3:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              "make_cursor_layout-3:%s, total(height/width):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
-              vim.inspect(total_width),
-              vim.inspect(center_row),
-              vim.inspect(center_col)
+              vim.inspect(total_width)
             )
           )
           assert_true(isclose(actual.width, width))
           assert_true(isclose(actual.height, height))
-          assert_true(isclose(2 * (center_row - actual.start_row), height))
-          assert_true(isclose(2 * (actual.end_row - center_row), height))
-          assert_true(isclose(2 * (center_col - actual.start_col), width))
-          assert_true(isclose(2 * (actual.end_col - center_col), width))
         end)
         it("test4 with fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_center_layout({
-            relative = "editor",
+          local actual = popup_helpers.make_cursor_layout({
             height = 0.75,
             width = 0.85,
             row = 0,
             col = 0,
           }, { position = "left", size = 35, size_is_percent = true })
-          local total_width = vim.o.columns
-          local total_height = vim.o.lines
+          local total_height = vim.api.nvim_win_get_height(0)
+          local total_width = vim.api.nvim_win_get_width(0)
           local width = total_width * 0.85
           local height = total_height * 0.75
-          local center_row = total_height / 2
-          local center_col = total_width / 2
 
           print(
             string.format(
-              "make_layout-4, actual:%s, total(height/width):%s/%s, center(row/col):%s/%s, height/width:%s/%s\n",
+              "make_cursor_layout-4, actual:%s, total(height/width):%s/%s, height/width:%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
-              vim.inspect(center_row),
-              vim.inspect(center_col),
               vim.inspect(height),
               vim.inspect(width)
             )
@@ -442,11 +412,6 @@ describe("detail.popup.popup_helpers", function()
 
           assert_true(isclose(actual.width, width))
           assert_true(isclose(actual.height, height))
-          assert_true(isclose(2 * (center_row - actual.start_row), height))
-          assert_true(isclose(2 * (actual.end_row - center_row), height))
-          assert_true(isclose(2 * (center_col - actual.start_col), width))
-          assert_true(isclose(2 * (actual.end_col - center_col), width))
-
           assert_true(isclose(actual.provider.width, width * 0.65 - 1))
           assert_true(isclose(actual.provider.height, height))
           assert_eq(actual.provider.start_row, actual.start_row)
@@ -462,36 +427,27 @@ describe("detail.popup.popup_helpers", function()
           assert_eq(actual.previewer.end_col, actual.start_col + actual.previewer.width)
         end)
         it("test5 with fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_center_layout({
-            relative = "editor",
+          local actual = popup_helpers.make_cursor_layout({
             height = 1,
             width = 1,
             row = 0,
             col = 0,
           }, { position = "up", size = 15 })
-          local total_height = vim.o.lines
-          local total_width = vim.o.columns
+          local total_height = vim.api.nvim_win_get_height(0)
+          local total_width = vim.api.nvim_win_get_width(0)
           local width = total_width
           local height = total_height
-          local center_row = total_height / 2
-          local center_col = total_width / 2
           print(
             string.format(
-              "make_layout-5:%s, total(height/width):%s/%s,center(row/col):%s/%s\n",
+              "make_cursor_layout-5:%s, total(height/width):%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
-              vim.inspect(total_width),
-              vim.inspect(center_row),
-              vim.inspect(center_col)
+              vim.inspect(total_width)
             )
           )
 
           assert_true(isclose(actual.width, width))
           assert_true(isclose(actual.height, height))
-          assert_true(isclose(2 * (center_row - actual.start_row), height))
-          assert_true(isclose(2 * (actual.end_row - center_row), height))
-          assert_true(isclose(2 * (center_col - actual.start_col), width))
-          assert_true(isclose(2 * (actual.end_col - center_col), width))
 
           assert_true(isclose(actual.provider.height, height - 15 - 1))
           assert_eq(actual.provider.width, width)
@@ -508,8 +464,7 @@ describe("detail.popup.popup_helpers", function()
           assert_eq(actual.previewer.end_col, actual.end_col)
         end)
         it("test6 with fzf_preview_window_opts", function()
-          local actual = popup_helpers.make_center_layout({
-            relative = "win",
+          local actual = popup_helpers.make_cursor_layout({
             height = 0.9,
             width = 0.85,
             row = 1,
@@ -519,37 +474,19 @@ describe("detail.popup.popup_helpers", function()
           local total_width = vim.api.nvim_win_get_width(0)
           local width = total_width * 0.85
           local height = total_height * 0.9
-          local center_row = total_height / 2 + 1
-          local center_col = total_width / 2 - 2
           print(
             string.format(
-              "make_layout-6:%s, total(height/width):%s/%s, height/width:%s/%s, center(row/col):%s/%s\n",
+              "make_cursor_layout-6:%s, total(height/width):%s/%s, height/width:%s/%s\n",
               vim.inspect(actual),
               vim.inspect(total_height),
               vim.inspect(total_width),
               vim.inspect(height),
-              vim.inspect(width),
-              vim.inspect(center_row),
-              vim.inspect(center_col)
+              vim.inspect(width)
             )
           )
 
           assert_true(isclose(actual.width, width))
           assert_true(isclose(actual.height, height))
-          assert_true(isclose(2 * (center_row - actual.start_row), height))
-          print(
-            string.format(
-              "make_layout-6, (end_row(%s) - center_row(%s)) * 2 (%s) == height:%s: %s",
-              vim.inspect(actual.end_row),
-              vim.inspect(center_row),
-              vim.inspect(2 * (actual.end_row - center_row)),
-              vim.inspect(height),
-              vim.inspect(isclose(2 * (actual.end_row - center_row), height))
-            )
-          )
-          assert_true(isclose(2 * (actual.end_row - center_row), height))
-          assert_true(isclose(2 * (center_col - actual.start_col), width))
-          assert_true(isclose(2 * (actual.end_col - center_col), width))
 
           if total_height > 20 then
             assert_true(isclose(actual.provider.height, height - 15 - 1))


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
