### PR TITLE
refactor(diagnostic): part 9

### DIFF
--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -7,6 +7,7 @@ local switches = require("fzfx.lib.switches")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
 local env = require("fzfx.lib.env")
+local lsp = require("fzfx.lib.lsp")
 
 local actions_helper = require("fzfx.helper.actions")
 local labels_helper = require("fzfx.helper.previewer_labels")
@@ -83,50 +84,57 @@ M.variants = {
   },
 }
 
-local _, _, SIGN_ERROR_HL =
+local _, _, ERROR_TEXT_HL =
   color_hl.get_hl_with_fallback("DiagnosticSignError", "LspDiagnosticsSignError", "ErrorMsg")
-local _, _, SIGN_WARN_HL =
+local _, _, WARN_TEXT_HL =
   color_hl.get_hl_with_fallback("DiagnosticSignWarn", "LspDiagnosticsSignWarn", "WarningMsg")
-local _, _, SIGN_INFO_HL =
+local _, _, INFO_TEXT_HL =
   color_hl.get_hl_with_fallback("DiagnosticSignInfo", "LspDiagnosticsSignInfo", "None")
-local _, _, SIGN_HINT_HL =
+local _, _, HINT_TEXT_HL =
   color_hl.get_hl_with_fallback("DiagnosticSignHint", "LspDiagnosticsSignHint", "Comment")
 
