### PR TITLE
feat(health): add version info

### DIFF
--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -99,17 +99,17 @@ M.check = function()
           and tbl.list_not_empty(version.output)
           and #version.output >= version.line
         then
-          local merged = nil
+          local target_line = nil
           for i, out_line in ipairs(version.output) do
-            if i > version.line then
+            if i == version.line then
+              target_line = str.trim(out_line)
               break
             end
-            merged = merged and (merged .. "\t" .. str.trim(out_line)) or str.trim(out_line)
           end
-          msg = msg .. string.format("\n  - %s", merged)
+          msg = msg .. string.format("\n  - '%s': %s", version.name, target_line)
         else
           msg = msg
-            .. string.format("\n  - **Warning**: failed to get version info for '%s'", version.name)
+            .. string.format("\n  - (**Warning**) '%s': failed to get version info", version.name)
         end
       end
       vim.health.ok(msg)

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -99,14 +99,14 @@ M.check = function()
           and tbl.list_not_empty(version.output)
           and #version.output >= version.line
         then
-          local merged_lines = ""
-          for i, output_line in ipairs(version.output) do
+          local merged = nil
+          for i, out_line in ipairs(version.output) do
             if i > version.line then
               break
             end
-            merged_lines = merged_lines .. "\t" .. str.trim(output_line)
+            merged = merged and (merged .. "\t" .. str.trim(out_line)) or str.trim(out_line)
           end
-          msg = msg .. string.format("\n  - %s", merged_lines)
+          msg = msg .. string.format("\n  - %s", merged)
         else
           msg = msg
             .. string.format("\n  - **Warning**: failed to get version info for '%s'", version.name)

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,5 +1,6 @@
 local consts = require("fzfx.lib.constants")
 local tbl = require("fzfx.commons.tbl")
+local str = require("fzfx.commons.str")
 
 local M = {}
 
@@ -12,47 +13,47 @@ local EXEC_CONFIGS = {
   },
   {
     items = {
-      { cond = consts.HAS_CURL, name = consts.CURL },
+      { cond = consts.HAS_CURL, name = consts.CURL, version = "--version", line = 1 },
     },
     fail = { "curl" },
   },
   {
     items = {
-      { cond = consts.HAS_FD, name = consts.FD },
+      { cond = consts.HAS_FD, name = consts.FD, version = "--version", line = 1 },
       { cond = consts.HAS_FIND, name = consts.FIND },
     },
     fail = { "fd", "find", "gfind" },
   },
   {
     items = {
-      { cond = consts.HAS_BAT, name = consts.BAT },
+      { cond = consts.HAS_BAT, name = consts.BAT, version = "--version", line = 1 },
       { cond = consts.HAS_CAT, name = consts.CAT },
     },
     fail = { "bat", "batcat", "cat" },
   },
   {
     items = {
-      { cond = consts.HAS_RG, name = consts.RG },
+      { cond = consts.HAS_RG, name = consts.RG, version = "--version", line = 1 },
       { cond = consts.HAS_GREP, name = consts.GREP },
     },
     fail = { "rg", "grep", "ggrep" },
   },
   {
     items = {
-      { cond = consts.HAS_GIT, name = consts.GIT },
+      { cond = consts.HAS_GIT, name = consts.GIT, version = "--version", line = 1 },
     },
     fail = { "git" },
   },
   {
     items = {
-      { cond = consts.HAS_DELTA, name = consts.DELTA },
+      { cond = consts.HAS_DELTA, name = consts.DELTA, version = "--version", line = 1 },
     },
     fail = { "delta" },
   },
   {
     items = {
-      { cond = consts.HAS_LSD, name = consts.LSD },
-      { cond = consts.HAS_EZA, name = consts.EZA },
+      { cond = consts.HAS_LSD, name = consts.LSD, version = "--version", line = 1 },
+      { cond = consts.HAS_EZA, name = consts.EZA, version = "--version", line = 2 },
       { cond = consts.HAS_LS, name = consts.LS },
     },
     fail = { "lsd", "eza", "exa", "ls" },
@@ -66,22 +67,57 @@ M.check = function()
     local exec = tbl.List:of()
     for _, item in ipairs(config.items) do
       if item.cond then
-        exec:push(item.name)
+        exec:push(item)
       end
     end
     if not exec:empty() then
       local all_exec = exec
-        :map(function(value, index)
-          local result = string.format("'%s'", value)
+        :map(function(item, index)
+          local result = string.format("'%s'", item.name)
           return (index == 1 and exec:length() > 1) and result .. " (preferred)" or result
         end)
         :data()
-      vim.health.ok(string.format("Found %s", table.concat(all_exec, ",")))
+      local msg = string.format("Found %s", table.concat(all_exec, ","))
+      local all_version = exec
+        :filter(function(item)
+          return str.not_empty(item.version)
+        end)
+        :map(function(item)
+          local ok, output = pcall(vim.fn.systemlist, { item.name, item.version })
+          return {
+            ok = ok,
+            output = output,
+            line = item.line,
+            name = item.name,
+          }
+        end)
+        :data()
+      for _, version in ipairs(all_version) do
+        if
+          tbl.tbl_not_empty(version)
+          and version.ok
+          and tbl.list_not_empty(version.output)
+          and #version.output >= version.line
+        then
+          local merged_lines = ""
+          for i, output_line in ipairs(version.output) do
+            if i > version.line then
+              break
+            end
+            merged_lines = merged_lines .. "\t" .. str.trim(output_line)
+          end
+          msg = msg .. string.format("\n  - %s", merged_lines)
+        else
+          msg = msg
+            .. string.format("\n  - **Warning**: failed to get version info for '%s'", version.name)
+        end
+      end
+      vim.health.ok(msg)
     else
       local all_exec = tbl.List
         :copy(config.fail)
-        :map(function(value)
-          return string.format("'%s'", value)
+        :map(function(item)
+          return string.format("'%s'", item)
         end)
         :data()
       vim.health.error(string.format("Missing %s", table.concat(all_exec, ",")))


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
