### PR TITLE
refactor(lsp locations): part 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,7 @@ jobs:
           sudo apt-get -y -qq install bat
           sudo apt-get -y -qq install fzf
           luarocks install luacov
-          luarocks install luacov-reporter-lcov
-          luarocks install vusted
+          luarocks --lua-version=5.1 install vusted
           vusted --coverage ./spec
       - name: Generate Reports
         run: |
@@ -91,10 +90,10 @@ jobs:
           ls -l .
           echo "tail ./luacov.report.out"
           tail -n 50 ./luacov.report.out
-          cp luacov.report.out luacov.report.txt
+          # cp luacov.report.out luacov.report.txt
       - uses: codecov/codecov-action@v4
         with:
-          files: luacov.report.txt
+          files: luacov.report.out
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           sudo apt-get -y -qq install bat
           sudo apt-get -y -qq install fzf
           luarocks install luacov
+          luarocks install luacov-reporter-lcov
           luarocks --lua-version=5.1 install vusted
           vusted --coverage ./spec
       - name: Generate Reports
@@ -85,7 +86,7 @@ jobs:
           echo "ls ."
           ls -l .
           echo "run luacov"
-          luacov
+          luacov -r lcov
           echo "ls ."
           ls -l .
           echo "tail ./luacov.report.out"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           echo "ls ."
           ls -l .
           echo "run luacov"
-          luacov -r lcov
+          luacov
           echo "ls ."
           ls -l .
           echo "tail ./luacov.report.out"

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-## Common
+## Common Issues
 
 ### 1. Whitespace Escaping Issue
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD001 MD013 MD034 MD033 MD051 MD041 -->
 
 - [Home](/)
-- [Generic Schema](/GenericSchema.md)
+- [A Generic Schema for Creating FZF Command](/GenericSchema.md)
 - [API References](/ApiReferences.md)
 - [Known Issues](/KnownIssues.md)

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -15,11 +15,15 @@ local previewers_helper = require("fzfx.helper.previewers")
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 
 -- Please see:
--- Microsoft LSP specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+-- LSP specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
 -- Neovim LSP manual: https://neovim.io/doc/user/lsp.html
 
 local M = {}
 
+-- Please see:
+-- LSP specification - Location: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
+-- LSP specification - LocationLink: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink
+--
 --- @alias fzfx.LspRangeStart {line:integer,character:integer}
 --- @alias fzfx.LspRangeEnd {line:integer,character:integer}
 --- @alias fzfx.LspRange {start:fzfx.LspRangeStart,end:fzfx.LspRangeEnd}