-local LSP_DIAGNOSTICS_SIGNS = {
-  [1] = {
+--- @alias fzfx.LspDiagnosticSignDef {severity:integer,name:string,text:string,texthl:string,textcolor:string}
+--- @type fzfx.LspDiagnosticSignDef[]
+M._LSP_DIAGNOSTIC_SIGNS = {
+  -- 1 Error
+  {
     severity = 1,
     name = "DiagnosticSignError",
     text = env.icon_enabled() and "" or "E", -- nf-fa-times \uf00d
-    texthl = SIGN_ERROR_HL,
+    texthl = ERROR_TEXT_HL --[[@as string]],
     textcolor = "red",
   },
-  [2] = {
+  -- 2 Warn
+  {
     severity = 2,
     name = "DiagnosticSignWarn",
     text = env.icon_enabled() and "" or "W", -- nf-fa-warning \uf071
-    texthl = SIGN_WARN_HL,
+    texthl = WARN_TEXT_HL --[[@as string]],
     textcolor = "orange",
   },
-  [3] = {
+  -- 3 Info
+  {
     severity = 3,
     name = "DiagnosticSignInfo",
     text = env.icon_enabled() and "" or "I", -- nf-fa-info_circle \uf05a
-    texthl = SIGN_INFO_HL,
+    texthl = INFO_TEXT_HL --[[@as string]],
     textcolor = "cyan",
   },
-  [4] = {
+  -- 4 Hint
+  {
     severity = 4,
     name = "DiagnosticSignHint",
     text = env.icon_enabled() and "" or "H", -- nf-fa-bell \uf0f3
-    texthl = SIGN_HINT_HL,
+    texthl = HINT_TEXT_HL --[[@as string]],
     textcolor = "grey",
   },
 }
 
---- @return {severity:integer,name:string,text:string,texthl:string,textcolor:string}[]
-M._make_lsp_diagnostic_signs = function()
+-- Get already defined signs definition, or use default signs config.
+--- @return fzfx.LspDiagnosticSignDef[]
+M._make_signs = function()
   local results = {}
-  for _, signs in ipairs(LSP_DIAGNOSTICS_SIGNS) do
+  for _, signs in ipairs(M._LSP_DIAGNOSTIC_SIGNS) do
     local sign_def = vim.fn.sign_getdefined(signs.name) --[[@as table]]
     local item = vim.deepcopy(signs)
     if not tbl.tbl_empty(sign_def) then
@@ -140,11 +148,11 @@ end
 
 --- @param diag {bufnr:integer,lnum:integer,col:integer,message:string,severity:integer}
 --- @return {bufnr:integer,filename:string,lnum:integer,col:integer,text:string,severity:integer}?
-M._process_lsp_diagnostic_item = function(diag)
+M._process_diag = function(diag)
   if not vim.api.nvim_buf_is_valid(diag.bufnr) then
     return nil
   end
-  log.debug(string.format("|_process_lsp_diagnostic_item| diag-1:%s", vim.inspect(diag)))
+  -- log.debug(string.format("|_process_diag| diag:%s", vim.inspect(diag)))
   local result = {
     bufnr = diag.bufnr,
     filename = path.reduce(vim.api.nvim_buf_get_name(diag.bufnr)),
@@ -153,45 +161,39 @@ M._process_lsp_diagnostic_item = function(diag)
     text = vim.trim(diag.message:gsub("\n", " ")),
     severity = diag.severity or 1,
   }
-  log.debug(
-    string.format(
-      "|_process_lsp_diagnostic_item| diag-2:%s, result:%s",
-      vim.inspect(diag),
-      vim.inspect(result)
-    )
-  )
+  -- log.debug(string.format("|_process_diag| result:%s", vim.inspect(result)))
   return result
 end
 
 --- @param opts {buffer:boolean?}?
 --- @return fun(query:string,context:fzfx.PipelineContext):string[]|nil
-M._make_lsp_diagnostics_provider = function(opts)
-  local signs = M._make_lsp_diagnostic_signs()
+M._make_provider = function(opts)
+  local buffer_mode = tbl.tbl_get(opts, "buffer") or false
+  local signs = M._make_signs()
 
   --- @param query string
   --- @param context fzfx.PipelineContext
   --- @return string[]|nil
   local function impl(query, context)
-    ---@diagnostic disable-next-line: deprecated
-    local lsp_clients = vim.lsp.get_active_clients()
+    local lsp_clients = lsp.get_clients()
     if tbl.tbl_empty(lsp_clients) then
       log.echo(LogLevels.INFO, "no active lsp clients.")
       return nil
     end
-    local diag_list =
-      vim.diagnostic.get((type(opts) == "table" and opts.buffer) and context.bufnr or nil)
-    if tbl.tbl_empty(diag_list) then
-      log.echo(LogLevels.INFO, "no lsp diagnostics found.")
+
+    local diags = vim.diagnostic.get(buffer_mode and context.bufnr or nil)
+    if tbl.tbl_empty(diags) then
+      log.echo(LogLevels.INFO, "no diagnostics found.")
       return nil
     end
     -- sort order: error > warn > info > hint
-    table.sort(diag_list, function(a, b)
+    table.sort(diags, function(a, b)
       return a.severity < b.severity
     end)
 
     local results = {}
-    for _, item in ipairs(diag_list) do
-      local diag = M._process_lsp_diagnostic_item(item)
+    for _, item in ipairs(diags) do
+      local diag = M._process_diag(item)
       if diag then
         -- it looks like:
         -- `lua/fzfx/config.lua:10:13: Unused local `query`.
@@ -230,27 +232,31 @@ end
 M.providers = {
   workspace_diagnostics = {
     key = "ctrl-w",
-    provider = M._make_lsp_diagnostics_provider(),
+    provider = M._make_provider(),
     provider_type = ProviderTypeEnum.LIST,
     provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
   buffer_diagnostics = {
     key = "ctrl-u",
-    provider = M._make_lsp_diagnostics_provider({ buffer = true }),
+    provider = M._make_provider({ buffer = true }),
     provider_type = ProviderTypeEnum.LIST,
     provider_decorator = { module = "prepend_icon_grep", builtin = true },
   },
 }
 
--- if you want to use fzf-builtin previewer with bat, please use below configs:
+-- If you want to use fzf-builtin previewer with bat, please use below configs:
 --
+-- ```
 -- previewer = previewers_helper.preview_files_grep
 -- previewer_type = PreviewerTypeEnum.COMMAND_LIST
-
--- if you want to use nvim buffer previewer, please use below configs:
+-- ```
 --
+-- If you want to use nvim buffer previewer, please use below configs:
+--
+-- ```
 -- previewer = previewers_helper.buffer_preview_files_grep
 -- previewer_type = PreviewerTypeEnum.BUFFER_FILE
+-- ```
 
 local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_grep
   or previewers_helper.buffer_preview_files_grep

--- a/spec/cfg/lsp_diagnostics_spec.lua
+++ b/spec/cfg/lsp_diagnostics_spec.lua
@@ -26,17 +26,15 @@ describe("fzfx.cfg.lsp_diagnostics", function()
       local actual = lsp_diagnostics_cfg._make_signs()
       assert_eq(type(actual), "table")
       assert_eq(#actual, 4)
-      for i, sign_item in ipairs(actual) do
-        assert_eq(type(sign_item), "table")
-        assert_true(sign_item.severity >= 1 and sign_item.severity <= 4)
+      for i, sign in ipairs(actual) do
+        assert_eq(type(sign), "table")
+        assert_true(sign.severity >= 1 and sign.severity <= 4)
+        assert_true(string.len(sign.name) > 0 and str.startswith(sign.name, "DiagnosticSign"))
         assert_true(
-          string.len(sign_item.name) > 0 and str.startswith(sign_item.name, "DiagnosticSign")
-        )
-        assert_true(
-          str.endswith(sign_item.name, "Error")
-            or str.endswith(sign_item.name, "Warn")
-            or str.endswith(sign_item.name, "Info")
-            or str.endswith(sign_item.name, "Hint")
+          str.endswith(sign.name, "Error")
+            or str.endswith(sign.name, "Warn")
+            or str.endswith(sign.name, "Info")
+            or str.endswith(sign.name, "Hint")
         )
       end
     end)

--- a/spec/cfg/lsp_diagnostics_spec.lua
+++ b/spec/cfg/lsp_diagnostics_spec.lua
@@ -22,8 +22,8 @@ describe("fzfx.cfg.lsp_diagnostics", function()
   require("fzfx").setup()
 
   describe("lsp_diagnostics", function()
-    it("_make_lsp_diagnostic_signs", function()
-      local actual = lsp_diagnostics_cfg._make_lsp_diagnostic_signs()
+    it("_make_signs", function()
+      local actual = lsp_diagnostics_cfg._make_signs()
       assert_eq(type(actual), "table")
       assert_eq(#actual, 4)
       for i, sign_item in ipairs(actual) do

--- a/spec/cfg/lsp_diagnostics_spec.lua
+++ b/spec/cfg/lsp_diagnostics_spec.lua
@@ -40,7 +40,7 @@ describe("fzfx.cfg.lsp_diagnostics", function()
         )
       end
     end)
-    it("_process_lsp_diagnostic_item", function()
+    it("_process_diag", function()
       local diags = {
         { bufnr = 0, lnum = 1, col = 1, message = "a", severity = 1 },
         { bufnr = 1, lnum = 1, col = 1, message = "b", severity = 2 },
@@ -49,7 +49,7 @@ describe("fzfx.cfg.lsp_diagnostics", function()
         { bufnr = 5, lnum = 1, col = 1, message = "e" },
       }
       for _, diag in ipairs(diags) do
-        local actual = lsp_diagnostics_cfg._process_lsp_diagnostic_item(diag)
+        local actual = lsp_diagnostics_cfg._process_diag(diag)
         if actual ~= nil then
           assert_eq(actual.bufnr, diag.bufnr)
           assert_eq(actual.lnum, diag.lnum + 1)
@@ -58,8 +58,59 @@ describe("fzfx.cfg.lsp_diagnostics", function()
         end
       end
     end)
-    it("_make_lsp_diagnostics_provider", function()
-      local f = lsp_diagnostics_cfg._make_lsp_diagnostics_provider()
+    it("_render_diag_to_line", function()
+      local inputs = {
+        {
+          bufnr = 0,
+          filename = "lua/fzfx/config.lua",
+          lnum = 10,
+          col = 13,
+          text = "Unused local `query`",
+          severity = 1,
+        },
+        {
+          bufnr = 0,
+          filename = "lua/fzfx/config.lua",
+          lnum = 1,
+          col = 2,
+          text = "Unused local `query`",
+          severity = 2,
+        },
+        {
+          bufnr = 0,
+          filename = "lua/fzfx/config.lua",
+          lnum = 5000,
+          col = 500,
+          text = "Unused local `query`",
+          severity = 3,
+        },
+        {
+          bufnr = 0,
+          filename = "lua/fzfx/config.lua",
+          lnum = 30,
+          col = 12,
+          text = "Unused local `query`",
+          severity = 4,
+        },
+        {
+          bufnr = 0,
+          filename = "lua/fzfx/config.lua",
+          lnum = 30,
+          col = 12,
+          text = "Unused local `query`",
+        },
+      }
+      for _, input in ipairs(inputs) do
+        local actual = lsp_diagnostics_cfg._render_diag_to_line(input)
+        assert_eq(type(actual), "string")
+        assert_true(str.find(actual, input.text) > 0)
+        assert_true(str.find(actual, tostring(input.filename)) > 0)
+        assert_true(str.find(actual, tostring(input.lnum)) > 0)
+        assert_true(str.find(actual, tostring(input.col)) > 0)
+      end
+    end)
+    it("_make_provider", function()
+      local f = lsp_diagnostics_cfg._make_provider()
       local actual = f("", {})
       if actual ~= nil then
         assert_eq(type(actual), "table")

--- a/spec/cfg/lsp_diagnostics_spec.lua
+++ b/spec/cfg/lsp_diagnostics_spec.lua
@@ -1,4 +1,3 @@
----@diagnostic disable: undefined-field, unused-local, missing-fields, need-check-nil, param-type-mismatch, assign-type-mismatch
 local cwd = vim.fn.getcwd()
 
 describe("fzfx.cfg.lsp_diagnostics", function()


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
