### PR TITLE
refactor(previewer_labels): part 15

### DIFF
--- a/lua/fzfx/helper/previewer_labels.lua
+++ b/lua/fzfx/helper/previewer_labels.lua
@@ -139,6 +139,7 @@ M.label_ls = M._make_label_ls(parsers.parse_ls)
 M.label_lsd = M._make_label_ls(parsers.parse_lsd)
 M.label_eza = M._make_label_ls(parsers.parse_eza)
 
+-- Make label for vim mark.
 --- @param line string?
 --- @param context fzfx.VimMarksPipelineContext
 --- @return string
@@ -150,7 +151,9 @@ M.label_vim_mark = function(line, context)
   local filename = parsed.filename
   if str.empty(filename) then
     filename = vim.api.nvim_buf_get_name(context.bufnr)
+    filename = path.normalize(filename, { double_backslash = true, expand = true })
   end
+
   if
     str.not_empty(filename) and path.isfile(filename --[[@as string]])
   then

--- a/lua/fzfx/helper/previewer_labels.lua
+++ b/lua/fzfx/helper/previewer_labels.lua
@@ -7,6 +7,7 @@ local parsers = require("fzfx.helper.parsers")
 
 local M = {}
 
+-- Make label for fd/find results. It's only the filename without prepending filepath.
 --- @param line string?
 --- @return string
 M.label_find = function(line)
@@ -17,6 +18,7 @@ M.label_find = function(line)
   return vim.fn.fnamemodify(parsed.filename, ":t") or ""
 end
 
+-- Make label for rg results. It's only the filename without prepending filepath, line number and column number.
 --- @param line string?
 --- @return string
 M.label_rg = function(line)
@@ -32,6 +34,7 @@ M.label_rg = function(line)
   )
 end
 
+-- Make label for rg results with no filename. It looks the same with `label_rg` result.
 --- @param line string?
 --- @param context fzfx.PipelineContext?
 --- @return string
@@ -40,11 +43,13 @@ M.label_rg_no_filename = function(line, context)
     return ""
   end
   local bufnr = tbl.tbl_get(context, "bufnr")
-  if not num.ge(bufnr, 0) or not vim.api.nvim_buf_is_valid(bufnr) then
+  if type(bufnr) ~= "number" or not vim.api.nvim_buf_is_valid(bufnr) then
     return ""
   end
+
   local filename = vim.api.nvim_buf_get_name(bufnr)
   filename = path.normalize(filename, { double_backslash = true, expand = true })
+
   local parsed = parsers.parse_rg_no_filename(line --[[@as string]])
   return string.format(
     "%s:%d%s",
@@ -54,6 +59,7 @@ M.label_rg_no_filename = function(line, context)
   )
 end
 
+-- Make label for grep/`git grep` results. It's only the filename without prepending filepath, and line number (there's no column number).
 --- @param line string?
 --- @return string?
 M.label_grep = function(line)
@@ -64,6 +70,7 @@ M.label_grep = function(line)
   return string.format("%s:%d", vim.fn.fnamemodify(parsed.filename, ":t"), parsed.lineno or 1)
 end
 
+-- Make label for grep/`git grep` results with no filename. It looks same with `label_grep` result.
 --- @param line string?
 --- @param context fzfx.PipelineContext?
 --- @return string?
@@ -72,19 +79,22 @@ M.label_grep_no_filename = function(line, context)
     return ""
   end
   local bufnr = tbl.tbl_get(context, "bufnr")
-  if not num.ge(bufnr, 0) or not vim.api.nvim_buf_is_valid(bufnr) then
+  if type(bufnr) ~= "number" or not vim.api.nvim_buf_is_valid(bufnr) then
     return ""
   end
+
   local filename = vim.api.nvim_buf_get_name(bufnr)
   filename = path.normalize(filename, { double_backslash = true, expand = true })