@@ -155,8 +159,9 @@ end
 
 -- locations {
 
--- lsp methods: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp/protocol.lua#L1028
--- lsp capabilities: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp.lua#L39
+-- Please see:
+-- Neovim LSP methods: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp/protocol.lua#L1028
+-- Neovim LSP capabilities: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp.lua#L39
 --
 --- @alias fzfx.LspMethod "textDocument/definition"|"textDocument/type_definition"|"textDocument/references"|"textDocument/implementation"|"callHierarchy/incomingCalls"|"callHierarchy/outgoingCalls"|"textDocument/prepareCallHierarchy"
 --- @alias fzfx.LspServerCapability "definitionProvider"|"typeDefinitionProvider"|"referencesProvider"|"implementationProvider"|"callHierarchyProvider"

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -14,6 +14,10 @@ local previewers_helper = require("fzfx.helper.previewers")
 
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 
+-- Please see:
+-- Microsoft LSP specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+-- Neovim LSP manual: https://neovim.io/doc/user/lsp.html
+
 local M = {}
 
 --- @alias fzfx.LspRangeStart {line:integer,character:integer}

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -10,6 +10,7 @@ local term_color = require("fzfx.commons.color.term")
 local switches = require("fzfx.lib.switches")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
+local lsp = require("fzfx.lib.lsp")
 
 local actions_helper = require("fzfx.helper.actions")
 local labels_helper = require("fzfx.helper.previewer_labels")
@@ -173,13 +174,12 @@ end
 
 -- locations {
 
--- Please see:
 -- Neovim LSP methods: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp/protocol.lua#L1028
 -- Neovim LSP capabilities: https://github.com/neovim/neovim/blob/dc9f7b814517045b5354364655f660aae0989710/runtime/lua/vim/lsp.lua#L39
 --
 --- @alias fzfx.LspMethod "textDocument/definition"|"textDocument/type_definition"|"textDocument/references"|"textDocument/implementation"|"callHierarchy/incomingCalls"|"callHierarchy/outgoingCalls"|"textDocument/prepareCallHierarchy"
 --- @alias fzfx.LspServerCapability "definitionProvider"|"typeDefinitionProvider"|"referencesProvider"|"implementationProvider"|"callHierarchyProvider"
----
+
 --- @param opts {method:fzfx.LspMethod,capability:fzfx.LspServerCapability,timeout:integer?}
 --- @return fun(query:string,context:fzfx.LspLocationPipelineContext):string[]|nil
 M._make_lsp_locations_provider = function(opts)
@@ -187,8 +187,7 @@ M._make_lsp_locations_provider = function(opts)
   --- @param context fzfx.LspLocationPipelineContext
   --- @return string[]|nil
   local function impl(query, context)
-    ---@diagnostic disable-next-line: deprecated
-    local lsp_clients = vim.lsp.get_active_clients({ bufnr = context.bufnr })
+    local lsp_clients = lsp.get_clients({ bufnr = context.bufnr })
     if tbl.tbl_empty(lsp_clients) then
       log.echo(LogLevels.INFO, "no active lsp clients.")
       return nil

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -113,7 +113,7 @@ end
 --- @param loc fzfx.LspLocation|fzfx.LspLocationLink
 --- @return string?
 M._render_lsp_location_to_line = function(loc)
-  -- log.debug("|_render_lsp_location_line| loc:%s", vim.inspect(loc))
+  -- log.debug("|_render_lsp_location_to_line| loc:%s", vim.inspect(loc))
 
   --- @type string
   local filename
@@ -124,7 +124,7 @@ M._render_lsp_location_to_line = function(loc)
     filename = path.reduce(vim.uri_to_fname(loc.uri))
     range = loc.range
     -- log.debug(
-    --   "|_render_lsp_location_line| location filename:%s, range:%s",
+    --   "|_render_lsp_location_to_line| location filename:%s, range:%s",
     --   vim.inspect(filename),
     --   vim.inspect(range)
     -- )
@@ -132,7 +132,7 @@ M._render_lsp_location_to_line = function(loc)
     filename = path.reduce(vim.uri_to_fname(loc.targetUri))
     range = loc.targetRange
     -- log.debug(
-    --   "|_render_lsp_location_line| locationlink filename:%s, range:%s",
+    --   "|_render_lsp_location_to_line| locationlink filename:%s, range:%s",
     --   vim.inspect(filename),
     --   vim.inspect(range)
     -- )
@@ -153,7 +153,7 @@ M._render_lsp_location_to_line = function(loc)
 
   local line = M._colorize_lsp_range(filelines[range.start.line + 1], range, term_color.red)
   -- log.debug(
-  --   "|_render_lsp_location_line| range:%s, loc_line:%s",
+  --   "|_render_lsp_location_to_line| range:%s, loc_line:%s",
   --   vim.inspect(range),
   --   vim.inspect(loc_line)
   -- )
@@ -165,7 +165,7 @@ M._render_lsp_location_to_line = function(loc)
     line
   )
   -- log.debug(
-  --   "|fzfx.config - _render_lsp_location_line| line:%s",
+  --   "|fzfx.config - _render_lsp_location_to_line| line:%s",
   --   vim.inspect(line)
   -- )
   return rendered_line

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -395,7 +395,6 @@ M._make_lsp_call_hierarchy_provider = function(opts)
   --- @param context fzfx.LspLocationPipelineContext
   --- @return string[]|nil
   local function impl(query, context)
-    ---@diagnostic disable-next-line: deprecated
     local lsp_clients = lsp.get_clients({ bufnr = context.bufnr })
     if tbl.tbl_empty(lsp_clients) then
       log.echo(LogLevels.INFO, "no active lsp clients.")

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -24,14 +24,16 @@ local M = {}
 -- LSP specification - Location: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
 -- LSP specification - LocationLink: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink
 -- LSP specification - Range: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
+-- LSP specification - DocumentUri: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentUri
 --
 --- @alias fzfx.LspRangeStart {line:integer,character:integer}
 --- @alias fzfx.LspRangeEnd {line:integer,character:integer}
 --- @alias fzfx.LspRange {start:fzfx.LspRangeStart,end:fzfx.LspRangeEnd}
---- @alias fzfx.LspLocation {uri:string,range:fzfx.LspRange}
---- @alias fzfx.LspLocationLink {originSelectionRange:fzfx.LspRange,targetUri:string,targetRange:fzfx.LspRange,targetSelectionRange:fzfx.LspRange}
+--- @alias fzfx.LspDocumentUri string
+--- @alias fzfx.LspLocation {uri:fzfx.LspDocumentUri,range:fzfx.LspRange}
+--- @alias fzfx.LspLocationLink {originSelectionRange:fzfx.LspRange,targetUri:fzfx.LspDocumentUri,targetRange:fzfx.LspRange,targetSelectionRange:fzfx.LspRange}
 
---- @param r fzfx.LspRange?
+--- @param r fzfx.LspRange|any
 --- @return boolean
 M._is_lsp_range = function(r)
   return type(tbl.tbl_get(r, "start", "line")) == "number"
@@ -40,14 +42,21 @@ M._is_lsp_range = function(r)
     and type(tbl.tbl_get(r, "end", "character")) == "number"
 end
 
---- @param loc fzfx.LspLocation|fzfx.LspLocationLink|nil
+--- @param u fzfx.LspDocumentUri|any
+--- @return boolean
+M._is_lsp_document_uri = function(u)
+  return type(u) == "string"
+end
+
+--- @param loc fzfx.LspLocation|fzfx.LspLocationLink|any
 M._is_lsp_location = function(loc)
-  return type(tbl.tbl_get(loc, "uri")) == "string" and M._is_lsp_range(tbl.tbl_get(loc, "range"))
+  return M._is_lsp_document_uri(tbl.tbl_get(loc, "uri"))
+    and M._is_lsp_range(tbl.tbl_get(loc, "range"))
 end
 
 --- @param loc fzfx.LspLocation|fzfx.LspLocationLink|nil
 M._is_lsp_locationlink = function(loc)
-  return type(tbl.tbl_get(loc, "targetUri")) == "string"
+  return M._is_lsp_document_uri(tbl.tbl_get(loc, "targetUri"))
     and M._is_lsp_range(tbl.tbl_get(loc, "targetRange"))
 end
 

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -298,21 +298,21 @@ M._is_lsp_call_hierarchy_item = function(item)
 end
 
 --- @param method string
---- @param call_item fzfx.LspCallHierarchyIncomingCall|any
+--- @param call fzfx.LspCallHierarchyIncomingCall|any
 --- @return boolean
-M._is_lsp_call_hierarchy_incoming_call = function(method, call_item)
+M._is_lsp_call_hierarchy_incoming_call = function(method, call)
   return method == "callHierarchy/incomingCalls"
-    and M._is_lsp_call_hierarchy_item(tbl.tbl_get(call_item, "from"))
-    and type(tbl.tbl_get(call_item, "fromRanges")) == "table"
+    and M._is_lsp_call_hierarchy_item(tbl.tbl_get(call, "from"))
+    and type(tbl.tbl_get(call, "fromRanges")) == "table"
 end
 
 --- @param method string
---- @param call_item fzfx.LspCallHierarchyOutgoingCall|any
+--- @param call fzfx.LspCallHierarchyOutgoingCall|any
 --- @return boolean
-M._is_lsp_call_hierarchy_outgoing_call = function(method, call_item)
+M._is_lsp_call_hierarchy_outgoing_call = function(method, call)
   return method == "callHierarchy/outgoingCalls"
-    and M._is_lsp_call_hierarchy_item(tbl.tbl_get(call_item, "to"))
-    and type(tbl.tbl_get(call_item, "fromRanges")) == "table"
+    and M._is_lsp_call_hierarchy_item(tbl.tbl_get(call, "to"))
+    and type(tbl.tbl_get(call, "fromRanges")) == "table"
 end
 
 --- @param item fzfx.LspCallHierarchyItem
@@ -377,13 +377,13 @@ M._render_lsp_call_hierarchy_to_lines = function(item, ranges)
 end
 
 --- @param method fzfx.LspMethod
---- @param hi_item fzfx.LspCallHierarchyIncomingCall|fzfx.LspCallHierarchyOutgoingCall
+--- @param call fzfx.LspCallHierarchyIncomingCall|fzfx.LspCallHierarchyOutgoingCall
 --- @return fzfx.LspCallHierarchyItem?, fzfx.LspRange[]|nil
-M._retrieve_lsp_call_hierarchy_item_and_from_ranges = function(method, hi_item)
-  if M._is_lsp_call_hierarchy_incoming_call(method, hi_item) then
-    return hi_item.from, hi_item.fromRanges
-  elseif M._is_lsp_call_hierarchy_outgoing_call(method, hi_item) then
-    return hi_item.to, hi_item.fromRanges
+M._retrieve_lsp_call_hierarchy_item_and_from_ranges = function(method, call)
+  if M._is_lsp_call_hierarchy_incoming_call(method, call) then
+    return call.from, call.fromRanges
+  elseif M._is_lsp_call_hierarchy_outgoing_call(method, call) then
+    return call.to, call.fromRanges
   else
     return nil, nil
   end

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -23,6 +23,7 @@ local M = {}
 -- Please see:
 -- LSP specification - Location: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
 -- LSP specification - LocationLink: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink
+-- LSP specification - Range: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
 --
 --- @alias fzfx.LspRangeStart {line:integer,character:integer}
 --- @alias fzfx.LspRangeEnd {line:integer,character:integer}

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -396,7 +396,7 @@ M._make_lsp_call_hierarchy_provider = function(opts)
   --- @return string[]|nil
   local function impl(query, context)
     ---@diagnostic disable-next-line: deprecated
-    local lsp_clients = vim.lsp.get_active_clients({ bufnr = context.bufnr })
+    local lsp_clients = lsp.get_clients({ bufnr = context.bufnr })
     if tbl.tbl_empty(lsp_clients) then
       log.echo(LogLevels.INFO, "no active lsp clients.")
       return nil

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -550,15 +550,19 @@ M._lsp_position_context_maker = function()
   return context
 end
 
--- if you want to use fzf-builtin previewer with bat, please use below configs:
+-- If you want to use fzf-builtin previewer with bat, please use below configs:
 --
+-- ```
 -- previewer = previewers_helper.preview_files_grep
 -- previewer_type = PreviewerTypeEnum.COMMAND_LIST
-
--- if you want to use nvim buffer previewer, please use below configs:
+-- ```
 --
+-- If you want to use nvim buffer previewer, please use below configs:
+--
+-- ```
 -- previewer = previewers_helper.buffer_preview_files_grep
 -- previewer_type = PreviewerTypeEnum.BUFFER_FILE
+-- ```
 
 local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_grep
   or previewers_helper.buffer_preview_files_grep

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -274,26 +274,27 @@ end
 
 -- call hierarchy {
 
+-- LSP Call Hierarchy: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy
 --- @alias fzfx.LspCallHierarchyItem {name:string,kind:integer,detail:string?,uri:string,range:fzfx.LspRange,selectionRange:fzfx.LspRange}
+--- LSP Call Hierarchy Incoming Calls: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls
 --- @alias fzfx.LspCallHierarchyIncomingCall {from:fzfx.LspCallHierarchyItem,fromRanges:fzfx.LspRange[]}
+--- LSP Call Hierarchy Outgoing Calls: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_outgoingCalls
 --- @alias fzfx.LspCallHierarchyOutgoingCall {to:fzfx.LspCallHierarchyItem,fromRanges:fzfx.LspRange[]}
 
---- @param item fzfx.LspCallHierarchyItem?
+--- @param item fzfx.LspCallHierarchyItem|any
 --- @return boolean
 M._is_lsp_call_hierarchy_item = function(item)
   -- log.debug(
   --   "|fzfx.config - _is_lsp_call_hierarchy_item| item:%s",
   --   vim.inspect(item)
   -- )
-  return type(item) == "table"
-    and type(item.name) == "string"
-    and string.len(item.name) > 0
-    and (item.kind ~= nil)
-    and (item.detail == nil or type(item.detail) == "string")
-    and type(item.uri) == "string"
-    and string.len(item.uri) > 0
-    and M._is_lsp_range(item.range)
-    and M._is_lsp_range(item.selectionRange)
+  local item_detail = tbl.tbl_get(item, "detail")
+  return type(tbl.tbl_get(item, "name")) == "string" -- name
+    and tbl.tbl_get(item, "kind") ~= nil -- kind
+    and (item_detail == nil or type(item_detail) == "string") -- detail
+    and type(tbl.tbl_get(item, "uri")) == "string" -- uri
+    and M._is_lsp_range(item.range) -- range
+    and M._is_lsp_range(item.selectionRange) -- selectionRange
 end
 
 --- @param method string

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -1,3 +1,7 @@
+-- Please see:
+-- LSP specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+-- Neovim LSP manual: https://neovim.io/doc/user/lsp.html
+
 local tbl = require("fzfx.commons.tbl")
 local path = require("fzfx.commons.path")
 local fileio = require("fzfx.commons.fileio")
@@ -14,23 +18,17 @@ local previewers_helper = require("fzfx.helper.previewers")
 
 local PreviewerTypeEnum = require("fzfx.schema").PreviewerTypeEnum
 
--- Please see:
--- LSP specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
--- Neovim LSP manual: https://neovim.io/doc/user/lsp.html
-
 local M = {}
 
--- Please see:
--- LSP specification - Location: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
--- LSP specification - LocationLink: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink
--- LSP specification - Range: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
--- LSP specification - DocumentUri: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentUri
---
+-- LSP Range: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
 --- @alias fzfx.LspRangeStart {line:integer,character:integer}
 --- @alias fzfx.LspRangeEnd {line:integer,character:integer}
 --- @alias fzfx.LspRange {start:fzfx.LspRangeStart,end:fzfx.LspRangeEnd}
+-- LSP DocumentUri: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentUri
 --- @alias fzfx.LspDocumentUri string
+-- LSP Location: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location
 --- @alias fzfx.LspLocation {uri:fzfx.LspDocumentUri,range:fzfx.LspRange}
+-- LSP LocationLink: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#locationLink
 --- @alias fzfx.LspLocationLink {originSelectionRange:fzfx.LspRange,targetUri:fzfx.LspDocumentUri,targetRange:fzfx.LspRange,targetSelectionRange:fzfx.LspRange}
 
 --- @param r fzfx.LspRange|any
@@ -48,13 +46,13 @@ M._is_lsp_document_uri = function(u)
   return type(u) == "string"
 end
 
---- @param loc fzfx.LspLocation|fzfx.LspLocationLink|any
+--- @param loc fzfx.LspLocation|any
 M._is_lsp_location = function(loc)
   return M._is_lsp_document_uri(tbl.tbl_get(loc, "uri"))
     and M._is_lsp_range(tbl.tbl_get(loc, "range"))
 end
 
---- @param loc fzfx.LspLocation|fzfx.LspLocationLink|nil
+--- @param loc fzfx.LspLocationLink|any
 M._is_lsp_locationlink = function(loc)
   return M._is_lsp_document_uri(tbl.tbl_get(loc, "targetUri"))
     and M._is_lsp_range(tbl.tbl_get(loc, "targetRange"))
@@ -63,7 +61,7 @@ end
 --- @param line string
 --- @param range fzfx.LspRange
 --- @param renderer fun(text:string):string
---- @return string?
+--- @return string
 M._colorize_lsp_range = function(line, range, renderer)
   local line_start = range.start.character + 1
   local line_end = range["end"].line ~= range.start.line and #line

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -3,6 +3,7 @@
 -- Neovim LSP manual: https://neovim.io/doc/user/lsp.html
 
 local tbl = require("fzfx.commons.tbl")
+local str = require("fzfx.commons.str")
 local path = require("fzfx.commons.path")
 local fileio = require("fzfx.commons.fileio")
 local term_color = require("fzfx.commons.color.term")
@@ -234,23 +235,23 @@ M._make_lsp_locations_provider = function(opts)
       pairs(response --[[@as table]])
     do
       if client_id ~= nil and tbl.tbl_not_empty(tbl.tbl_get(client_response, "result")) then
-        local lsp_loc = client_response.result
-        if M._is_lsp_location(lsp_loc) then
-          local loc_hash = M._hash_lsp_location(lsp_loc)
+        local locations = client_response.result
+        if M._is_lsp_location(locations) then
+          local loc_hash = M._hash_lsp_location(locations)
           if visited_locations[loc_hash] == nil then
             visited_locations[loc_hash] = true
-            local line = M._render_lsp_location_to_line(lsp_loc)
-            if type(line) == "string" and string.len(line) > 0 then
+            local line = M._render_lsp_location_to_line(locations)
+            if str.not_empty(line) then
               table.insert(results, line)
             end
           end
         else
-          for _, loc in ipairs(lsp_loc) do
+          for _, loc in ipairs(locations) do
             local loc_hash = M._hash_lsp_location(loc)
             if visited_locations[loc_hash] == nil then
               visited_locations[loc_hash] = true
               local line = M._render_lsp_location_to_line(loc)
-              if type(line) == "string" and string.len(line) > 0 then
+              if str.not_empty(line) then
                 table.insert(results, line)
               end
             end

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -2,7 +2,7 @@ local tbl = require("fzfx.commons.tbl")
 local path = require("fzfx.commons.path")
 local str = require("fzfx.commons.str")
 local num = require("fzfx.commons.num")
-local term_color = require("fzfx.commons.color.term")
+local color_term = require("fzfx.commons.color.term")
 local fileio = require("fzfx.commons.fileio")
 local spawn = require("fzfx.commons.spawn")
 local uv = require("fzfx.commons.uv")
@@ -679,7 +679,7 @@ local HeaderSwitch = {}
 --- @param action string
 --- @return string
 local function _render_help(name, action)
-  return term_color.magenta(string.upper(action), "Special")
+  return color_term.magenta(string.upper(action), "Special")
     .. " to "
     .. table.concat(str.split(name, "_"), " ")
 end

--- a/lua/fzfx/lib/lsp.lua
+++ b/lua/fzfx/lib/lsp.lua
@@ -1,0 +1,8 @@
+local version = require("fzfx.commons.version")
+
+local M = {}
+
+---@diagnostic disable-next-line: deprecated
+M.get_clients = version.ge("0.10") and vim.lsp.get_clients or vim.lsp.get_active_clients
+
+return M

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -7,6 +7,7 @@
 -- ========== Provider ==========
 --
 --- @alias fzfx.PlainProvider string|string[]
+-- Note: The 1st parameter 'query' is the user input query in fzf prompt.
 --- @alias fzfx.CommandProvider fun(query:string?,context:fzfx.PipelineContext?):string?|string[]?
 --- @alias fzfx.ListProvider fun(query:string?,context:fzfx.PipelineContext?):string[]?
 --- @alias fzfx.Provider fzfx.PlainProvider|fzfx.CommandProvider|fzfx.ListProvider
@@ -24,19 +25,15 @@ local ProviderTypeEnum = {
   LIST = "list",
 }
 --
--- Note: the 1st parameter 'query' is the user input query in fzf prompt.
---
---
 -- ========== Provider Decorator ==========
 --
+-- Note: In `fzfx._FunctionProviderDecorator`, the 1st parameter `line` is the raw generated line from providers.
 --- @alias fzfx._FunctionProviderDecorator fun(line:string?):string?
 --- @alias fzfx.ProviderDecorator {module:string,rtp:string?,builtin:boolean?}
 --
--- Note: in `fzfx._FunctionProviderDecorator`, the 1st parameter `line` is the raw generated line from providers.
---
---
 -- ========== Previewer ==========
 --
+-- Note: The 1st parameter 'line' is the current selected line in (the left side of) the fzf binary.
 --- @alias fzfx.CommandPreviewer fun(line:string?,context:fzfx.PipelineContext?):string?
 --- @alias fzfx.ListPreviewer fun(line:string?,context:fzfx.PipelineContext?):string[]?
 --- @alias fzfx.BufferFilePreviewerResult {filename:string,lineno:integer?,column:integer?}
@@ -52,12 +49,10 @@ local PreviewerTypeEnum = {
   BUFFER_FILE = "buffer_file",
 }
 --
--- Note: the 1st parameter 'line' is the current selected line in (the left side of) the fzf binary.
---
---
 -- ========== Previewer Label ==========
 --
 --- @alias fzfx.PlainPreviewerLabel string
+-- Note: The 1st parameter 'line' is the current selected line in (the left side of) the fzf binary.
 --- @alias fzfx.FunctionPreviewerLabel fun(line:string?,context:fzfx.PipelineContext?):string?
 --- @alias fzfx.PreviewerLabel fzfx.PlainPreviewerLabel|fzfx.FunctionPreviewerLabel
 ---
@@ -67,9 +62,6 @@ local PreviewerLabelTypeEnum = {
   PLAIN = "plain",
   FUNCTION = "function",
 }
---
--- Note: the 1st parameter 'line' is the current selected line in (the left side of) the fzf binary.
---
 --
 -- ========== Command Feed ==========
 --
@@ -83,7 +75,6 @@ local CommandFeedEnum = {
   RESUME = "resume",
 }
 --
---
 -- ========== Fzf Option ==========
 --
 --- @alias fzfx.PlainFzfOpt string
@@ -92,37 +83,52 @@ local CommandFeedEnum = {
 ---
 --- @alias fzfx.FzfOpt fzfx.PlainFzfOpt|fzfx.PairFzfOpt|fzfx.FunctionFzfOpt
 --
---
 -- ========== Interaction/Action ==========
 --
 --- @alias fzfx.ActionKey string
+-- Note: The 1st parameter in `Interaction` is the current line.
 --- @alias fzfx.Interaction fun(line:string?,context:fzfx.PipelineContext):any
+-- Note: The 1st parameter in `Action` is the selected line(s).
 --- @alias fzfx.Action fun(line:string[]|nil,context:fzfx.PipelineContext):any
---
--- Note: the 1st parameter in `Interaction` is the current line.
--- Note: the 1st parameter in `Action` is the selected line(s).
---
 --
 -- ========== Config ==========
 --
+-- Note:
+-- 1. The "key" option is to press and switch to this provider. For example in "FzfxFiles" command, user press "CTRL-U" to switch to **unrestricted mode**, press "CTRL-R" to switch to **restricted mode** (here a **mode** is actually a provider).
+-- 2. The "provider" option is the **provider** we mentioned above, that provides the data source, i.e. the lines (in the left side) of fzf binary.
+-- 3. The "provider_type" option by default is "plain" or "plain_list". Also see "get_provider_type_or_default" function in below.
+-- 4. The "provider_decorator" option is optional.
 --- @alias fzfx.ProviderConfig {key:fzfx.ActionKey,provider:fzfx.Provider,provider_type:fzfx.ProviderType?,provider_decorator:fzfx.ProviderDecorator?}
---- The 'provider_type' by default is "plain"
-
+--
+-- Note:
+-- 1. The "previewer" option is the **previewer** we mentioned above, that previews the content of the current line, i.e. generates lines (in the right side) of fzf binary.
+-- 2. The "previewer_type" option by default "command". Also see "get_previewer_type_or_default" function in below.
+-- 3. The "previewer_label" option is optional.
+-- 4. The "previewer_label_type" option by default is "plain" or "function". Also see "get_previewer_label_type_or_default" function in below.
 --- @alias fzfx.PreviewerConfig {previewer:fzfx.Previewer,previewer_type:fzfx.PreviewerType?,previewer_label:fzfx.PreviewerLabel?,previewer_label_type:fzfx.PreviewerLabelType?}
-
+---
+--
+-- Note: A pipeline name is the same with the provider name.
 --- @alias fzfx.PipelineName string
--- a pipeline name is a provider name, a previewer name
 --
 --- @alias fzfx.InteractionName string
 --
+-- Note:
+-- 1. The "key" option is to press and invokes the binded lua function.
+-- 2. The "interaction" option is the **interaction** we mentioned above.
+-- 3. The "reload_after_execute" option is to tell fzf binary, that reloads the query after execute this interaction.
 --- @alias fzfx.InteractionConfig {key:fzfx.ActionKey,interaction:fzfx.Interaction,reload_after_execute:boolean?}
---
+---
+-- Note: Please refer to the command configurations in "fzfx.cfg" packages for the usage.
 --- @alias fzfx.VariantConfig {name:string,feed:fzfx.CommandFeed,default_provider:fzfx.PipelineName?}
 --
+-- Note: Please refer to the command configurations in "fzfx.cfg" packages for the usage.
 --- @alias fzfx.CommandConfig {name:string,desc:string?}
 --
+-- Note: Please refer to the command configurations in "fzfx.cfg" packages for the usage.
 --- @alias fzfx.GroupConfig {command:fzfx.CommandConfig,variants:fzfx.VariantConfig[],providers:fzfx.ProviderConfig|table<fzfx.PipelineName,fzfx.ProviderConfig>,previewers:fzfx.PreviewerConfig|table<fzfx.PipelineName,fzfx.PreviewerConfig>,actions:table<fzfx.ActionKey,fzfx.Action>,interactions:table<fzfx.InteractionName,fzfx.InteractionConfig>?,fzf_opts:fzfx.FzfOpt[]?}
 
+-- Whether `cfg` is a `fzfx.VariantConfig` instance.
 --- @param cfg fzfx.VariantConfig?
 --- @return boolean
 local function is_variant_config(cfg)
@@ -133,6 +139,7 @@ local function is_variant_config(cfg)
     and string.len(cfg.feed) > 0
 end
 
+-- Whether `cfg` is a `fzfx.ProviderConfig` instance.
 --- @param cfg fzfx.ProviderConfig?
 --- @return boolean
 local function is_provider_config(cfg)
@@ -148,6 +155,7 @@ local function is_provider_config(cfg)
     )
 end
 
+-- Whether `cfg` is a `fzfx.PreviewerConfig` instance.
 --- @param cfg fzfx.PreviewerConfig?
 --- @return boolean
 local function is_previewer_config(cfg)
@@ -159,6 +167,7 @@ local function is_previewer_config(cfg)
     )
 end
 
+-- Get provider type or default.
 --- @param provider_config fzfx.ProviderConfig
 --- @return fzfx.ProviderType
 local function get_provider_type_or_default(provider_config)
@@ -169,12 +178,14 @@ local function get_provider_type_or_default(provider_config)
     )
 end
 
