### PR TITLE
refactor(health): refactor checkhealth

### DIFF
--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -143,6 +143,18 @@ M._versions = function(items)
   return result
 end
 
+--- @param misses string[]
+--- @return string
+M._misses = function(misses)
+  local result = tbl.List
+    :copy(misses)
+    :map(function(item)
+      return string.format("'%s'", item)
+    end)
+    :join(", ")
+  return "Missing " .. result
+end
+
 M.check = function()
   vim.health.start("fzfx")
 
@@ -159,13 +171,8 @@ M.check = function()
       msg = msg .. M._versions(items)
       vim.health.ok(msg)
     else
-      local misses = tbl.List
-        :copy(config.missed)
-        :map(function(item)
-          return string.format("'%s'", item)
-        end)
-        :join(", ")
-      vim.health.error(string.format("Missing %s", misses))
+      local msg = M._misses(config.missed)
+      vim.health.error(msg)
     end
   end
 end

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -95,7 +95,7 @@ end
 --- @return string
 M._versions = function(items)
   local result = ""
-  local all_version = items
+  items
     :map(function(
       item --[[@as fzfx.HealthCheckItem]]
     )
@@ -128,8 +128,8 @@ M._versions = function(items)
         and #ver.output >= ver.line
       then
         local target_line = nil
-        for j, out_line in ipairs(ver.output) do
-          if j == ver.line then
+        for i, out_line in ipairs(ver.output) do
+          if i == ver.line then
             target_line = str.trim(out_line)
             break
           end
@@ -159,13 +159,13 @@ M.check = function()
       msg = msg .. M._versions(items)
       vim.health.ok(msg)
     else
-      local missed_items = tbl.List
+      local misses = tbl.List
         :copy(config.missed)
         :map(function(item)
           return string.format("'%s'", item)
         end)
-        :data()
-      vim.health.error(string.format("Missing %s", table.concat(missed_items, ", ")))
+        :join(", ")
+      vim.health.error(string.format("Missing %s", misses))
     end
   end
 end

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable: redundant-parameter
+
 local consts = require("fzfx.lib.constants")
 local tbl = require("fzfx.commons.tbl")
 local str = require("fzfx.commons.str")

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -4,7 +4,7 @@ local str = require("fzfx.commons.str")
 
 local M = {}
 
-local EXEC_CONFIGS = {
+local CHECKS = {
   {
     items = {
       { cond = consts.HAS_FZF, name = consts.FZF, version = "--version", line = 1 },
@@ -70,7 +70,7 @@ local EXEC_CONFIGS = {
 M.check = function()
   vim.health.start("fzfx")
 
-  for _, config in ipairs(EXEC_CONFIGS) do
+  for _, config in ipairs(CHECKS) do
     local exec = tbl.List:of()
     for _, item in ipairs(config.items) do
       if item.cond then
@@ -140,7 +140,7 @@ M.check = function()
         end)
         :data()
       local fail_level = config.fail_level or "error"
-      local fail_message = vim.health[fail_level]
+      local fail_message = vim.health[fail_level] --[[@as function]]
       fail_message(string.format("Missing %s", table.concat(all_exec, ", ")))
     end
   end

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -9,53 +9,53 @@ local CHECKS = {
     items = {
       { cond = consts.HAS_FZF, name = consts.FZF, version = "--version", line = 1 },
     },
-    fail = { "fzf" },
+    missed = { "fzf" },
   },
   {
     items = {
       { cond = consts.HAS_ECHO, name = consts.ECHO },
     },
-    fail = { "echo" },
+    missed = { "echo" },
   },
   {
     items = {
       { cond = consts.HAS_CURL, name = consts.CURL, version = "--version", line = 1 },
     },
-    fail = { "curl" },
+    missed = { "curl" },
   },
   {
     items = {
       { cond = consts.HAS_FD, name = consts.FD, version = "--version", line = 1 },
       { cond = consts.HAS_FIND, name = consts.FIND },
     },
-    fail = { "fd", "find", "gfind" },
+    missed = { "fd", "find", "gfind" },
   },
   {
     items = {
       { cond = consts.HAS_BAT, name = consts.BAT, version = "--version", line = 1 },
       { cond = consts.HAS_CAT, name = consts.CAT },
     },
-    fail = { "bat", "batcat", "cat" },
+    missed = { "bat", "batcat", "cat" },
   },
   {
     items = {
       { cond = consts.HAS_RG, name = consts.RG, version = "--version", line = 1 },
       { cond = consts.HAS_GREP, name = consts.GREP },
     },
-    fail = { "rg", "grep", "ggrep" },
+    missed = { "rg", "grep", "ggrep" },
   },
   {
     items = {
       { cond = consts.HAS_GIT, name = consts.GIT, version = "--version", line = 1 },
     },
-    fail = { "git" },
+    missed = { "git" },
   },
   {
     items = {
       { cond = consts.HAS_DELTA, name = consts.DELTA, version = "--version", line = 1 },
     },
-    fail = { "delta" },
-    fail_level = "warn",
+    missed = { "delta" },
+    missed_level = "warn",
   },
   {
     items = {
@@ -63,7 +63,7 @@ local CHECKS = {
       { cond = consts.HAS_EZA, name = consts.EZA, version = "--version", line = 2 },
       { cond = consts.HAS_LS, name = consts.LS },
     },
-    fail = { "lsd", "eza", "exa", "ls" },
+    missed = { "lsd", "eza", "exa", "ls" },
   },
 }
 
@@ -133,15 +133,13 @@ M.check = function()
       end
       vim.health.ok(msg)
     else
-      local all_exec = tbl.List
-        :copy(config.fail)
+      local missed_items = tbl.List
+        :copy(config.missed)
         :map(function(item)
           return string.format("'%s'", item)
         end)
         :data()
-      local fail_level = config.fail_level or "error"
-      local fail_message = vim.health[fail_level] --[[@as function]]
-      fail_message(string.format("Missing %s", table.concat(all_exec, ", ")))
+      vim.health.error(string.format("Missing %s", table.concat(missed_items, ", ")))
     end
   end
 end

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -89,6 +89,10 @@ M._summary = function(items)
   return "Found " .. founded_items
 end
 
+--- @param items commons.List
+--- @return string
+M._versions = function(items) end
+
 M.check = function()
   vim.health.start("fzfx")
 

--- a/lua/fzfx/health.lua
+++ b/lua/fzfx/health.lua
@@ -9,7 +9,7 @@ local M = {}
 --- @alias fzfx.HealthCheckItem {cond:boolean,name:string,version:string?,line:integer?}
 --- @alias fzfx.HealthCheck {items:fzfx.HealthCheckItem[],missed:string[]}
 --- @type fzfx.HealthCheck[]
-local HEALTH_CHECKS = {
+M.HEALTH_CHECKS = {
   {
     items = {
       { cond = consts.HAS_FZF, name = consts.FZF, version = "--version", line = 1 },
@@ -158,7 +158,7 @@ end
 M.check = function()
   vim.health.start("fzfx")
 
-  for _, config in ipairs(HEALTH_CHECKS) do
+  for _, config in ipairs(M.HEALTH_CHECKS) do
     local configured_items = tbl.List:copy(config.items)
     local items = configured_items:filter(function(
       item --[[@as fzfx.HealthCheckItem]]

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -17,10 +17,34 @@ describe("health", function()
   end)
 
   local health = require("fzfx.health")
+  local tbl = require("fzfx.commons.tbl")
+  local str = require("fzfx.commons.str")
 
   describe("[check]", function()
     it("run", function()
       health.check()
+    end)
+    it("_misses", function()
+      local actual1 = health._misses({ "a", "b", "c" })
+      assert_eq(actual1, "Missing 'a', 'b', 'c'")
+      local actual2 = health._misses({})
+      assert_eq(actual2, "Missing ")
+    end)
+    it("_versions", function()
+      for _, config in ipairs(health.HEALTH_CHECKS) do
+        local configured_items = tbl.List:copy(config.items)
+        local items = configured_items:filter(function(
+          item --[[@as fzfx.HealthCheckItem]]
+        )
+          return item.cond
+        end)
+
+        if not items:empty() then
+          local actual = health._versions(items)
+          print(string.format("actual:%s\n", vim.inspect(actual)))
+          assert_true(str.startswith(actual, "\n  - ") or str.empty(actual))
+        end
+      end
     end)
   end)
 end)

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -46,5 +46,21 @@ describe("health", function()
         end
       end
     end)
+    it("_summary", function()
+      for _, config in ipairs(health.HEALTH_CHECKS) do
+        local configured_items = tbl.List:copy(config.items)
+        local items = configured_items:filter(function(
+          item --[[@as fzfx.HealthCheckItem]]
+        )
+          return item.cond
+        end)
+
+        if not items:empty() then
+          local actual = health._summary(items)
+          print(string.format("actual:%s\n", vim.inspect(actual)))
+          assert_true(str.startswith(actual, "Found "))
+        end
+      end
+    end)
   end)
 end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