+
   local parsed = parsers.parse_grep_no_filename(line --[[@as string]])
   return string.format("%s:%d", vim.fn.fnamemodify(filename, ":t"), parsed.lineno or 1)
 end
 
---- @param parser fun(line:string,context:fzfx.VimCommandsPipelineContext|fzfx.VimKeyMapsPipelineContext):table|string
---- @param default_value string
+-- Make label for vim command or keymap.
+--- @param parser fun(line:string,context:any):table
+--- @param default_label string
 --- @return fun(line:string,context:fzfx.VimCommandsPipelineContext|fzfx.VimKeyMapsPipelineContext):string
-M._make_label_vim_command_or_keymap = function(parser, default_value)
+M._make_label_vim_command_or_keymap = function(parser, default_label)
   --- @param line string?
   --- @param context fzfx.VimCommandsPipelineContext
   --- @return string
@@ -100,7 +110,7 @@ M._make_label_vim_command_or_keymap = function(parser, default_value)
     then
       return string.format("%s:%d", vim.fn.fnamemodify(parsed.filename, ":t"), parsed.lineno)
     end
-    return default_value
+    return default_label
   end
   return impl
 end
@@ -108,7 +118,8 @@ end
 M.label_vim_command = M._make_label_vim_command_or_keymap(parsers.parse_vim_command, "Definition")
 M.label_vim_keymap = M._make_label_vim_command_or_keymap(parsers.parse_vim_keymap, "Definition")
 
---- @param parser fun(line:string, context:fzfx.FileExplorerPipelineContext):table
+-- Make label for lsd/eza/exa/ls.
+--- @param parser fun(line:string, context:any):table
 --- @return fun(line:string, context:fzfx.FileExplorerPipelineContext):string?
 M._make_label_ls = function(parser)
   --- @param line string