+-- Get previewer type or default.
 --- @param previewer_config fzfx.PreviewerConfig
 --- @return fzfx.PreviewerType
 local function get_previewer_type_or_default(previewer_config)
   return previewer_config.previewer_type or PreviewerTypeEnum.COMMAND
 end
 
+-- Get previewer label type or default.
 --- @param previewer_config fzfx.PreviewerConfig
 --- @return fzfx.PreviewerLabelType
 local function get_previewer_label_type_or_default(previewer_config)

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -14,11 +14,7 @@ describe("fzfx.cfg._lsp_locations", function()
   local github_actions = os.getenv("GITHUB_ACTIONS") == "true"
 
   local str = require("fzfx.commons.str")
-  local term_color = require("fzfx.commons.color.term")
-  local constants = require("fzfx.lib.constants")
-  local contexts = require("fzfx.helper.contexts")
-  local providers = require("fzfx.helper.providers")
-  local fzf_helpers = require("fzfx.detail.fzf_helpers")
+  local color_term = require("fzfx.commons.color.term")
   local _lsp_locations = require("fzfx.cfg._lsp_locations")
   require("fzfx").setup()
 
@@ -51,19 +47,50 @@ describe("fzfx.cfg._lsp_locations", function()
       assert_true(_lsp_locations._is_lsp_locationlink(LOCATIONLINK))
     end)
     it("_colorize_lsp_range", function()
-      local r = {
+      -- case-1
+      local r1 = {
         start = { line = 1, character = 20 },
         ["end"] = { line = 1, character = 26 },
       }
-      local loc = _lsp_locations._colorize_lsp_range(
+      local loc1 = _lsp_locations._colorize_lsp_range(
         'describe("_lsp_location_render_line", function()',
-        r,
-        term_color.red
+        r1,
+        color_term.red
       )
-      -- print(string.format("lsp render line:%s\n", vim.inspect(loc)))
-      assert_eq(type(loc), "string")
-      assert_true(str.startswith(loc, "describe"))
-      assert_true(str.endswith(loc, "function()"))
+      print(string.format("_colorize_lsp_range-1:%s\n", vim.inspect(loc1)))
+      assert_eq(type(loc1), "string")
+      assert_true(str.startswith(loc1, "describe"))
+      assert_true(str.endswith(loc1, "function()"))
+
+      -- case-2
+      local r2 = {
+        start = { line = 1, character = 38 },
+        ["end"] = { line = 1, character = 50 },
+      }
+      local loc2 = _lsp_locations._colorize_lsp_range(
+        'describe("_lsp_location_render_line", function()',
+        r2,
+        color_term.red
+      )
+      print(string.format("_colorize_lsp_range-2:%s\n", vim.inspect(loc2)))
+      assert_eq(type(loc2), "string")
+      assert_true(str.startswith(loc2, "describe"))
+      assert_true(str.endswith(loc2, "function()\27[0m"))
+
+      -- case-3
+      local r3 = {
+        start = { line = 1, character = 0 },
+        ["end"] = { line = 1, character = 30 },
+      }
+      local loc3 = _lsp_locations._colorize_lsp_range(
+        'describe("_lsp_location_render_line", function()',
+        r3,
+        color_term.red
+      )
+      print(string.format("_colorize_lsp_range-3:%s\n", vim.inspect(loc3)))
+      assert_eq(type(loc3), "string")
+      assert_true(str.startswith(loc3, "\27[0;31mdescribe"))
+      assert_true(str.endswith(loc3, "function()"))
     end)
     it("renders location", function()
       local actual = _lsp_locations._render_lsp_location_line(LOCATION)

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -95,6 +95,7 @@ describe("fzfx.cfg._lsp_locations", function()
       assert_true(str.endswith(loc3, "function()"))
     end)
     it("_render_lsp_location_to_line case 1", function()
+      local PWD = vim.env.PWD
       local range = {
         start = { line = 1, character = 10 },
         ["end"] = { line = 10, character = 31 },
@@ -104,10 +105,12 @@ describe("fzfx.cfg._lsp_locations", function()
         range = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
+      print(string.format("_render_lsp_location_to_line-1 PWD:%s", vim.inspect(PWD)))
       print(string.format("_render_lsp_location_to_line-1:%s\n", vim.inspect(actual)))
       assert_true(actual == nil)
     end)
     it("_render_lsp_location_to_line case 2", function()
+      local PWD = vim.env.PWD
       local range = {
         start = { line = 10, character = 10 },
         ["end"] = { line = 10, character = 31 },
@@ -117,6 +120,7 @@ describe("fzfx.cfg._lsp_locations", function()
         targetRange = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
+      print(string.format("_render_lsp_location_to_line-2 PWD:%s", vim.inspect(PWD)))
       print(string.format("_render_lsp_location_to_line-2:%s\n", vim.inspect(actual)))
       if not GITHUB_ACTIONS then
         assert_true(type(actual) == "string")
@@ -125,6 +129,7 @@ describe("fzfx.cfg._lsp_locations", function()
       end
     end)
     it("_render_lsp_location_to_line case 3", function()
+      local PWD = vim.env.PWD
       local range = {
         start = { line = 3000, character = 10 },
         ["end"] = { line = 3000, character = 31 },
@@ -134,6 +139,7 @@ describe("fzfx.cfg._lsp_locations", function()
         range = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
+      print(string.format("_render_lsp_location_to_line-3 PWD:%s", vim.inspect(PWD)))
       print(string.format("_render_lsp_location_to_line-3:%s\n", vim.inspect(actual)))
       assert_true(actual == nil)
     end)

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -210,18 +210,40 @@ describe("fzfx.cfg._lsp_locations", function()
     end)
     it("_make_lsp_locations_provider", function()
       local ctx = _lsp_locations._lsp_position_context_maker()
-      local f = _lsp_locations._make_lsp_locations_provider({
-        method = "textDocument/definition",
-        capability = "definitionProvider",
-      })
-      assert_eq(type(f), "function")
-      local actual = f("", ctx)
-      if actual ~= nil then
-        assert_eq(type(actual), "table")
-        assert_true(#actual >= 0)
-        for _, act in ipairs(actual) do
-          assert_eq(type(act), "string")
-          assert_true(string.len(act) > 0)
+      local opts = {
+        -- definition
+        {
+          method = "textDocument/definition",
+          capability = "definitionProvider",
+        },
+        -- type definition
+        {
+          method = "textDocument/type_definition",
+          capability = "typeDefinitionProvider",
+        },
+        -- reference
+        {
+          method = "textDocument/references",
+          capability = "referencesProvider",
+        },
+        -- implementation
+        {
+          method = "textDocument/implementation",
+          capability = "implementationProvider",
+        },
+      }
+
+      for _, opt in ipairs(opts) do
+        local f = _lsp_locations._make_lsp_locations_provider(opt)
+        assert_eq(type(f), "function")
+        local actual = f("", ctx)
+        if actual ~= nil then
+          assert_eq(type(actual), "table")
+          assert_true(#actual >= 0)
+          for _, a in ipairs(actual) do
+            assert_eq(type(a), "string")
+            assert_true(string.len(a) > 0)
+          end
         end
       end
     end)

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -11,7 +11,7 @@ describe("fzfx.cfg._lsp_locations", function()
     vim.cmd([[noautocmd edit README.md]])
   end)
 
-  local github_actions = os.getenv("GITHUB_ACTIONS") == "true"
+  local GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
   local str = require("fzfx.commons.str")
   local color_term = require("fzfx.commons.color.term")
@@ -118,7 +118,11 @@ describe("fzfx.cfg._lsp_locations", function()
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
       print(string.format("_render_lsp_location_to_line-2:%s\n", vim.inspect(actual)))
-      assert_true(type(actual) == "string")
+      if not GITHUB_ACTIONS then
+        assert_true(type(actual) == "string")
+      else
+        assert_true(type(actual) == "string" or actual == nil)
+      end
     end)
     it("_render_lsp_location_to_line case 3", function()
       local range = {

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -356,6 +356,40 @@ describe("fzfx.cfg._lsp_locations", function()
       local actual3 = _lsp_locations._render_lsp_call_hierarchy_to_lines(item3, { range3 })
       print(string.format("_render_lsp_call_hierarchy_to_lines-3:%s\n", vim.inspect(actual3)))
       assert_true(#actual3 >= 0)
+
+      local item4 = {
+        name = "name",
+        kind = 2,
+        detail = "detail",
+        uri = string.format("file://%s/lua/fzfx.lua", PWD),
+        range = range3,
+        selectionRange = range3,
+      }
+      local actual4 = _lsp_locations._render_lsp_call_hierarchy_to_lines(item4, {})
+      print(string.format("_render_lsp_call_hierarchy_to_lines-4:%s\n", vim.inspect(actual3)))
+      assert_true(actual4 == nil)
+
+      local range5 = {
+        start = {
+          line = 29,
+          character = 1,
+        },
+        ["end"] = {
+          line = 29,
+          character = 30,
+        },
+      }
+      local item5 = {
+        name = "name",
+        kind = 2,
+        detail = "detail",
+        uri = nil,
+        range = range3,
+        selectionRange = range3,
+      }
+      local actual5 = _lsp_locations._render_lsp_call_hierarchy_to_lines(item5, { range5 })
+      print(string.format("_render_lsp_call_hierarchy_to_lines-5:%s\n", vim.inspect(actual5)))
+      assert_true(actual5 == nil)
     end)
     it("_retrieve_lsp_call_hierarchy_item_and_from_ranges", function()
       local actual11, actual12 = _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -92,15 +92,31 @@ describe("fzfx.cfg._lsp_locations", function()
       assert_true(str.startswith(loc3, "\27[0;31mdescribe"))
       assert_true(str.endswith(loc3, "function()"))
     end)
-    it("renders location", function()
-      local actual = _lsp_locations._render_lsp_location_line(LOCATION)
+    it("_render_lsp_location_to_line case 1", function()
+      local range = {
+        start = { line = 1, character = 10 },
+        ["end"] = { line = 10, character = 31 },
+      }
+      local loc = {
+        uri = "file:///usr/home/github/linrongbin16/fzfx.nvim",
+        range = range,
+      }
+      local actual = _lsp_locations._render_lsp_location_to_line(loc)
       -- print(
       --     string.format("render lsp location:%s\n", vim.inspect(actual))
       -- )
-      assert_true(actual == nil or type(actual) == "string")
+      assert_true(actual == nil)
     end)
-    it("renders locationlink", function()
-      local actual = _lsp_locations._render_lsp_location_line(LOCATIONLINK)
+    it("_render_lsp_location_to_line case 2", function()
+      local range = {
+        start = { line = 1, character = 10 },
+        ["end"] = { line = 10, character = 31 },
+      }
+      local loc = {
+        targetUri = "file:///usr/home/github/linrongbin16/fzfx.nvim/README.md",
+        targetRange = range,
+      }
+      local actual = _lsp_locations._render_lsp_location_to_line(loc)
       -- print(
       --     string.format(
       --         "render lsp locationlink:%s\n",
@@ -108,6 +124,24 @@ describe("fzfx.cfg._lsp_locations", function()
       --     )
       -- )
       assert_true(actual == nil or type(actual) == "string")
+    end)
+    it("_render_lsp_location_to_line case 3", function()
+      local range = {
+        start = { line = 3000, character = 10 },
+        ["end"] = { line = 3000, character = 31 },
+      }
+      local loc = {
+        uri = "file:///usr/home/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
+        range = range,
+      }
+      local actual = _lsp_locations._render_lsp_location_to_line(loc)
+      -- print(
+      --     string.format(
+      --         "render lsp locationlink:%s\n",
+      --         vim.inspect(actual)
+      --     )
+      -- )
+      assert_true(actual == nil)
     end)
     it("_lsp_position_context_maker", function()
       local ctx = _lsp_locations._lsp_position_context_maker()

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -398,24 +398,39 @@ describe("fzfx.cfg._lsp_locations", function()
       )
       assert_true(vim.deep_equal(actual11, INCOMING_CALLS.from))
       assert_true(vim.deep_equal(actual12, INCOMING_CALLS.fromRanges))
+
       local actual21, actual22 = _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(
         "callHierarchy/incomingCalls",
         OUTGOING_CALLS
       )
       assert_eq(actual21, nil)
       assert_eq(actual22, nil)
+
       local actual31, actual32 = _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(
         "callHierarchy/outgoingCalls",
         INCOMING_CALLS
       )
       assert_eq(actual31, nil)
       assert_eq(actual32, nil)
+
       local actual41, actual42 = _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(
         "callHierarchy/outgoingCalls",
         OUTGOING_CALLS
       )
       assert_true(vim.deep_equal(actual41, OUTGOING_CALLS.to))
       assert_true(vim.deep_equal(actual42, OUTGOING_CALLS.fromRanges))
+
+      local actual51, actual52 =
+        _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(nil, nil)
+      assert_true(actual51 == nil)
+      assert_true(actual52 == nil)
+
+      local actual61, actual62 = _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(
+        "textDocument/definition",
+        OUTGOING_CALLS
+      )
+      assert_true(actual61 == nil)
+      assert_true(actual62 == nil)
     end)
     it("_make_lsp_call_hierarchy_provider", function()
       local ctx = _lsp_locations._lsp_position_context_maker()

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -109,7 +109,7 @@ describe("fzfx.cfg._lsp_locations", function()
     end)
     it("_render_lsp_location_to_line case 2", function()
       local range = {
-        start = { line = 1, character = 10 },
+        start = { line = 10, character = 10 },
         ["end"] = { line = 10, character = 31 },
       }
       local loc = {

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -96,7 +96,6 @@ describe("fzfx.cfg._lsp_locations", function()
       assert_true(str.endswith(loc3, "function()"))
     end)
     it("_render_lsp_location_to_line case 1", function()
-      local PWD = vim.env.PWD
       local range = {
         start = { line = 1, character = 10 },
         ["end"] = { line = 10, character = 31 },
@@ -117,7 +116,6 @@ describe("fzfx.cfg._lsp_locations", function()
       assert_true(actual == nil)
     end)
     it("_render_lsp_location_to_line case 2", function()
-      local PWD = vim.env.PWD
       local range = {
         start = { line = 10, character = 10 },
         ["end"] = { line = 10, character = 31 },
@@ -135,14 +133,9 @@ describe("fzfx.cfg._lsp_locations", function()
           vim.inspect(loc)
         )
       )
-      -- if not GITHUB_ACTIONS then
       assert_true(type(actual) == "string")
-      -- else
-      --   assert_true(type(actual) == "string" or actual == nil)
-      -- end
     end)
     it("_render_lsp_location_to_line case 3", function()
-      local PWD = vim.env.PWD
       local range = {
         start = { line = 3000, character = 10 },
         ["end"] = { line = 3000, character = 31 },

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -434,32 +434,28 @@ describe("fzfx.cfg._lsp_locations", function()
     end)
     it("_make_lsp_call_hierarchy_provider", function()
       local ctx = _lsp_locations._lsp_position_context_maker()
-      local f1 = _lsp_locations._make_lsp_call_hierarchy_provider({
-        method = "callHierarchy/incomingCalls",
-        capability = "callHierarchyProvider",
-      })
-      assert_eq(type(f1), "function")
-      local actual1 = f1("", ctx)
-      if actual1 ~= nil then
-        assert_eq(type(actual1), "table")
-        assert_true(#actual1 >= 0)
-        for _, act in ipairs(actual1) do
-          assert_eq(type(act), "string")
-          assert_true(string.len(act) > 0)
-        end
-      end
-      local f2 = _lsp_locations._make_lsp_call_hierarchy_provider({
-        method = "callHierarchy/outgoingCalls",
-        capability = "callHierarchyProvider",
-      })
-      assert_eq(type(f2), "function")
-      local actual2 = f2("", ctx)
-      if actual2 ~= nil then
-        assert_eq(type(actual2), "table")
-        assert_true(#actual2 >= 0)
-        for _, act in ipairs(actual2) do
-          assert_eq(type(act), "string")
-          assert_true(string.len(act) > 0)
+      local opts = {
+        {
+          method = "callHierarchy/incomingCalls",
+          capability = "callHierarchyProvider",
+        },
+        {
+          method = "callHierarchy/outgoingCalls",
+          capability = "callHierarchyProvider",
+        },
+      }
+
+      for _, opt in ipairs(opts) do
+        local f = _lsp_locations._make_lsp_call_hierarchy_provider(opt)
+        assert_eq(type(f), "function")
+        local actual = f("", ctx)
+        if actual ~= nil then
+          assert_eq(type(actual), "table")
+          assert_true(#actual >= 0)
+          for _, a in ipairs(actual) do
+            assert_eq(type(a), "string")
+            assert_true(string.len(a) > 0)
+          end
         end
       end
     end)

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -101,12 +101,18 @@ describe("fzfx.cfg._lsp_locations", function()
         ["end"] = { line = 10, character = 31 },
       }
       local loc = {
-        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim", HOME_DIR),
+        uri = string.format("file://%s", PWD),
         range = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
       print(string.format("_render_lsp_location_to_line-1 PWD:%s", vim.inspect(PWD)))
-      print(string.format("_render_lsp_location_to_line-1:%s\n", vim.inspect(actual)))
+      print(
+        string.format(
+          "_render_lsp_location_to_line-1:%s, loc:%s\n",
+          vim.inspect(actual),
+          vim.inspect(loc)
+        )
+      )
       assert_true(actual == nil)
     end)
     it("_render_lsp_location_to_line case 2", function()
@@ -116,17 +122,23 @@ describe("fzfx.cfg._lsp_locations", function()
         ["end"] = { line = 10, character = 31 },
       }
       local loc = {
-        targetUri = string.format("file://%s/github/linrongbin16/fzfx.nvim/README.md", HOME_DIR),
+        targetUri = string.format("file://%s/README.md", PWD),
         targetRange = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
       print(string.format("_render_lsp_location_to_line-2 PWD:%s", vim.inspect(PWD)))
-      print(string.format("_render_lsp_location_to_line-2:%s\n", vim.inspect(actual)))
-      if not GITHUB_ACTIONS then
-        assert_true(type(actual) == "string")
-      else
-        assert_true(type(actual) == "string" or actual == nil)
-      end
+      print(
+        string.format(
+          "_render_lsp_location_to_line-2:%s, loc:%s\n",
+          vim.inspect(actual),
+          vim.inspect(loc)
+        )
+      )
+      -- if not GITHUB_ACTIONS then
+      assert_true(type(actual) == "string")
+      -- else
+      --   assert_true(type(actual) == "string" or actual == nil)
+      -- end
     end)
     it("_render_lsp_location_to_line case 3", function()
       local PWD = vim.env.PWD
@@ -135,12 +147,18 @@ describe("fzfx.cfg._lsp_locations", function()
         ["end"] = { line = 3000, character = 31 },
       }
       local loc = {
-        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim/lua/fzfx.lua", HOME_DIR),
+        uri = string.format("file://%s/lua/fzfx.lua", PWD),
         range = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
       print(string.format("_render_lsp_location_to_line-3 PWD:%s", vim.inspect(PWD)))
-      print(string.format("_render_lsp_location_to_line-3:%s\n", vim.inspect(actual)))
+      print(
+        string.format(
+          "_render_lsp_location_to_line-3:%s, loc:%s\n",
+          vim.inspect(actual),
+          vim.inspect(loc)
+        )
+      )
       assert_true(actual == nil)
     end)
     it("_hash_lsp_location", function()

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -21,16 +21,17 @@ describe("fzfx.cfg._lsp_locations", function()
 
   describe("_lsp_locations", function()
     local HOME_DIR = uv.os_homedir()
+    local PWD = vim.env.PWD
     local RANGE = {
       start = { line = 1, character = 10 },
       ["end"] = { line = 10, character = 31 },
     }
     local LOCATION = {
-      uri = "file:///usr/home/github/linrongbin16/fzfx.nvim",
+      uri = string.format("file://%s", PWD),
       range = RANGE,
     }
     local LOCATIONLINK = {
-      targetUri = "file:///usr/home/github/linrongbin16/fzfx.nvim",
+      targetUri = string.format("file://%s", PWD),
       targetRange = RANGE,
     }
     it("_is_lsp_range", function()
@@ -250,6 +251,7 @@ describe("fzfx.cfg._lsp_locations", function()
   end)
 
   describe("[_call_hierarchy]", function()
+    local PWD = vim.env.PWD
     local RANGE = {
       start = {
         character = 1,
@@ -264,7 +266,7 @@ describe("fzfx.cfg._lsp_locations", function()
       name = "name",
       kind = 2,
       detail = "detail",
-      uri = "file:///usr/home/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua",
+      uri = string.format("file://%s/lua/fzfx/config.lua", PWD),
       range = RANGE,
       selectionRange = RANGE,
     }
@@ -313,17 +315,54 @@ describe("fzfx.cfg._lsp_locations", function()
       )
       assert_true(actual1)
     end)
-    it("_render_lsp_call_hierarchy_line", function()
-      local actual1 = _lsp_locations._render_lsp_call_hierarchy_line(
-        INCOMING_CALLS.from,
-        INCOMING_CALLS.fromRanges
+    it("_render_lsp_call_hierarchy_to_lines", function()
+      local item1 = INCOMING_CALLS.from
+      local range1 = INCOMING_CALLS.fromRanges
+      local actual1 = _lsp_locations._render_lsp_call_hierarchy_to_lines(item1, range1)
+      print(
+        string.format(
+          "_render_lsp_call_hierarchy_to_lines-1:%s, item:%s, range:%s\n",
+          vim.inspect(actual1),
+          vim.inspect(item1),
+          vim.inspect(range1)
+        )
       )
-      print(string.format("incoming render lines:%s\n", vim.inspect(actual1)))
       assert_true(#actual1 >= 0)
-      local actual2 =
-        _lsp_locations._render_lsp_call_hierarchy_line(OUTGOING_CALLS.to, OUTGOING_CALLS.fromRanges)
-      print(string.format("outgoing render lines:%s\n", vim.inspect(actual2)))
-      assert_true(#actual1 >= 0)
+
+      local item2 = OUTGOING_CALLS.to
+      local range2 = OUTGOING_CALLS.fromRanges
+      local actual2 = _lsp_locations._render_lsp_call_hierarchy_to_lines(item2, range2)
+      print(
+        string.format(
+          "_render_lsp_call_hierarchy_to_lines-2:%s, item:%s, range:%s\n",
+          vim.inspect(actual2),
+          vim.inspect(item2),
+          vim.inspect(range2)
+        )
+      )
+      assert_true(#actual2 >= 0)
+
+      local range3 = {
+        start = {
+          line = 29,
+          character = 1,
+        },
+        ["end"] = {
+          line = 29,
+          character = 30,
+        },
+      }
+      local item3 = {
+        name = "name",
+        kind = 2,
+        detail = "detail",
+        uri = string.format("file://%s/lua/fzfx.lua", PWD),
+        range = range3,
+        selectionRange = range3,
+      }
+      local actual3 = _lsp_locations._render_lsp_call_hierarchy_to_lines(item3, { range3 })
+      print(string.format("_render_lsp_call_hierarchy_to_lines-3:%s\n", vim.inspect(actual3)))
+      assert_true(#actual3 >= 0)
     end)
     it("_retrieve_lsp_call_hierarchy_item_and_from_ranges", function()
       local actual11, actual12 = _lsp_locations._retrieve_lsp_call_hierarchy_item_and_from_ranges(

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -16,9 +16,11 @@ describe("fzfx.cfg._lsp_locations", function()
   local str = require("fzfx.commons.str")
   local color_term = require("fzfx.commons.color.term")
   local _lsp_locations = require("fzfx.cfg._lsp_locations")
+  local uv = require("fzfx.commons.uv")
   require("fzfx").setup()
 
   describe("_lsp_locations", function()
+    local HOME_DIR = uv.os_homedir()
     local RANGE = {
       start = { line = 1, character = 10 },
       ["end"] = { line = 10, character = 31 },
@@ -98,13 +100,11 @@ describe("fzfx.cfg._lsp_locations", function()
         ["end"] = { line = 10, character = 31 },
       }
       local loc = {
-        uri = "file:///usr/home/github/linrongbin16/fzfx.nvim",
+        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim", HOME_DIR),
         range = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
-      -- print(
-      --     string.format("render lsp location:%s\n", vim.inspect(actual))
-      -- )
+      print(string.format("_render_lsp_location_to_line-1:%s\n", vim.inspect(actual)))
       assert_true(actual == nil)
     end)
     it("_render_lsp_location_to_line case 2", function()
@@ -113,17 +113,12 @@ describe("fzfx.cfg._lsp_locations", function()
         ["end"] = { line = 10, character = 31 },
       }
       local loc = {
-        targetUri = "file:///usr/home/github/linrongbin16/fzfx.nvim/README.md",
+        targetUri = string.format("file://%s/github/linrongbin16/fzfx.nvim/README.md", HOME_DIR),
         targetRange = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
-      -- print(
-      --     string.format(
-      --         "render lsp locationlink:%s\n",
-      --         vim.inspect(actual)
-      --     )
-      -- )
-      assert_true(actual == nil or type(actual) == "string")
+      print(string.format("_render_lsp_location_to_line-2:%s\n", vim.inspect(actual)))
+      assert_true(type(actual) == "string")
     end)
     it("_render_lsp_location_to_line case 3", function()
       local range = {
@@ -131,16 +126,11 @@ describe("fzfx.cfg._lsp_locations", function()
         ["end"] = { line = 3000, character = 31 },
       }
       local loc = {
-        uri = "file:///usr/home/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
+        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim/lua/fzfx.lua", HOME_DIR),
         range = range,
       }
       local actual = _lsp_locations._render_lsp_location_to_line(loc)
-      -- print(
-      --     string.format(
-      --         "render lsp locationlink:%s\n",
-      --         vim.inspect(actual)
-      --     )
-      -- )
+      print(string.format("_render_lsp_location_to_line-3:%s\n", vim.inspect(actual)))
       assert_true(actual == nil)
     end)
     it("_lsp_position_context_maker", function()

--- a/spec/cfg/_lsp_locations_spec.lua
+++ b/spec/cfg/_lsp_locations_spec.lua
@@ -137,6 +137,38 @@ describe("fzfx.cfg._lsp_locations", function()
       print(string.format("_render_lsp_location_to_line-3:%s\n", vim.inspect(actual)))
       assert_true(actual == nil)
     end)
+    it("_hash_lsp_location", function()
+      local range1 = {
+        start = { line = 1, character = 10 },
+        ["end"] = { line = 10, character = 31 },
+      }
+      local loc1 = {
+        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim", HOME_DIR),
+        range = range1,
+      }
+      local range2 = {
+        start = { line = 3000, character = 10 },
+        ["end"] = { line = 3000, character = 31 },
+      }
+      local loc2 = {
+        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim/lua/fzfx.lua", HOME_DIR),
+        range = range2,
+      }
+      local range3 = {
+        start = { line = 3000, character = 10 },
+        ["end"] = { line = 3000, character = 31 },
+      }
+      local loc3 = {
+        uri = string.format("file://%s/github/linrongbin16/fzfx.nvim/lua/fzfx.lua", HOME_DIR),
+        range = range3,
+      }
+      local h1 = _lsp_locations._hash_lsp_location(loc1)
+      local h2 = _lsp_locations._hash_lsp_location(loc2)
+      local h3 = _lsp_locations._hash_lsp_location(loc3)
+      assert_false(h1 == h2)
+      assert_false(h1 == h3)
+      assert_true(h2 == h3)
+    end)
     it("_lsp_position_context_maker", function()
       local ctx = _lsp_locations._lsp_position_context_maker()
       -- print(string.format("lsp position context:%s\n", vim.inspect(ctx)))

--- a/spec/lib/lsp_spec.lua
+++ b/spec/lib/lsp_spec.lua
@@ -1,0 +1,19 @@
+local cwd = vim.fn.getcwd()
+
+describe("lib.lsp", function()
+  local assert_eq = assert.is_equal
+  local assert_true = assert.is_true
+  local assert_false = assert.is_false
+
+  before_each(function()
+    vim.api.nvim_command("cd " .. cwd)
+  end)
+
+  local lsp = require("fzfx.lib.lsp")
+
+  describe("[get_clients]", function()
+    it("is callable", function()
+      assert_true(vim.is_callable(lsp.get_clients))
+    end)
+  end)
+end)


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
