### PR TITLE
perf(bat): immediately build bat themes after initialize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: JohnnyMorganz/stylua-action@v3
+      - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/lua/fzfx.lua
+++ b/lua/fzfx.lua
@@ -1,10 +1,11 @@
+local log = require("fzfx.lib.log")
+local LogLevels = require("fzfx.lib.log").LogLevels
+
 --- @param opts fzfx.Options?
 local function setup(opts)
   -- configs
   local configs = require("fzfx.config").setup(opts)
 
-  local log = require("fzfx.lib.log")
-  local LogLevels = require("fzfx.lib.log").LogLevels
   -- log
   log.setup({
     level = configs.debug.enable and LogLevels.DEBUG or LogLevels.INFO,

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -544,13 +544,13 @@ M.setup = function()
     return
   end
 
-  bat_themes_helper.get_theme_dir()
-
-  if str.not_empty(vim.g.colors_name) then
-    vim.defer_fn(function()
-      M._build_theme(vim.g.colors_name)
-    end, 100)
-  end
+  bat_themes_helper.get_theme_dir(function()
+    if str.not_empty(vim.g.colors_name) then
+      vim.schedule(function()
+        M._build_theme(vim.g.colors_name)
+      end)
+    end
+  end)
 
   vim.api.nvim_create_autocmd({ "ColorScheme" }, {
     callback = function(event)

--- a/lua/fzfx/helper/bat_themes.lua
+++ b/lua/fzfx/helper/bat_themes.lua
@@ -35,7 +35,7 @@ M.get_theme_dir = function(cb)
       cached_theme_dir = path.join(config_dir, "themes")
       vim.schedule(function()
         M._create_theme_dir(cached_theme_dir)
-        if vim.is_callable(cb) then
+        if cb ~= nil and vim.is_callable(cb) then
           cb(cached_theme_dir)
         end
       end)

--- a/lua/fzfx/helper/bat_themes.lua
+++ b/lua/fzfx/helper/bat_themes.lua
@@ -18,9 +18,9 @@ end
 --- @type string?
 local cached_theme_dir = nil
 
---- @param f (fun(theme_dir:string?):nil)|nil
+--- @param cb (fun(theme_dir:string?):nil)|nil
 --- @return string?
-M.get_theme_dir = function(f)
+M.get_theme_dir = function(cb)
   if str.empty(cached_theme_dir) then
     log.ensure(constants.HAS_BAT, "|get_theme_dir| cannot find 'bat' executable")
 
@@ -35,8 +35,8 @@ M.get_theme_dir = function(f)
       cached_theme_dir = path.join(config_dir, "themes")
       vim.schedule(function()
         M._create_theme_dir(cached_theme_dir)
-        if vim.is_callable(f) then
-          f(cached_theme_dir)
+        if vim.is_callable(cb) then
+          cb(cached_theme_dir)
         end
       end)
     end)

--- a/lua/fzfx/helper/bat_themes.lua
+++ b/lua/fzfx/helper/bat_themes.lua
@@ -18,8 +18,9 @@ end
 --- @type string?
 local cached_theme_dir = nil
 
+--- @param f (fun(theme_dir:string?):nil)|nil
 --- @return string?
-M.get_theme_dir = function()
+M.get_theme_dir = function(f)
   if str.empty(cached_theme_dir) then
     log.ensure(constants.HAS_BAT, "|get_theme_dir| cannot find 'bat' executable")
 
@@ -34,6 +35,9 @@ M.get_theme_dir = function()
       cached_theme_dir = path.join(config_dir, "themes")
       vim.schedule(function()
         M._create_theme_dir(cached_theme_dir)
+        if vim.is_callable(f) then
+          f(cached_theme_dir)
+        end
       end)
     end)
 


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
