### PR TITLE
feat(popup): move to upper side if bottom has not enough space

### DIFF
--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -86,9 +86,9 @@ M._hash_lsp_location = function(loc)
     tbl.tbl_get(range, "end", "line") or 0,
     tbl.tbl_get(range, "end", "character") or 0
   )
-  log.debug(
-    string.format("|_hash_lsp_location| loc:%s, hash:%s", vim.inspect(loc), vim.inspect(result))
-  )
+  -- log.debug(
+  --   string.format("|_hash_lsp_location| loc:%s, hash:%s", vim.inspect(loc), vim.inspect(result))
+  -- )
   return result
 end
 
@@ -296,17 +296,17 @@ end
 --- @param ranges fzfx.LspRange[]
 --- @return string[]
 M._render_lsp_call_hierarchy_line = function(item, ranges)
-  log.debug(
-    string.format(
-      "|_render_lsp_call_hierarchy_line| item:%s, ranges:%s",
-      vim.inspect(item),
-      vim.inspect(ranges)
-    )
-  )
+  -- log.debug(
+  --   string.format(
+  --     "|_render_lsp_call_hierarchy_line| item:%s, ranges:%s",
+  --     vim.inspect(item),
+  --     vim.inspect(ranges)
+  --   )
+  -- )
   local filename = nil
   if type(item.uri) == "string" and string.len(item.uri) > 0 and M._is_lsp_range(item.range) then
     filename = path.reduce(vim.uri_to_fname(item.uri))
-    log.debug("|_render_lsp_call_hierarchy_line| location filename: " .. vim.inspect(filename))
+    -- log.debug("|_render_lsp_call_hierarchy_line| location filename: " .. vim.inspect(filename))
   end
   if type(ranges) ~= "table" or #ranges == 0 then
     return {}
@@ -322,14 +322,14 @@ M._render_lsp_call_hierarchy_line = function(item, ranges)
   for i, r in ipairs(ranges) do
     if type(filelines) == "table" and #filelines >= r.start.line + 1 then
       local item_line = M._colorize_lsp_range(filelines[r.start.line + 1], r, term_color.red)
-      log.debug(
-        string.format(
-          "|_render_lsp_call_hierarchy_line| %s-range:%s, item_line:%s",
-          vim.inspect(i),
-          vim.inspect(r),
-          vim.inspect(item_line)
-        )
-      )
+      -- log.debug(
+      --   string.format(
+      --     "|_render_lsp_call_hierarchy_line| %s-range:%s, item_line:%s",
+      --     vim.inspect(i),
+      --     vim.inspect(r),
+      --     vim.inspect(item_line)
+      --   )
+      -- )
       local line = string.format(
         "%s:%s:%s:%s",
         providers_helper.LSP_FILENAME_COLOR(vim.fn.fnamemodify(filename, ":~:.")),
@@ -337,13 +337,13 @@ M._render_lsp_call_hierarchy_line = function(item, ranges)
         tostring(r.start.character + 1),
         item_line
       )
-      log.debug(
-        string.format(
-          "|_render_lsp_call_hierarchy_line| %s-line:%s",
-          vim.inspect(i),
-          vim.inspect(line)
-        )
-      )
+      -- log.debug(
+      --   string.format(
+      --     "|_render_lsp_call_hierarchy_line| %s-line:%s",
+      --     vim.inspect(i),
+      --     vim.inspect(line)
+      --   )
+      -- )
       table.insert(lines, line)
     end
   end
@@ -398,14 +398,14 @@ M._make_lsp_call_hierarchy_provider = function(opts)
       context.position_params,
       opts.timeout or 3000
     )
-    log.debug(
-      string.format(
-        "|_make_lsp_call_hierarchy_provider| prepare, opts:%s, lsp_results:%s, lsp_err:%s",
-        vim.inspect(opts),
-        vim.inspect(lsp_results),
-        vim.inspect(lsp_err)
-      )
-    )
+    -- log.debug(
+    --   string.format(
+    --     "|_make_lsp_call_hierarchy_provider| prepare, opts:%s, lsp_results:%s, lsp_err:%s",
+    --     vim.inspect(opts),
+    --     vim.inspect(lsp_results),
+    --     vim.inspect(lsp_err)
+    --   )
+    -- )
     if lsp_err then
       log.echo(LogLevels.ERROR, lsp_err)
       return nil
@@ -438,15 +438,15 @@ M._make_lsp_call_hierarchy_provider = function(opts)
       { item = lsp_item[1] },
       opts.timeout or 3000
     )
-    log.debug(
-      string.format(
-        "|_make_lsp_call_hierarchy_provider| 2nd call, opts:%s, lsp_item: %s, lsp_results2:%s, lsp_err2:%s",
-        vim.inspect(opts),
-        vim.inspect(lsp_item),
-        vim.inspect(lsp_results2),
-        vim.inspect(lsp_err2)
-      )
-    )
+    -- log.debug(
+    --   string.format(
+    --     "|_make_lsp_call_hierarchy_provider| 2nd call, opts:%s, lsp_item: %s, lsp_results2:%s, lsp_err2:%s",
+    --     vim.inspect(opts),
+    --     vim.inspect(lsp_item),
+    --     vim.inspect(lsp_results2),
+    --     vim.inspect(lsp_err2)
+    --   )
+    -- )
     if lsp_err2 then
       log.echo(LogLevels.ERROR, lsp_err2)
       return nil
