### PR TITLE
feat(health): add health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ https://github.com/linrongbin16/fzfx.nvim/assets/6496887/b5e2b0dc-4dd6-4c18-b1da
 - [rg](https://github.com/BurntSushi/ripgrep) (**optional** for live grep, by default use [grep](https://man7.org/linux/man-pages/man1/grep.1.html)).
 - [fd](https://github.com/sharkdp/fd) (**optional** for find files, by default use [find](https://man7.org/linux/man-pages/man1/find.1.html)).
 - [bat](https://github.com/sharkdp/bat) (**optional** for preview files, by default use [cat](https://man7.org/linux/man-pages/man1/cat.1.html)).
+- [git](https://git-scm.com/) (**mandatory** for git diff, show, blame).
 - [delta](https://github.com/dandavison/delta) (**optional** for preview git diff, show, blame).
 - [lsd](https://github.com/lsd-rs/lsd)/[eza](https://github.com/eza-community/eza) (**optional** for file explorer, by default use [ls](https://man7.org/linux/man-pages/man1/ls.1.html)).
 

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -3,6 +3,19 @@ local tbl = require("fzfx.commons.tbl")
 
 local M = {}
 
+M._common = function()
+  if consts.HAS_ECHO then
+    vim.health.ok(string.format("'%s' found", consts.ECHO))
+  else
+    vim.health.error("'echo' not found")
+  end
+  if consts.HAS_CURL then
+    vim.health.ok(string.format("'%s' found", consts.CURL))
+  else
+    vim.health.error("'curl' not found")
+  end
+end
+
 M._find = function()
   if consts.HAS_FD then
     vim.health.ok(string.format("'%s' found", consts.FD))
@@ -23,10 +36,51 @@ M._cat = function()
   end
 end
 
+M._grep = function()
+  if consts.HAS_RG then
+    vim.health.ok(string.format("'%s' found", consts.RG))
+  elseif consts.HAS_GREP then
+    vim.health.ok(string.format("'%s' found", consts.GREP))
+  else
+    vim.health.error("'rg'/'grep'/'ggrep' not found")
+  end
+end
+
+M._git = function()
+  if consts.HAS_GIT then
+    vim.health.ok(string.format("'%s' found", consts.GIT))
+  else
+    vim.health.error("'git' not found")
+  end
+  if consts.HAS_DELTA then
+    vim.health.ok(string.format("'%s' found", consts.DELTA))
+  end
+end
+
+M._ls = function()
+  if consts.HAS_LSD then
+    vim.health.ok(string.format("'%s' found", consts.LSD))
+  elseif consts.HAS_EZA then
+    vim.health.ok(string.format("'%s' found", consts.EZA))
+  elseif consts.HAS_LS then
+    vim.health.ok(string.format("'%s' found", consts.LS))
+  else
+    vim.health.error("'lsd'/'eza'/'exa'/'ls' not found")
+  end
+  if consts.HAS_DELTA then
+    vim.health.ok(string.format("'%s' found", consts.DELTA))
+  end
+end
+
 M.check = function()
   vim.health.start("fzfx")
 
+  M._common()
   M._find()
+  M._cat()
+  M._grep()
+  M._git()
+  M._ls()
 end
 
 return M

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,6 +1,13 @@
 local consts = require("fzfx.lib.constants")
+local tbl = require("fzfx.commons.tbl")
 
 local M = {}
+
+--- @param name string
+--- @return string
+local function stringize(name)
+  return string.format("'%s'", name)
+end
 
 M._common = function()
   if consts.HAS_ECHO then
@@ -16,12 +23,24 @@ M._common = function()
 end
 
 M._find = function()
+  local exec = tbl.List:of()
+
   if consts.HAS_FD then
-    vim.health.ok(string.format("'%s' found", consts.FD))
-  elseif consts.HAS_FIND then
-    vim.health.ok(string.format("'%s' found", consts.FIND))
+    exec:push(consts.FD)
+  end
+  if consts.HAS_FIND then
+    exec:push(consts.FIND)
+  end
+
+  if exec:empty() then
+    vim.health.error("Missing 'fd'/'find'/'gfind'")
   else
-    vim.health.error("'fd'/'find'/'gfind' not found")
+    exec = exec
+      :map(function(value)
+        return stringize(value)
+      end)
+      :data()
+    vim.health.ok(string.format("Found %s", table.concat(exec, ",")))
   end
 end
 

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,5 +1,4 @@
 local consts = require("fzfx.lib.constants")
-local tbl = require("fzfx.commons.tbl")
 
 local M = {}
 

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -13,6 +13,16 @@ M._find = function()
   end
 end
 
+M._cat = function()
+  if consts.HAS_BAT then
+    vim.health.ok(string.format("'%s' found", consts.BAT))
+  elseif consts.HAS_CAT then
+    vim.health.ok(string.format("'%s' found", consts.CAT))
+  else
+    vim.health.error("'bat'/'batcat'/'cat' not found")
+  end
+end
+
 M.check = function()
   vim.health.start("fzfx")
 

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,6 +1,4 @@
 local consts = require("fzfx.lib.constants")
-local tbl = require("fzfx.commons.tbl")
-local str = require("fzfx.commons.str")
 
 local M = {}
 

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,4 +1,6 @@
 local consts = require("fzfx.lib.constants")
+local tbl = require("fzfx.commons.tbl")
+local str = require("fzfx.commons.str")
 
 local M = {}
 
@@ -9,8 +11,7 @@ M._common = function()
     vim.health.error("'echo' not found")
   end
   if consts.HAS_CURL then
-    local curl_info = vim.fn.systemlist({ consts.CURL, "--version" })
-    vim.health.ok(string.format("'%s' found: %s", consts.CURL, curl_info[1]))
+    vim.health.ok(string.format("'%s' found", consts.CURL))
   else
     vim.health.error("'curl' not found")
   end

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -59,12 +59,6 @@ local EXEC_CONFIGS = {
   },
 }
 
---- @param name string
---- @return string
-local function stringize(name)
-  return string.format("'%s'", name)
-end
-
 M.check = function()
   vim.health.start("fzfx")
 
@@ -78,7 +72,7 @@ M.check = function()
     if not exec:empty() then
       local all_exec = exec
         :map(function(value, index)
-          local result = stringize(value)
+          local result = string.format("'%s'", value)
           return (index == 1 and exec:length() > 1) and result .. " (preferred)" or result
         end)
         :data()
@@ -87,7 +81,7 @@ M.check = function()
       local all_exec = tbl.List
         :copy(config.fail)
         :map(function(value)
-          return stringize(value)
+          return string.format("'%s'", value)
         end)
         :data()
       vim.health.error(string.format("Missing %s", table.concat(all_exec, ",")))

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -77,8 +77,9 @@ M.check = function()
     end
     if not exec:empty() then
       local all_exec = exec
-        :map(function(value)
-          return stringize(value)
+        :map(function(value, index)
+          local result = stringize(value)
+          return (index == 1 and exec:length() > 1) and result .. " (preferred)" or result
         end)
         :data()
       vim.health.ok(string.format("Found %s", table.concat(all_exec, ",")))

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -9,6 +9,18 @@ M._files = function()
     execs:push(consts.FD)
   elseif consts.HAS_FIND then
     execs:push(consts.FIND)
+  else
+    vim.health.error(
+      string.format("'FzfxFiles' doesn't have providers, 'fd'/'find'/'gfind' not found")
+    )
+  end
+
+  if consts.HAS_BAT then
+    execs:push(consts.BAT)
+  elseif consts.HAS_CAT then
+    execs:push(consts.CAT)
+  else
+    vim.health.warn(string.format("'bat'/'cat' not found"))
   end
 
   execs = execs

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -10,14 +10,14 @@ M._files = function()
   elseif consts.HAS_FIND then
     execs:push(consts.FIND)
   end
+
   execs = execs
     :map(function(value, index)
       return string.format("'%s'", value)
     end)
     :data()
-  ---@diagnostic disable-next-line: cast-local-type
-  execs = table.concat(execs, ",")
-  vim.health.ok(string.format("'FzfxFiles' uses %s", execs))
+
+  vim.health.ok(string.format("'FzfxFiles' uses %s", table.concat(execs, ",")))
 end
 
 M.check = function()

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,0 +1,29 @@
+local consts = require("fzfx.lib.constants")
+local tbl = require("fzfx.commons.tbl")
+
+local M = {}
+
+M._files = function()
+  local execs = tbl.List:of()
+  if consts.HAS_FD then
+    execs:push(consts.FD)
+  elseif consts.HAS_FIND then
+    execs:push(consts.FIND)
+  end
+  execs = execs
+    :map(function(value, index)
+      return string.format("'%s'", value)
+    end)
+    :data()
+  ---@diagnostic disable-next-line: cast-local-type
+  execs = table.concat(execs, ",")
+  vim.health.ok(string.format("'FzfxFiles' uses %s", execs))
+end
+
+M.check = function()
+  vim.health.start("fzfx")
+
+  M._files()
+end
+
+return M

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -3,39 +3,20 @@ local tbl = require("fzfx.commons.tbl")
 
 local M = {}
 
-M._files = function()
-  local execs = tbl.List:of()
+M._find = function()
   if consts.HAS_FD then
-    execs:push(consts.FD)
+    vim.health.ok(string.format("'%s' found", consts.FD))
   elseif consts.HAS_FIND then
-    execs:push(consts.FIND)
+    vim.health.ok(string.format("'%s' found", consts.FIND))
   else
-    vim.health.error(
-      string.format("'FzfxFiles' doesn't have providers, 'fd'/'find'/'gfind' not found")
-    )
+    vim.health.error("'fd'/'find'/'gfind' not found")
   end
-
-  if consts.HAS_BAT then
-    execs:push(consts.BAT)
-  elseif consts.HAS_CAT then
-    execs:push(consts.CAT)
-  else
-    vim.health.warn(string.format("'bat'/'cat' not found"))
-  end
-
-  execs = execs
-    :map(function(value, index)
-      return string.format("'%s'", value)
-    end)
-    :data()
-
-  vim.health.ok(string.format("'FzfxFiles' uses %s", table.concat(execs, ",")))
 end
 
 M.check = function()
   vim.health.start("fzfx")
 
-  M._files()
+  M._find()
 end
 
 return M

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -9,7 +9,8 @@ M._common = function()
     vim.health.error("'echo' not found")
   end
   if consts.HAS_CURL then
-    vim.health.ok(string.format("'%s' found", consts.CURL))
+    local curl_info = vim.fn.systemlist({ consts.CURL, "--version" })
+    vim.health.ok(string.format("'%s' found: %s", consts.CURL, curl_info[1]))
   else
     vim.health.error("'curl' not found")
   end

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -1,0 +1,26 @@
+local cwd = vim.fn.getcwd()
+
+describe("health", function()
+  local assert_eq = assert.is_equal
+  local assert_true = assert.is_true
+  local assert_false = assert.is_false
+
+  before_each(function()
+    vim.api.nvim_command("cd " .. cwd)
+    vim.opt.swapfile = false
+    vim.health = {
+      start = function() end,
+      ok = function() end,
+      error = function() end,
+      warn = function() end,
+    }
+  end)
+
+  local health = require("fzfx.health")
+
+  describe("[check]", function()
+    it("run", function()
+      health.check()
+    end)
+  end)
+end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