--- a/spec/helper/previewer_labels_spec.lua
+++ b/spec/helper/previewer_labels_spec.lua
@@ -20,16 +20,9 @@ describe("helper.previewer_labels", function()
 
   local str = require("fzfx.commons.str")
   local fileio = require("fzfx.commons.fileio")
-
-  local parsers = require("fzfx.helper.parsers")
-  local labels = require("fzfx.helper.previewer_labels")
-
-  require("fzfx").setup({
-    debug = {
-      enable = true,
-      file_log = true,
-    },
-  })
+  local parsers_helper = require("fzfx.helper.parsers")
+  local previewer_labels_helper = require("fzfx.helper.previewer_labels")
+  require("fzfx").setup()
 
   describe("[label_find]", function()
     it("test", function()
@@ -42,7 +35,7 @@ describe("helper.previewer_labels", function()
         "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_find(line)
+        local actual = previewer_labels_helper.label_find(line)
         assert_eq(type(actual), "string")
         assert_true(str.endswith(line, actual))
       end
@@ -60,7 +53,7 @@ describe("helper.previewer_labels", function()
         "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:71:9129",
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_rg(line)
+        local actual = previewer_labels_helper.label_rg(line)
         assert_eq(type(actual), "string")
         assert_eq(type(str.find(line, actual)), "number")
         assert_true(str.find(line, actual) > 0)
@@ -79,7 +72,7 @@ describe("helper.previewer_labels", function()
       }
       for _, line in ipairs(lines) do
         local ctx = make_context()
-        local actual = labels.label_rg_no_filename(line, ctx)
+        local actual = previewer_labels_helper.label_rg_no_filename(line, ctx)
         local splits = str.split(line, ":")
         assert_eq(type(actual), "string")
         assert_true(str.endswith(actual, string.format("%s:%s", splits[1], splits[2])))
@@ -101,7 +94,7 @@ describe("helper.previewer_labels", function()
         "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:81:72:9129",
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_grep(line)
+        local actual = previewer_labels_helper.label_grep(line)
         assert_eq(type(actual), "string")
         assert_eq(type(str.find(line, actual)), "number")
         assert_true(str.find(line, actual) > 0)
@@ -120,7 +113,7 @@ describe("helper.previewer_labels", function()
       }
       for _, line in ipairs(lines) do
         local ctx = make_context()
-        local actual = labels.label_grep_no_filename(line, ctx)
+        local actual = previewer_labels_helper.label_grep_no_filename(line, ctx)
         local splits = str.split(line, ":")
         assert_eq(type(actual), "string")
         assert_true(str.endswith(actual, splits[1]))
@@ -144,7 +137,7 @@ describe("helper.previewer_labels", function()
         ":Next             N   |Y  |N/A  |N/A  |N/A              /opt/homebrew/Cellar/neovim/0.9.4/share/nvim/runtime/doc/index.txt:1124",
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_vim_command(line, CONTEXT)
+        local actual = previewer_labels_helper.label_vim_command(line, CONTEXT)
         assert_eq(type(actual), "string")
         local actual_splits = str.split(actual, ":")
         assert_eq(#actual_splits, 2)
@@ -157,7 +150,7 @@ describe("helper.previewer_labels", function()
         ':bdelete          N   |Y  |N/A  |N/A  |N/A              "delete buffer"',
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_vim_command(line, CONTEXT)
+        local actual = previewer_labels_helper.label_vim_command(line, CONTEXT)
         assert_eq(type(actual), "string")
         assert_eq(actual, "Definition")
       end
@@ -177,7 +170,7 @@ describe("helper.previewer_labels", function()
         "<Plug>(YankyGPutAfterShiftRight)             n   |Y      |N     |Y      ~/.config/nvim/lazy/yanky.nvim/lua/yanky.lua:369",
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_vim_keymap(line, CONTEXT)
+        local actual = previewer_labels_helper.label_vim_keymap(line, CONTEXT)
         assert_eq(type(actual), "string")
         local actual_splits = str.split(actual, ":")
         assert_eq(#actual_splits, 2)
@@ -192,7 +185,7 @@ describe("helper.previewer_labels", function()
         '<2-LeftMouse>                                n   |N      |N     |Y      "<Plug>(matchup-double-click)"',
       }
       for _, line in ipairs(lines) do
-        local actual = labels.label_vim_keymap(line, CONTEXT)
+        local actual = previewer_labels_helper.label_vim_keymap(line, CONTEXT)
         assert_eq(type(actual), "string")
         assert_eq(actual, "Definition")
       end
@@ -234,7 +227,7 @@ describe("helper.previewer_labels", function()
         "codecov.yml",
       }
       for i, line in ipairs(lines) do
-        local actual = labels.label_ls(line, CONTEXT)
+        local actual = previewer_labels_helper.label_ls(line, CONTEXT)
         local expect = expects[i]
         assert_true(str.endswith(actual, expect))
       end
@@ -259,7 +252,7 @@ describe("helper.previewer_labels", function()
         "test",
       }
       for i, line in ipairs(lines) do
-        local actual = labels.label_lsd(line, CONTEXT)
+        local actual = previewer_labels_helper.label_lsd(line, CONTEXT)
         local expect = expects[i]
         assert_true(str.endswith(actual, expect))
       end
@@ -289,7 +282,7 @@ describe("helper.previewer_labels", function()
         "test2-README.md",
       }
       for i, line in ipairs(lines) do
-        local actual = labels.label_eza(line, CONTEXT)
+        local actual = previewer_labels_helper.label_eza(line, CONTEXT)
         local expect = expects[i]
         assert_true(str.endswith(actual, expect))
       end
@@ -302,7 +295,7 @@ describe("helper.previewer_labels", function()
       local n = #CONTEXT.marks
       for i = 2, n do
         local line = CONTEXT.marks[i]
-        local actual = labels.label_vim_mark(line, CONTEXT)
+        local actual = previewer_labels_helper.label_vim_mark(line, CONTEXT)
         local splits = str.split(actual, ":")
         print(
           string.format(


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
