### PR TITLE
feat(previewer): respect 'number' options

### DIFF
--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -667,7 +667,8 @@ function BufferPopupWindow:preview_file_contents(file_content, content_view, on_
         title_pos = "center",
       }
       vim.api.nvim_win_set_config(self.previewer_winnr, title_opts)
-      api.set_win_option(self.previewer_winnr, "number", true)
+      local number_opt = api.get_win_option(self._saved_current_winnr, "number")
+      api.set_win_option(self.previewer_winnr, "number", number_opt)
     end
 
     if str.not_empty(file_content.previewer_label_result) then

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -667,8 +667,8 @@ function BufferPopupWindow:preview_file_contents(file_content, content_view, on_
         title_pos = "center",
       }
       vim.api.nvim_win_set_config(self.previewer_winnr, title_opts)
-      local number_opt = api.get_win_option(self._saved_current_winnr, "number")
-      api.set_win_option(self.previewer_winnr, "number", number_opt)
+      local wrap = self._saved_buffer_previewer_opts.fzf_preview_window_opts.wrap
+      _set_default_previewer_win_options(self.previewer_winnr, wrap, self._saved_current_winnr)
     end
 
     if str.not_empty(file_content.previewer_label_result) then

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -257,6 +257,7 @@ end
 --- @field previewer_is_hidden boolean
 local BufferPopupWindow = {}
 
+--- @param bufnr integer
 local function _set_default_buf_options(bufnr)
   api.set_buf_option(bufnr, "bufhidden", "wipe")
   api.set_buf_option(bufnr, "buflisted", false)
@@ -265,8 +266,10 @@ end
 
 --- @param winnr integer
 --- @param wrap boolean
-local function _set_default_previewer_win_options(winnr, wrap)
-  api.set_win_option(winnr, "number", true)
+--- @param current_winnr integer
+local function _set_default_previewer_win_options(winnr, wrap, current_winnr)
+  local number_opt = api.get_win_option(current_winnr, "number")
+  api.set_win_option(winnr, "number", number_opt)
   api.set_win_option(winnr, "spell", false)
   api.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
   -- apis.set_win_option(winnr, "scrolloff", 0)
@@ -275,7 +278,9 @@ local function _set_default_previewer_win_options(winnr, wrap)
   api.set_win_option(winnr, "wrap", wrap)
 end
 
-local function _set_default_provider_win_options(winnr)
+--- @param winnr integer
+--- @param current_winnr integer
+local function _set_default_provider_win_options(winnr, current_winnr)
   api.set_win_option(winnr, "number", false)
   api.set_win_option(winnr, "spell", false)
   api.set_win_option(winnr, "winhighlight", "Pmenu:,Normal:Normal")
@@ -333,12 +338,12 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
     previewer_winnr = vim.api.nvim_open_win(previewer_bufnr, true, previewer_win_confs)
     log.ensure(previewer_winnr > 0, "failed to create previewer win")
     local wrap = buffer_previewer_opts.fzf_preview_window_opts.wrap
-    _set_default_previewer_win_options(previewer_winnr, wrap)
+    _set_default_previewer_win_options(previewer_winnr, wrap, current_winnr)
   end
 
   local provider_winnr = vim.api.nvim_open_win(provider_bufnr, true, provider_win_confs)
   log.ensure(provider_winnr > 0, "failed to create provider win")
-  _set_default_provider_win_options(provider_winnr)
+  _set_default_provider_win_options(provider_winnr, current_winnr)
 
   -- set cursor at provider window
   vim.api.nvim_set_current_win(provider_winnr)
@@ -432,7 +437,7 @@ function BufferPopupWindow:resize()
       self.provider_winnr,
       vim.tbl_deep_extend("force", old_win_confs, new_win_confs)
     )
-    _set_default_provider_win_options(self.provider_winnr)
+    _set_default_provider_win_options(self.provider_winnr, self._saved_current_winnr)
   else
     local old_provider_win_confs = vim.api.nvim_win_get_config(self.provider_winnr)
     local win_confs = M.make_opts(
@@ -449,7 +454,7 @@ function BufferPopupWindow:resize()
       self.provider_winnr,
       vim.tbl_deep_extend("force", old_provider_win_confs, win_confs.provider or {})
     )
-    _set_default_provider_win_options(self.provider_winnr)
+    _set_default_provider_win_options(self.provider_winnr, self._saved_current_winnr)
 
     if self:previewer_is_valid() then
       local old_previewer_win_confs = vim.api.nvim_win_get_config(self.previewer_winnr)
@@ -464,7 +469,7 @@ function BufferPopupWindow:resize()
       )
 
       local wrap = self._saved_buffer_previewer_opts.fzf_preview_window_opts.wrap
-      _set_default_previewer_win_options(self.previewer_winnr, wrap)
+      _set_default_previewer_win_options(self.previewer_winnr, wrap, self._saved_current_winnr)
     end
   end
 
@@ -926,7 +931,7 @@ function BufferPopupWindow:show_preview()
   _set_default_buf_options(self.previewer_bufnr)
   self.previewer_winnr = vim.api.nvim_open_win(self.previewer_bufnr, true, win_confs.previewer)
   local wrap = self._saved_buffer_previewer_opts.fzf_preview_window_opts.wrap
-  _set_default_previewer_win_options(self.previewer_winnr, wrap)
+  _set_default_previewer_win_options(self.previewer_winnr, wrap, self._saved_current_winnr)
   vim.api.nvim_set_current_win(self.provider_winnr)
 
   self:resize()


### PR DESCRIPTION
Resolve #684 .

# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