@@ -462,25 +462,25 @@ M._make_lsp_call_hierarchy_provider = function(opts)
         and type(lsp_result.result) == "table"
       then
         local lsp_hi_item_list = lsp_result.result
-        log.debug(
-          string.format(
-            "|_make_lsp_call_hierarchy_provider| method:%s, lsp_hi_item_list:%s",
-            vim.inspect(opts.method),
-            vim.inspect(lsp_hi_item_list)
-          )
-        )
+        -- log.debug(
+        --   string.format(
+        --     "|_make_lsp_call_hierarchy_provider| method:%s, lsp_hi_item_list:%s",
+        --     vim.inspect(opts.method),
+        --     vim.inspect(lsp_hi_item_list)
+        --   )
+        -- )
         for _, lsp_hi_item in ipairs(lsp_hi_item_list) do
           local hi_item, from_ranges =
             M._retrieve_lsp_call_hierarchy_item_and_from_ranges(opts.method, lsp_hi_item)
-          log.debug(
-            string.format(
-              "|_make_lsp_call_hierarchy_provider| method:%s, lsp_hi_item:%s, hi_item:%s, from_ranges:%s",
-              vim.inspect(opts.method),
-              vim.inspect(lsp_hi_item_list),
-              vim.inspect(hi_item),
-              vim.inspect(from_ranges)
-            )
-          )
+          -- log.debug(
+          --   string.format(
+          --     "|_make_lsp_call_hierarchy_provider| method:%s, lsp_hi_item:%s, hi_item:%s, from_ranges:%s",
+          --     vim.inspect(opts.method),
+          --     vim.inspect(lsp_hi_item_list),
+          --     vim.inspect(hi_item),
+          --     vim.inspect(from_ranges)
+          --   )
+          -- )
           if M._is_lsp_call_hierarchy_item(hi_item) and type(from_ranges) == "table" then
             local lines = M._render_lsp_call_hierarchy_line(
               hi_item --[[@as fzfx.LspCallHierarchyItem]],

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -354,18 +354,18 @@ M.make_cursor_layout = function(
   -- thus we would place it in upper-side of cursor
   log.debug(
     string.format(
-      "|make_cursor_layout| height/width:%s/%s, start_row:%s, start_row + height(%s) >= total_height(%s):%s, start_row - 3 - height(%s) >= 1:%s",
+      "|make_cursor_layout| height/width:%s/%s, start_row:%s, start_row + height(%s) > total_height(%s):%s, start_row - 3 - height(%s) >= 1:%s",
       vim.inspect(height),
       vim.inspect(width),
       vim.inspect(start_row),
       vim.inspect(start_row_plus_height),
       vim.inspect(total_height),
-      vim.inspect(start_row_plus_height >= total_height),
+      vim.inspect(start_row_plus_height > total_height),
       vim.inspect(start_row_minus_3_and_height),
       vim.inspect(start_row_minus_3_and_height >= 1)
     )
   )
-  if start_row_plus_height >= total_height and start_row_minus_3_and_height >= 1 then
+  if start_row_plus_height > total_height and start_row_minus_3_and_height >= 1 then
     start_row = start_row_minus_3_and_height
   end
   local end_row = start_row + height

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -368,7 +368,7 @@ M.make_cursor_layout = function(
   if start_row_plus_height > total_height and start_row_minus_3_and_height >= 1 then
     start_row = start_row_minus_3_and_height
   end
-  local end_row = start_row_plus_height
+  local end_row = start_row + height
 
   if win_opts.col > -1 and win_opts.col < 1 then
     start_col = math.floor(total_width * win_opts.col) + cursor_relative_col

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -314,16 +314,15 @@ M.make_cursor_layout = function(
   local total_width = vim.api.nvim_win_get_width(relative_winnr)
   local total_height = vim.api.nvim_win_get_height(relative_winnr)
   local cursor_pos = vim.api.nvim_win_get_cursor(relative_winnr)
-  local win_first_line = relative_win_first_line
-  local cursor_relative_row = cursor_pos[1] - win_first_line
+  local cursor_relative_row = cursor_pos[1] - relative_win_first_line
   local cursor_relative_col = cursor_pos[2]
   log.debug(
     string.format(
-      "|make_cursor_layout| total height/width:%s/%s, cursor:%s, win first line:%s, cursor relative row/col:%s/%s",
+      "|make_cursor_layout| total height/width:%s/%s, cursor:%s, relative_win_first_line:%s, cursor relative row/col:%s/%s",
       vim.inspect(total_height),
       vim.inspect(total_width),
       vim.inspect(cursor_pos),
-      vim.inspect(win_first_line),
+      vim.inspect(relative_win_first_line),
       vim.inspect(cursor_relative_row),
       vim.inspect(cursor_relative_col)
     )
@@ -347,6 +346,24 @@ M.make_cursor_layout = function(
     start_row = math.floor(total_height * win_opts.row) + cursor_relative_row
   else
     start_row = win_opts.row + cursor_relative_row
+  end
+  -- if cursor based popup window is too beyond bottom, it will cover the cursor
+  -- thus we would place it in upper-side of cursor
+  log.debug(
+    string.format(
+      "|make_cursor_layout| height/width:%s/%s, start_row:%s, start_row + height(%s) > total_height(%s):%s, start_row - 3 - height(%s) >= 1:%s",
+      vim.inspect(height),
+      vim.inspect(width),
+      vim.inspect(start_row),
+      vim.inspect(start_row + height),
+      vim.inspect(total_height),
+      vim.inspect(start_row + height > total_height),
+      vim.inspect(start_row - 2 - height),
+      vim.inspect((start_row - 2 - height) >= 1)
+    )
+  )
+  if start_row + height > total_height and (start_row - 3 - height) >= 1 then
+    start_row = start_row - height - 3
   end
   local end_row = start_row + height
 

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -349,7 +349,7 @@ M.make_cursor_layout = function(
   end
 
   local start_row_plus_height = start_row + height
-  local start_row_minus_3_minus_height = start_row - 3 - height
+  local start_row_minus_3_and_height = start_row - 3 - height
   -- if cursor based popup window is too beyond bottom, it will cover the cursor
   -- thus we would place it in upper-side of cursor
   log.debug(
@@ -361,12 +361,12 @@ M.make_cursor_layout = function(
       vim.inspect(start_row_plus_height),
       vim.inspect(total_height),
       vim.inspect(start_row_plus_height > total_height),
-      vim.inspect(start_row_minus_3_minus_height),
-      vim.inspect(start_row_minus_3_minus_height >= 1)
+      vim.inspect(start_row_minus_3_and_height),
+      vim.inspect(start_row_minus_3_and_height >= 1)
     )
   )
-  if start_row_plus_height > total_height and start_row_minus_3_minus_height >= 1 then
-    start_row = start_row_minus_3_minus_height
+  if start_row_plus_height > total_height and start_row_minus_3_and_height >= 1 then
+    start_row = start_row_minus_3_and_height
   end
   local end_row = start_row_plus_height
 

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -354,18 +354,18 @@ M.make_cursor_layout = function(
   -- thus we would place it in upper-side of cursor
   log.debug(
     string.format(
-      "|make_cursor_layout| height/width:%s/%s, start_row:%s, start_row + height(%s) > total_height(%s):%s, start_row - 3 - height(%s) >= 1:%s",
+      "|make_cursor_layout| height/width:%s/%s, start_row:%s, start_row + height(%s) >= total_height(%s):%s, start_row - 3 - height(%s) >= 1:%s",
       vim.inspect(height),
       vim.inspect(width),
       vim.inspect(start_row),
       vim.inspect(start_row_plus_height),
       vim.inspect(total_height),
-      vim.inspect(start_row_plus_height > total_height),
+      vim.inspect(start_row_plus_height >= total_height),
       vim.inspect(start_row_minus_3_and_height),
       vim.inspect(start_row_minus_3_and_height >= 1)
     )
   )
-  if start_row_plus_height > total_height and start_row_minus_3_and_height >= 1 then
+  if start_row_plus_height >= total_height and start_row_minus_3_and_height >= 1 then
     start_row = start_row_minus_3_and_height
   end
   local end_row = start_row + height

--- a/lua/fzfx/detail/popup/popup_helpers.lua
+++ b/lua/fzfx/detail/popup/popup_helpers.lua
@@ -347,6 +347,9 @@ M.make_cursor_layout = function(
   else
     start_row = win_opts.row + cursor_relative_row
   end
+
+  local start_row_plus_height = start_row + height
+  local start_row_minus_3_minus_height = start_row - 3 - height
   -- if cursor based popup window is too beyond bottom, it will cover the cursor
   -- thus we would place it in upper-side of cursor
   log.debug(
@@ -355,17 +358,17 @@ M.make_cursor_layout = function(
       vim.inspect(height),
       vim.inspect(width),
       vim.inspect(start_row),
-      vim.inspect(start_row + height),
+      vim.inspect(start_row_plus_height),
       vim.inspect(total_height),
-      vim.inspect(start_row + height > total_height),
-      vim.inspect(start_row - 2 - height),
-      vim.inspect((start_row - 2 - height) >= 1)
+      vim.inspect(start_row_plus_height > total_height),
+      vim.inspect(start_row_minus_3_minus_height),
+      vim.inspect(start_row_minus_3_minus_height >= 1)
     )
   )
-  if start_row + height > total_height and (start_row - 3 - height) >= 1 then
-    start_row = start_row - height - 3
+  if start_row_plus_height > total_height and start_row_minus_3_minus_height >= 1 then
+    start_row = start_row_minus_3_minus_height
   end
-  local end_row = start_row + height
+  local end_row = start_row_plus_height
 
   if win_opts.col > -1 and win_opts.col < 1 then
     start_col = math.floor(total_width * win_opts.col) + cursor_relative_col


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
