### PR TITLE
refactor(previewers): part 16

### DIFF
--- a/docs/ApiReferences/fzfx_helper.md
+++ b/docs/ApiReferences/fzfx_helper.md
@@ -7,6 +7,7 @@ And there're multiple sub-packages inside (sorted in alphabetical order):
 - [`fzfx.helper.parsers`](#parsers)
 - [`fzfx.helper.actions`](#actions)
 - [`fzfx.helper.provider_decorators`](#provider_decorators)
+- [`fzfx.helper.previewers`](#previewers)
 - [`fzfx.helper.previewer_labels`](#previewer_labels)
 
 ## `parsers`
@@ -156,7 +157,7 @@ This module contains all the actions. Press the key and quit the searching popup
 
 ### `git log`/`git blame`
 
-- [`yank_git_commit`](https://github.com/linrongbin16/fzfx.nvim/blob/8309f62a3ad02b2634ac0fe2885ef1fed83c70f0/lua/fzfx/helper/actions.lua?plain=1#L496): It yanks git commit ID (via `:let @+ = `) for `git log` or `git blame` query results.
+- [`yank_git_commit`](https://github.com/linrongbin16/fzfx.nvim/blob/8309f62a3ad02b2634ac0fe2885ef1fed83c70f0/lua/fzfx/helper/actions.lua?plain=1#L496): It yanks git commit ID (via `:let @+ =`) for `git log` or `git blame` query results.
 
 ### `git status --short`
 
@@ -187,6 +188,25 @@ It prepends file type icons for `fd`/`find` results.
 ### [`prepend_icon_grep`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/provider_decorators/prepend_icon_grep.lua?plain=1#L11)
 
 It prepends file type icons for `rg`/`grep`/`git grep` results.
+
+## `previewers`
+
+This module contains most all the shared previewers used by different configurations in `fzfx.cfg` package.
+
+There're two kinds of previewer implementations: fzf's builtin preview window, and Neovim's buffer.
+
+- fzf's builtin preview window are named with prefix `fzf_`.
+- Neovim's buffer are named with prefix `buffer_`.
+
+To enable fzf's builtin preview window, set feature flag: `vim.g.fzfx_disable_buffer_previewer=1`. To enable Neovim's buffer, unset it.
+
+The fzf's builtin preview window is natively supported by the fzf command, it has the best performance. But we have to use `bat` or `cat` to preview file contents, which doesn't support a compatible colorscheme with the nvim editor.
+
+On the other hand, the Neovim buffer natively uses the nvim editor's colorscheme. But there's a huge gap between it and the fzf command, thus brings more development effort and architectural fragmentation, also limits some flexibility of the engine. But anyway, people love their colorschemes.
+
+### [`fzf_preview_find`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L114)/[`buffer_preview_find`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L122)
+
+`fzf_preview_find` generates
 
 ## `previewer_labels`
 

--- a/docs/ApiReferences/fzfx_helper.md
+++ b/docs/ApiReferences/fzfx_helper.md
@@ -178,4 +178,44 @@ This module contains all the actions. Press the key and quit the searching popup
 
 ## `provider_decorators`
 
+This module contains decorators for providers, which beautifies provider's query results. A most common case is prepending file type icons (with RGB color) for `fd`/`find` or `rg`/`grep` query results.
+
+### [`prepend_icon_find`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/provider_decorators/prepend_icon_find.lua?plain=1#L11)
+
+It prepends file type icons for `fd`/`find` results.
+
+### [`prepend_icon_grep`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/provider_decorators/prepend_icon_grep.lua?plain=1#L11)
+
+It prepends file type icons for `rg`/`grep`/`git grep` results.
+
 ## `previewer_labels`
+
+This module contains labels for previewers, which introduces/summaries previewer's contents.
+
+### [`label_find`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L13)
+
+It works for `fd`/`find` query results.
+
+### [`label_rg`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L24)/[`label_grep`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L65)
+
+`label_rg` works for `rg` query results, `label_grep` works for `grep`/`git grep` query results.
+
+### [`label_rg_no_filename`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L41)/[`label_grep_no_filename`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L77)
+
+They're the same with `label_rg`/`label_grep`, but work for `FzfxBufLiveGrep` command.
+
+### [`label_lsd`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L139)/[`label_eza`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L140)/[`label_ls`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L138)
+
+It works for `FzfxFileExplorer` command.
+
+### [`label_vim_command`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L118)
+
+It works for `FzfxCommands` command.
+
+### [`label_vim_keymap`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L119)
+
+It works for `FzfxKeyMaps` command.
+
+### [`label_vim_mark`](https://github.com/linrongbin16/fzfx.nvim/blob/971a1b6bd25c300465aa0c906a971c5efef8d8ea/lua/fzfx/helper/previewer_labels.lua?plain=1#L146)
+
+It works for `FzfxMarks` command.

--- a/docs/ApiReferences/fzfx_lib.md
+++ b/docs/ApiReferences/fzfx_lib.md
@@ -1,0 +1,3 @@
+# [`fzfx.lib`](https://github.com/linrongbin16/fzfx.nvim/tree/main/lua/fzfx/lib)
+
+The `fzfx.lib` package contains all fundamental infrastructures.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,3 +6,4 @@
 - API References
   - [`fzfx.cfg`](/ApiReferences/fzfx_cfg.md)
   - [`fzfx.helper`](/ApiReferences/fzfx_helper.md)
+  - [`fzfx.lib`](/ApiReferences/fzfx_lib.md)

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -551,24 +551,15 @@ M._lsp_position_context_maker = function()
   return context
 end
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_grep
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_grep
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_grep
-  or previewers_helper.buffer_preview_files_grep
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   previewer = previewer,

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -554,10 +554,10 @@ end
 local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
-  previewer = previewers_helper.fzf_preview_find
+  previewer = previewers_helper.fzf_preview_grep
   previewer_type = PreviewerTypeEnum.COMMAND_LIST
 else
-  previewer = previewers_helper.buffer_preview_find
+  previewer = previewers_helper.buffer_preview_grep
   previewer_type = PreviewerTypeEnum.BUFFER_FILE
 end
 

--- a/lua/fzfx/cfg/buf_live_grep.lua
+++ b/lua/fzfx/cfg/buf_live_grep.lua
@@ -117,25 +117,15 @@ M.providers = {
   provider_type = ProviderTypeEnum.COMMAND_LIST,
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_grep
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_grep
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled()
-    and previewers_helper.preview_files_grep_no_filename
-  or previewers_helper.buffer_preview_files_grep_no_filename
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   previewer = previewer,

--- a/lua/fzfx/cfg/buf_live_grep.lua
+++ b/lua/fzfx/cfg/buf_live_grep.lua
@@ -120,10 +120,10 @@ M.providers = {
 local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
-  previewer = previewers_helper.fzf_preview_find
+  previewer = previewers_helper.fzf_preview_grep_no_filename
   previewer_type = PreviewerTypeEnum.COMMAND_LIST
 else
-  previewer = previewers_helper.buffer_preview_find
+  previewer = previewers_helper.buffer_preview_grep_no_filename
   previewer_type = PreviewerTypeEnum.BUFFER_FILE
 end
 
@@ -149,6 +149,8 @@ M.actions = {
 M.fzf_opts = {
   "--multi",
   "--disabled",
+  { "--delimiter", ":" },
+  { "--preview-window", "+{1}-/2" },
   { "--prompt", "Buffer Live Grep > " },
 }
 

--- a/lua/fzfx/cfg/buffers.lua
+++ b/lua/fzfx/cfg/buffers.lua
@@ -80,24 +80,15 @@ M.providers = {
   provider_decorator = { module = _decorator.PREPEND_ICON_FIND },
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_find
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_find
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_find
-  or previewers_helper.buffer_preview_files_find
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   previewer = previewer,

--- a/lua/fzfx/cfg/file_explorer.lua
+++ b/lua/fzfx/cfg/file_explorer.lua
@@ -291,7 +291,7 @@ M._previewer = function(line, context)
   local parsed = parser(line, context)
 
   if path.isfile(parsed.filename) then
-    return previewers_helper.preview_files(parsed.filename)
+    return previewers_helper._fzf_preview_find(parsed.filename)
   elseif path.isdir(parsed.filename) then
     return M._directory_previewer(parsed.filename)
   else

--- a/lua/fzfx/cfg/files.lua
+++ b/lua/fzfx/cfg/files.lua
@@ -150,24 +150,15 @@ M.providers = {
   },
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_find
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_find
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_find
-  or previewers_helper.buffer_preview_files_find
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   restricted_mode = {

--- a/lua/fzfx/cfg/git_blame.lua
+++ b/lua/fzfx/cfg/git_blame.lua
@@ -85,7 +85,7 @@ M.providers = {
 
 M.previewers = {
   default = {
-    previewer = previewers_helper.preview_git_commit,
+    previewer = previewers_helper.fzf_preview_git_commit,
   },
 }
 

--- a/lua/fzfx/cfg/git_commits.lua
+++ b/lua/fzfx/cfg/git_commits.lua
@@ -143,10 +143,10 @@ M.providers = {
 
 M.previewers = {
   all_commits = {
-    previewer = previewers_helper.preview_git_commit,
+    previewer = previewers_helper.fzf_preview_git_commit,
   },
   buffer_commits = {
-    previewer = previewers_helper.preview_git_commit,
+    previewer = previewers_helper.fzf_preview_git_commit,
   },
 }
 

--- a/lua/fzfx/cfg/git_files.lua
+++ b/lua/fzfx/cfg/git_files.lua
@@ -118,24 +118,15 @@ M.providers = {
   },
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_find
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_find
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_find
-  or previewers_helper.buffer_preview_files_find
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   current_folder = {

--- a/lua/fzfx/cfg/git_live_grep.lua
+++ b/lua/fzfx/cfg/git_live_grep.lua
@@ -80,24 +80,15 @@ M.providers = {
   provider_decorator = { module = _decorator.PREPEND_ICON_GREP },
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_grep
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_grep
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_grep
-  or previewers_helper.buffer_preview_files_grep
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_grep
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_grep
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   previewer = previewer,

--- a/lua/fzfx/cfg/git_status.lua
+++ b/lua/fzfx/cfg/git_status.lua
@@ -1,12 +1,9 @@
 local tbl = require("fzfx.commons.tbl")
 
-local constants = require("fzfx.lib.constants")
-local shells = require("fzfx.lib.shells")
 local cmds = require("fzfx.lib.commands")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
 
-local parsers_helper = require("fzfx.helper.parsers")
 local actions_helper = require("fzfx.helper.actions")
 local previewers_helper = require("fzfx.helper.previewers")
 
@@ -135,29 +132,12 @@ M.providers = {
   },
 }
 
---- @param line string
---- @param context fzfx.PipelineContext
---- @return string?
-M._previewer = function(line, context)
-  local parsed = parsers_helper.parse_git_status(line)
-  if constants.HAS_DELTA then
-    local win_width = previewers_helper.get_preview_window_width()
-    return string.format(
-      [[git diff %s | delta -n --tabs 4 --width %d]],
-      shells.shellescape(parsed.filename),
-      win_width
-    )
-  else
-    return string.format([[git diff --color=always %s]], shells.shellescape(parsed.filename))
-  end
-end
-
 M.previewers = {
   current_folder = {
-    previewer = M._previewer,
+    previewer = previewers_helper.fzf_preview_git_status,
   },
   workspace = {
-    previewer = M._previewer,
+    previewer = previewers_helper.fzf_preview_git_status,
   },
 }
 

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -221,10 +221,10 @@ M.providers = {
 local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
-  previewer = previewers_helper.fzf_preview_find
+  previewer = previewers_helper.fzf_preview_grep
   previewer_type = PreviewerTypeEnum.COMMAND_LIST
 else
-  previewer = previewers_helper.buffer_preview_find
+  previewer = previewers_helper.buffer_preview_grep
   previewer_type = PreviewerTypeEnum.BUFFER_FILE
 end
 

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -218,24 +218,15 @@ M.providers = {
   },
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_grep
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_grep
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_grep
-  or previewers_helper.buffer_preview_files_grep
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   restricted_mode = {

--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -259,10 +259,10 @@ M.providers = {
 local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
-  previewer = previewers_helper.fzf_preview_find
+  previewer = previewers_helper.fzf_preview_grep
   previewer_type = PreviewerTypeEnum.COMMAND_LIST
 else
-  previewer = previewers_helper.buffer_preview_find
+  previewer = previewers_helper.buffer_preview_grep
   previewer_type = PreviewerTypeEnum.BUFFER_FILE
 end
 

--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -256,24 +256,15 @@ M.providers = {
   },
 }
 
--- If you want to use fzf-builtin previewer with bat, please use below configs:
---
--- ```
--- previewer = previewers_helper.preview_files_grep
--- previewer_type = PreviewerTypeEnum.COMMAND_LIST
--- ```
---
--- If you want to use nvim buffer previewer, please use below configs:
---
--- ```
--- previewer = previewers_helper.buffer_preview_files_grep
--- previewer_type = PreviewerTypeEnum.BUFFER_FILE
--- ```
-
-local previewer = switches.buffer_previewer_disabled() and previewers_helper.preview_files_grep
-  or previewers_helper.buffer_preview_files_grep
-local previewer_type = switches.buffer_previewer_disabled() and PreviewerTypeEnum.COMMAND_LIST
-  or PreviewerTypeEnum.BUFFER_FILE
+local previewer
+local previewer_type
+if switches.buffer_previewer_disabled() then
+  previewer = previewers_helper.fzf_preview_find
+  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+else
+  previewer = previewers_helper.buffer_preview_find
+  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+end
 
 M.previewers = {
   workspace_diagnostics = {

--- a/lua/fzfx/cfg/vim_commands.lua
+++ b/lua/fzfx/cfg/vim_commands.lua
@@ -561,7 +561,7 @@ M._previewer = function(line, context)
     --   "|_previewer| loc:%s",
     --   vim.inspect(parsed)
     -- )
-    return previewers_helper.fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
+    return previewers_helper._fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
   elseif consts.HAS_ECHO and tbl.tbl_not_empty(parsed) then
     -- log.debug(
     --   "|_previewer| desc:%s",

--- a/lua/fzfx/cfg/vim_commands.lua
+++ b/lua/fzfx/cfg/vim_commands.lua
@@ -561,7 +561,7 @@ M._previewer = function(line, context)
     --   "|_previewer| loc:%s",
     --   vim.inspect(parsed)
     -- )
-    return previewers_helper.preview_files_with_line_range(parsed.filename, parsed.lineno)
+    return previewers_helper.fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
   elseif consts.HAS_ECHO and tbl.tbl_not_empty(parsed) then
     -- log.debug(
     --   "|_previewer| desc:%s",

--- a/lua/fzfx/cfg/vim_keymaps.lua
+++ b/lua/fzfx/cfg/vim_keymaps.lua
@@ -514,7 +514,7 @@ M._previewer = function(line, context)
     --   "|fzfx.config - vim_keymaps_previewer| loc:%s",
     --   vim.inspect(parsed)
     -- )
-    return previewers_helper.fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
+    return previewers_helper._fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
   elseif constants.HAS_ECHO and tbl.tbl_not_empty(parsed) then
     -- log.debug(
     --   "|fzfx.config - vim_keymaps_previewer| desc:%s",

--- a/lua/fzfx/cfg/vim_keymaps.lua
+++ b/lua/fzfx/cfg/vim_keymaps.lua
@@ -514,7 +514,7 @@ M._previewer = function(line, context)
     --   "|fzfx.config - vim_keymaps_previewer| loc:%s",
     --   vim.inspect(parsed)
     -- )
-    return previewers_helper.preview_files_with_line_range(parsed.filename, parsed.lineno)
+    return previewers_helper.fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
   elseif constants.HAS_ECHO and tbl.tbl_not_empty(parsed) then
     -- log.debug(
     --   "|fzfx.config - vim_keymaps_previewer| desc:%s",

--- a/lua/fzfx/cfg/vim_marks.lua
+++ b/lua/fzfx/cfg/vim_marks.lua
@@ -271,7 +271,7 @@ M._previewer = function(line, context)
     --   "|fzfx.config - _vim_marks_previewer| loc:%s",
     --   vim.inspect(parsed)
     -- )
-    return previewers_helper.preview_files_with_line_range(parsed.filename, parsed.lineno)
+    return previewers_helper.fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
   elseif constants.HAS_ECHO and tbl.tbl_not_empty(parsed) then
     -- log.debug(
     --   "|fzfx.config - _vim_marks_previewer| desc:%s",

--- a/lua/fzfx/cfg/vim_marks.lua
+++ b/lua/fzfx/cfg/vim_marks.lua
@@ -271,7 +271,7 @@ M._previewer = function(line, context)
     --   "|fzfx.config - _vim_marks_previewer| loc:%s",
     --   vim.inspect(parsed)
     -- )
-    return previewers_helper.fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
+    return previewers_helper._fzf_preview_grep_with_line_range(parsed.filename, parsed.lineno)
   elseif constants.HAS_ECHO and tbl.tbl_not_empty(parsed) then
     -- log.debug(
     --   "|fzfx.config - _vim_marks_previewer| desc:%s",

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -12,7 +12,7 @@ local bat_themes_helper = require("fzfx.helper.bat_themes")
 
 local M = {}
 
--- files {
+-- bat utils {
 
 --- @return string
 M._bat_style = function()
@@ -47,6 +47,47 @@ M._bat_theme = function()
   return "--theme=" .. theme
 end
 
+-- bat utils }
+
+-- preview fd/find results with cat/bat {
+
+-- Generate the cat/bat shell command in strings list, for previewing fd/find results.
+--- @param filename string
+--- @return string[]
+M._fzf_preview_find = function(filename)
+  if consts.HAS_BAT then
+    local style = M._bat_style()
+    local theme = M._bat_theme()
+    -- "bat --style=%s --theme=%s --color=always --pager=never -- %s"
+    local bat_command = {
+      consts.BAT,
+      style,
+      theme,
+      "--color=always",
+      "--pager=never",
+    }
+    table.insert(bat_command, "--")
+    table.insert(bat_command, filename)
+    return bat_command
+  else
+    -- "cat -n -- %s"
+    return {
+      consts.CAT,
+      "-n",
+      "--",
+      filename,
+    }
+  end
+end
+
+M.fzf_preview_find = function() end
+
+M._buf_preview_find = function() end
+
+M.buf_preview_find = function() end
+
+-- preview fd/find results with cat/bat }
+
 -- for rg/grep, the line number is the 2nd column split by colon ':'.
 -- so we set fzf's option '--preview-window=+{2}-/2' + '--delimiter=:' (see live_grep).
 -- the `+{2}-/2` indicates:
@@ -79,7 +120,9 @@ M.preview_files = function(filename, lineno)
   else
     -- "cat %s"
     return {
-      "cat",
+      consts.CAT,
+      "-n",
+      "--",
       filename,
     }
   end

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -3,7 +3,7 @@ local path = require("fzfx.commons.path")
 local tbl = require("fzfx.commons.tbl")
 local num = require("fzfx.commons.num")
 
-local constants = require("fzfx.lib.constants")
+local consts = require("fzfx.lib.constants")
 local log = require("fzfx.lib.log")
 local LogLevels = require("fzfx.lib.log").LogLevels
 
@@ -14,32 +14,37 @@ local M = {}
 
 -- files {
 
---- @return string, string
-M._bat_style_theme = function()
+--- @return string
+M._bat_style = function()
   local style = "numbers,changes"
-  if type(vim.env["BAT_STYLE"]) == "string" and string.len(vim.env["BAT_STYLE"]) > 0 then
+  if str.not_empty(vim.env["BAT_STYLE"]) then
     style = vim.env["BAT_STYLE"]
   end
+  return "--style=" .. style
+end
+
+--- @return string
+M._bat_theme = function()
   local theme = "base16"
-  if type(vim.env["BAT_THEME"]) == "string" and string.len(vim.env["BAT_THEME"]) > 0 then
+  if str.not_empty(vim.env["BAT_THEME"]) then
     theme = vim.env["BAT_THEME"]
-    return style, theme
+    return "--theme=" .. theme
   end
 
-  if constants.HAS_BAT and vim.opt.termguicolors then
+  if consts.HAS_BAT and vim.opt.termguicolors then
     local colorname = vim.g.colors_name --[[@as string]]
     if str.not_empty(colorname) then
       local theme_config_file = bat_themes_helper.get_theme_config_filename(colorname) --[[@as string]]
       if str.not_empty(theme_config_file) and path.isfile(theme_config_file) then
         local theme_name = bat_themes_helper.get_theme_name(colorname) --[[@as string]]
         if str.not_empty(theme_name) then
-          return style, theme_name
+          return "--theme=" .. theme_name
         end
       end
     end
   end
 
-  return style, theme
+  return "--theme=" .. theme
 end
 
 -- for rg/grep, the line number is the 2nd column split by colon ':'.
@@ -53,12 +58,12 @@ end
 --- @param lineno integer?
 --- @return string[]
 M.preview_files = function(filename, lineno)
-  if constants.HAS_BAT then
+  if consts.HAS_BAT then
     local style, theme = M._bat_style_theme()
     -- "%s --style=%s --theme=%s --color=always --pager=never --highlight-line=%s -- %s"
     return type(lineno) == "number"
         and {
-          constants.BAT,
+          consts.BAT,
           "--style=" .. style,
           "--theme=" .. theme,
           "--color=always",
@@ -68,7 +73,7 @@ M.preview_files = function(filename, lineno)
           filename,
         }
       or {
-        constants.BAT,
+        consts.BAT,
         "--style=" .. style,
         "--theme=" .. theme,
         "--color=always",
@@ -171,7 +176,7 @@ end
 --- @param commit string
 --- @return string?
 M._make_preview_git_commit = function(commit)
-  if constants.HAS_DELTA then
+  if consts.HAS_DELTA then
     local win_width = M.get_preview_window_width()
     return string.format([[git show %s | delta -n --tabs 4 --width %d]], commit, win_width)
   else
@@ -200,10 +205,10 @@ end
 --- @param lineno integer
 --- @return string[]
 M.preview_files_with_line_range = function(filename, lineno)
-  if constants.HAS_BAT then
+  if consts.HAS_BAT then
     local style, theme = M._bat_style_theme()
     return {
-      constants.BAT,
+      consts.BAT,
       "--style=" .. style,
       "--theme=" .. theme,
       "--color=always",

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -229,7 +229,7 @@ end
 
 -- git commit {
 
--- It generates 'git show' or 'delta' shell command for git log/blame results.
+-- It generates 'git show' (with 'delta') shell command for git log/blame results.
 --- @param line string
 --- @return string?
 M.fzf_preview_git_commit = function(line)
@@ -251,7 +251,7 @@ end
 
 -- git diff {
 
--- It generates 'git show' or 'delta' shell command for git log/blame results.
+-- It generates 'git diff' (with 'delta') shell command for git status results.
 --- @param line string
 --- @return string
 M.fzf_preview_git_status = function(line)

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -51,7 +51,6 @@ end
 
 -- preview fd/find results with cat/bat {
 
--- Generate the cat/bat shell command in strings list, for previewing fd/find results.
 --- @param filename string
 --- @return string[]
 M._fzf_preview_find = function(filename)
@@ -80,11 +79,25 @@ M._fzf_preview_find = function(filename)
   end
 end
 
-M.fzf_preview_find = function() end
+-- This previewer works with fzf's builtin preview window.
+-- To enable this previewer, set feature flag `vim.g.fzfx_disable_buffer_previewer=1`.
+-- Generate the cat/bat shell command in strings list, for previewing fd/find results.
+--- @param line string
+--- @return string[]
+M.fzf_preview_find = function(line)
+  local parsed = parsers_helper.parse_find(line)
+  return M._fzf_preview_find(parsed.filename)
+end
 
-M._buf_preview_find = function() end
-
-M.buf_preview_find = function() end
+-- This previewer works with Neovim's buffer, instead of fzf's builtin preview window.
+-- To enable this previewer, unset feature flag `vim.g.fzfx_disable_buffer_previewer`.
+-- Generate buffer configurations for previewing fd/find results.
+--- @param line string
+--- @return {filename:string}
+M.buf_preview_find = function(line)
+  local parsed = parsers_helper.parse_find(line)
+  return { filename = parsed.filename }
+end
 
 -- preview fd/find results with cat/bat }
 

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -284,7 +284,7 @@ end
 --- @param filename string
 --- @param lineno integer
 --- @return string[]
-M.fzf_preview_grep_with_line_range = function(filename, lineno)
+M._fzf_preview_grep_with_line_range = function(filename, lineno)
   if consts.HAS_BAT then
     -- "%s --style=%s --theme=%s --color=always --pager=never --highlight-line=%s -- %s"
     local results = vim.deepcopy(M._FZF_PREVIEW_BAT)

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -12,7 +12,6 @@ local tbl = require("fzfx.commons.tbl")
 local consts = require("fzfx.lib.constants")
 local shells = require("fzfx.lib.shells")
 local log = require("fzfx.lib.log")
-local LogLevels = require("fzfx.lib.log").LogLevels
 
 local parsers_helper = require("fzfx.helper.parsers")
 local bat_themes_helper = require("fzfx.helper.bat_themes")

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -1,3 +1,7 @@
+-- Note:
+-- The previewers works with fzf's builtin preview window, are named with prefix `fzf_`.
+-- The previewers works with Neovim's buffer, are named with prefix `buffer_`.
+
 local str = require("fzfx.commons.str")
 local path = require("fzfx.commons.path")
 local tbl = require("fzfx.commons.tbl")

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -249,7 +249,7 @@ end
 
 -- git commit }
 
--- git diff {
+-- git status {
 
 -- It generates 'git diff' (with 'delta') shell command for git status results.
 --- @param line string
@@ -266,7 +266,7 @@ M.fzf_preview_git_status = function(line)
   end
 end
 
--- git diff }
+-- git status }
 
 -- vim command/keymap/mark {
 

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -277,7 +277,7 @@ end
 -- we cannot use options `--preview-window=+{2}-/2` and `--delimiter=':'` to tell fzf what is the line number.
 -- So we have to use bat option `--line-range` to truncate other parts of preview contents,
 -- leave only interested text contents around the target line number.
--- But this also introduce another limitation: it doesn't support scrolling in preview window.
+-- But this also introduce another limitation: it cannot scroll up in preview window.
 --
 -- When working on Neovim's buffer, this is no longer an issue, the internal buffer previewer engine will handle it.
 --

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -59,28 +59,23 @@ end
 --- @return string[]
 M.preview_files = function(filename, lineno)
   if consts.HAS_BAT then
-    local style, theme = M._bat_style_theme()
+    local style = M._bat_style()
+    local theme = M._bat_theme()
+
     -- "%s --style=%s --theme=%s --color=always --pager=never --highlight-line=%s -- %s"
-    return type(lineno) == "number"
-        and {
-          consts.BAT,
-          "--style=" .. style,
-          "--theme=" .. theme,
-          "--color=always",
-          "--pager=never",
-          "--highlight-line=" .. lineno,
-          "--",
-          filename,
-        }
-      or {
-        consts.BAT,
-        "--style=" .. style,
-        "--theme=" .. theme,
-        "--color=always",
-        "--pager=never",
-        "--",
-        filename,
-      }
+    local bat_command = {
+      consts.BAT,
+      style,
+      theme,
+      "--color=always",
+      "--pager=never",
+    }
+    if type(lineno) == "number" then
+      table.insert(bat_command, "--highlight-line=" .. lineno)
+    end
+    table.insert(bat_command, "--")
+    table.insert(bat_command, filename)
+    return bat_command
   else
     -- "cat %s"
     return {
@@ -206,19 +201,26 @@ end
 --- @return string[]
 M.preview_files_with_line_range = function(filename, lineno)
   if consts.HAS_BAT then
-    local style, theme = M._bat_style_theme()
-    return {
+    local style = M._bat_style()
+    local theme = M._bat_theme()
+
+    -- "%s --style=%s --theme=%s --color=always --pager=never --highlight-line=%s -- %s"
+    local bat_command = {
       consts.BAT,
-      "--style=" .. style,
-      "--theme=" .. theme,
+      style,
+      theme,
       "--color=always",
       "--pager=never",
-      "--highlight-line=" .. lineno,
-      "--line-range",
-      string.format("%d:", math.max(lineno - M.get_preview_window_center(), 1)),
-      "--",
-      filename,
     }
+    table.insert(bat_command, "--highlight-line=" .. lineno)
+    table.insert(bat_command, "--line-range")
+    table.insert(
+      bat_command,
+      string.format("%d:", math.max(lineno - M.get_preview_window_center(), 1))
+    )
+    table.insert(bat_command, "--")
+    table.insert(bat_command, filename)
+    return bat_command
   else
     -- "cat %s"
     return {

--- a/spec/cfg/git_status_spec.lua
+++ b/spec/cfg/git_status_spec.lua
@@ -17,25 +17,6 @@ describe("fzfx.cfg.git_status", function()
   require("fzfx").setup()
 
   describe("[git_status]", function()
-    it("_previewer", function()
-      local lines = {
-        " M fzfx/config.lua",
-        " D fzfx/constants.lua",
-        " M fzfx/line_helpers.lua",
-        " M ../test/line_helpers_spec.lua",
-        "?? ../hello",
-      }
-      for _, line in ipairs(lines) do
-        local actual = git_status_cfg._previewer(line, nil)
-        assert_eq(type(actual), "string")
-        assert_true(str.find(actual, "git diff") > 0)
-        if consts.HAS_DELTA then
-          assert_true(str.find(actual, "delta") > 0)
-        else
-          assert_true(str.find(actual, "delta") == nil)
-        end
-      end
-    end)
     it("_make_provider", function()
       local actual1 = git_status_cfg._make_provider()("", nil)
       local n1 = #git_status_cfg._GIT_STATUS_WORKSPACE

--- a/spec/cfg/vim_marks_spec.lua
+++ b/spec/cfg/vim_marks_spec.lua
@@ -80,14 +80,46 @@ describe("fzfx.cfg.vim_marks", function()
           else
             assert_true(actual[1] == constants.BAT or actual[1] == constants.CAT)
             if constants.HAS_BAT then
-              assert_true(str.startswith(actual[2], "--style="))
-              assert_true(str.startswith(actual[3], "--theme="))
-              assert_eq(actual[4], "--color=always")
-              assert_eq(actual[5], "--pager=never")
-              assert_true(str.startswith(actual[6], "--highlight-line="))
-              assert_eq(actual[7], "--line-range")
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return str.startswith(a, "--style=")
+              end))
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return str.startswith(a, "--theme=")
+              end))
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return str.startswith(a, "--highlight-line=")
+              end))
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return a == "--line-range"
+              end))
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return a == "--color=always"
+              end))
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return a == "--pager=never"
+              end))
             elseif constants.HAS_CAT then
-              assert_eq(type(actual[2]), "string")
+              assert_true(tbl.List:copy(actual):none(function(a)
+                return str.startswith(a, "--style=")
+              end))
+              assert_true(tbl.List:copy(actual):none(function(a)
+                return str.startswith(a, "--theme=")
+              end))
+              assert_true(tbl.List:copy(actual):none(function(a)
+                return str.startswith(a, "--highlight-line=")
+              end))
+              assert_true(tbl.List:copy(actual):none(function(a)
+                return a == "--line-range"
+              end))
+              assert_true(tbl.List:copy(actual):none(function(a)
+                return a == "--color=always"
+              end))
+              assert_true(tbl.List:copy(actual):none(function(a)
+                return a == "--pager=never"
+              end))
+              assert_true(tbl.List:copy(actual):some(function(a)
+                return a == "-n"
+              end))
             end
           end
         end

--- a/spec/helper/previewers_spec.lua
+++ b/spec/helper/previewers_spec.lua
@@ -1,4 +1,3 @@
----@diagnostic disable: undefined-field, unused-local, missing-fields, need-check-nil, param-type-mismatch, assign-type-mismatch
 local cwd = vim.fn.getcwd()
 
 describe("helper.previewers", function()

--- a/spec/helper/previewers_spec.lua
+++ b/spec/helper/previewers_spec.lua
@@ -23,282 +23,260 @@ describe("helper.previewers", function()
   local tbl = require("fzfx.commons.tbl")
   local str = require("fzfx.commons.str")
   local path = require("fzfx.commons.path")
-  local constants = require("fzfx.lib.constants")
-  local previewers = require("fzfx.helper.previewers")
+  local consts = require("fzfx.lib.constants")
+  local previewers_helper = require("fzfx.helper.previewers")
   local conf = require("fzfx.config")
   local fzf_helpers = require("fzfx.detail.fzf_helpers")
   require("fzfx").setup()
 
-  describe("[_bat_style_theme]", function()
-    if constants.HAS_BAT then
-      it("default", function()
-        vim.env.BAT_STYLE = nil
-        vim.env.BAT_THEME = nil
-        local style, theme = previewers._bat_style_theme()
-        assert_eq(style, "numbers,changes")
-        assert_eq(type(theme), "string")
-      end)
-      it("overwrites", function()
-        vim.env.BAT_STYLE = "numbers,changes,headers"
-        vim.env.BAT_THEME = "zenburn"
-        local style, theme = previewers._bat_style_theme()
-        assert_eq(style, vim.env.BAT_STYLE)
-        assert_eq(theme, vim.env.BAT_THEME)
-        vim.env.BAT_STYLE = nil
-        vim.env.BAT_THEME = nil
-      end)
-    end
-  end)
-
-  describe("[preview_files]", function()
-    it("test", function()
-      local actual = previewers.preview_files("lua/fzfx/config.lua", 135)
-      -- print(
-      --     string.format("make file previewer:%s\n", vim.inspect(actual))
-      -- )
-      if actual[1] == constants.BAT then
-        assert_eq(actual[1], constants.BAT)
-        assert_eq(actual[2], "--style=numbers,changes")
-        assert_true(str.startswith(actual[3], "--theme="))
-        assert_eq(actual[4], "--color=always")
-        assert_eq(actual[5], "--pager=never")
-        assert_eq(actual[6], "--highlight-line=135")
-        assert_eq(actual[7], "--")
-        assert_eq(actual[8], "lua/fzfx/config.lua")
-      else
-        assert_eq(actual[1], "cat")
-        assert_eq(actual[2], "lua/fzfx/config.lua")
-      end
+  describe("[_bat_style]", function()
+    it("default", function()
+      vim.env.BAT_STYLE = nil
+      assert_eq(previewers_helper._bat_style(), "--style=numbers,changes")
+    end)
+    it("overwrite", function()
+      vim.env.BAT_STYLE = "full"
+      assert_eq(previewers_helper._bat_style(), "--style=full")
     end)
   end)
 
-  describe("[preview_files_find]", function()
-    it("test", function()
-      local lines = {
-        "~/github/linrongbin16/fzfx.nvim/README.md",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
-      }
-      for i, line in ipairs(lines) do
-        local actual = previewers.preview_files_find(line)
-        print(string.format("preview_files_find-%s:%s\n", vim.inspect(i), vim.inspect(actual)))
-        if actual[1] == constants.BAT then
-          assert_eq(actual[1], constants.BAT)
-          assert_eq(actual[2], "--style=numbers,changes")
-          assert_true(str.startswith(actual[3], "--theme="))
-          assert_eq(actual[4], "--color=always")
-          assert_eq(actual[5], "--pager=never")
-          assert_eq(actual[6], "--")
-          assert_eq(actual[7], path.normalize(line, { double_backslash = true, expand = true }))
-        else
-          assert_eq(actual[1], "cat")
-          assert_eq(actual[2], path.normalize(line, { double_backslash = true, expand = true }))
-        end
-      end
+  describe("[_bat_theme]", function()
+    it("default", function()
+      vim.env.BAT_THEME = nil
+      assert_true(str.startswith(previewers_helper._bat_theme(), "--theme="))
+    end)
+    it("overwrite", function()
+      vim.env.BAT_THEME = "MyBatTheme"
+      assert_eq(previewers_helper._bat_theme(), "--theme=MyBatTheme")
     end)
   end)
 
-  describe("[buffer_preview_files_find]", function()
+  describe("[_fzf_preview_window_width]", function()
     it("test", function()
-      local lines = {
-        "~/github/linrongbin16/fzfx.nvim/README.md",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt",
-      }
-      for i, line in ipairs(lines) do
-        local actual = previewers.buffer_preview_files_find(line)
-        print(
-          string.format("buffer_preview_files_find-%s:%s\n", vim.inspect(i), vim.inspect(actual))
-        )
-        assert_eq(type(actual), "table")
-        assert_true(str.endswith(path.normalize(line, { expand = true }), actual.filename))
-      end
-    end)
-  end)
-
-  describe("[preview_files_grep]", function()
-    it("test", function()
-      local lines = {
-        "~/github/linrongbin16/fzfx.nvim/README.md:1",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua:2",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua:3",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:4",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:5",
-      }
-      for _, line in ipairs(lines) do
-        local actual = previewers.preview_files_grep(line)
-        local expect =
-          path.normalize(str.split(line, ":")[1], { double_backslash = true, expand = true })
-        print(string.format("normalize:%s\n", vim.inspect(expect)))
-        print(string.format("file previewer grep:%s\n", vim.inspect(actual)))
-        if actual[1] == constants.BAT then
-          assert_eq(actual[1], constants.BAT)
-          assert_eq(actual[2], "--style=numbers,changes")
-          assert_true(str.startswith(actual[3], "--theme="))
-          assert_eq(actual[4], "--color=always")
-          assert_eq(actual[5], "--pager=never")
-          assert_true(str.startswith(actual[6], "--highlight-line"))
-          assert_eq(actual[7], "--")
-          assert_true(str.startswith(actual[8], expect))
-        else
-          assert_eq(actual[1], "cat")
-          assert_eq(actual[2], expect)
-        end
-      end
-    end)
-  end)
-
-  describe("[preview_files_grep_no_filename]", function()
-    it("test", function()
-      local lines = {
-        "1",
-        "2:1",
-        "3:hello",
-        "4:  local i = 1",
-      }
-      for _, line in ipairs(lines) do
-        local ctx = make_context()
-        local actual = previewers.preview_files_grep_no_filename(line, ctx)
-        local expect =
-          path.normalize(str.split(line, ":")[1], { double_backslash = true, expand = true })
-        print(string.format("normalize:%s\n", vim.inspect(expect)))
-        print(string.format("file previewer grep:%s\n", vim.inspect(actual)))
-        if actual[1] == constants.BAT then
-          assert_eq(actual[1], constants.BAT)
-          assert_eq(actual[2], "--style=numbers,changes")
-          assert_true(str.startswith(actual[3], "--theme="))
-          assert_eq(actual[4], "--color=always")
-          assert_eq(actual[5], "--pager=never")
-          assert_true(str.startswith(actual[6], "--highlight-line"))
-          assert_eq(actual[7], "--line-range")
-          assert_eq(actual[9], "--")
-        else
-          assert_eq(actual[1], "cat")
-        end
-      end
-    end)
-  end)
-
-  describe("[buffer_preview_files_grep_no_filename]", function()
-    it("test", function()
-      local lines = {
-        "1",
-        "2:1",
-        "3:hello",
-        "4:  local i = 1",
-      }
-      local ctx = make_context()
-      local filename = vim.api.nvim_buf_get_name(ctx.bufnr)
-      filename = path.normalize(filename, { double_backslash = true, expand = true })
-
-      for _, line in ipairs(lines) do
-        local actual = previewers.buffer_preview_files_grep_no_filename(line, ctx)
-        print(string.format("filename:%s\n", vim.inspect(filename)))
-        print(string.format("file previewer grep:%s\n", vim.inspect(actual)))
-        local splits = str.split(line, ":")
-        if actual then
-          assert_eq(actual.filename, filename)
-          assert_eq(actual.lineno, tonumber(splits[1]))
-        end
-      end
-    end)
-  end)
-
-  describe("[get_preview_window_width]", function()
-    it("test", function()
-      local actual = previewers.get_preview_window_width()
+      local actual = previewers_helper._fzf_preview_window_width()
       assert_eq(type(actual), "number")
-      assert_true(actual >= 3)
+      assert_true(actual > 0)
     end)
   end)
 
-  describe("[preview_git_commit]", function()
-    it("_make_preview_git_commit", function()
-      local lines = {
-        "44ee80e",
-        "706e1d6",
-      }
-      for _, line in ipairs(lines) do
-        local actual = previewers._make_preview_git_commit(line)
-        if actual ~= nil then
-          assert_eq(type(actual), "string")
-          assert_true(str.find(actual, "git show") > 0)
-          if vim.fn.executable("delta") > 0 then
-            assert_true(str.find(actual, "delta") > 0)
-          else
-            assert_true(str.find(actual, "delta") == nil)
-          end
+  describe("[_fzf_preview_window_centered_lineno]", function()
+    it("test", function()
+      local actual = previewers_helper._fzf_preview_window_half_height()
+      assert_eq(type(actual), "number")
+      assert_true(actual > 0)
+    end)
+  end)
+
+  describe("[_fzf_preview_find]", function()
+    it("test", function()
+      local filename = "README.md"
+      local actual = previewers_helper._fzf_preview_find(filename)
+      assert_eq(type(actual), "table")
+      if consts.HAS_BAT then
+        local n = #previewers_helper._FZF_PREVIEW_BAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_BAT[i])
+        end
+      else
+        local n = #previewers_helper._FZF_PREVIEW_CAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_CAT[i])
         end
       end
+      assert_eq(actual[#actual - 1], "--")
+      assert_eq(actual[#actual], filename)
+    end)
+  end)
+
+  describe("[fzf_preview_find]", function()
+    it("test", function()
+      local line = "README.md"
+      local actual = previewers_helper.fzf_preview_find(line)
+      assert_eq(type(actual), "table")
+      assert_true(actual[1] == consts.BAT or actual[1] == consts.CAT)
+    end)
+  end)
+
+  describe("[buffer_preview_find]", function()
+    it("test", function()
+      local line = "README.md"
+      local actual = previewers_helper.buffer_preview_find(line)
+      assert_eq(type(actual), "table")
+      assert_true(str.endswith(actual.filename, "README.md"))
+    end)
+  end)
+
+  describe("[_fzf_preview_grep]", function()
+    it("case-1", function()
+      local filename = "README.md"
+      local lineno = 12
+      local actual = previewers_helper._fzf_preview_grep(filename, lineno)
+      assert_eq(type(actual), "table")
+      if consts.HAS_BAT then
+        local n = #previewers_helper._FZF_PREVIEW_BAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_BAT[i])
+        end
+        assert_true(tbl.List:copy(actual):some(function(a)
+          return a == string.format("--highlight-line=%d", lineno)
+        end))
+      else
+        local n = #previewers_helper._FZF_PREVIEW_CAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_CAT[i])
+        end
+      end
+      assert_eq(actual[#actual - 1], "--")
+      assert_eq(actual[#actual], filename)
     end)
 
-    it("preview_git_commit", function()
+    it("case-2", function()
+      local filename = "README.md"
+      local actual = previewers_helper._fzf_preview_grep(filename)
+      assert_eq(type(actual), "table")
+      if consts.HAS_BAT then
+        local n = #previewers_helper._FZF_PREVIEW_BAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_BAT[i])
+        end
+        assert_true(tbl.List:copy(actual):none(function(a)
+          local p = str.find(a, "--highlight-line=")
+          return type(p) == "number" and p > 0
+        end))
+      else
+        local n = #previewers_helper._FZF_PREVIEW_CAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_CAT[i])
+        end
+      end
+      assert_eq(actual[#actual - 1], "--")
+      assert_eq(actual[#actual], filename)
+    end)
+  end)
+
+  describe("[fzf_preview_grep]", function()
+    it("test", function()
+      local line = "README.md:1:ok"
+      local actual = previewers_helper.fzf_preview_grep(line)
+      assert_eq(type(actual), "table")
+      assert_true(str.endswith(actual[#actual], "README.md"))
+    end)
+  end)
+
+  describe("[buffer_preview_grep]", function()
+    it("test", function()
+      local line = "README.md:13:ok"
+      local actual = previewers_helper.buffer_preview_grep(line)
+      assert_eq(type(actual), "table")
+      assert_true(str.endswith(actual.filename, "README.md"))
+      assert_eq(actual.lineno, 13)
+    end)
+  end)
+
+  describe("[fzf_preview_grep_no_filename]", function()
+    it("test", function()
+      local lines = { "1:1:ok", "2:1: this is the plugin" }
+      for i, line in ipairs(lines) do
+        local actual = previewers_helper.fzf_preview_grep_no_filename(line, make_context())
+        assert_eq(type(actual), "table")
+        if consts.HAS_BAT then
+          local n = #previewers_helper._FZF_PREVIEW_BAT
+          for j = 1, n do
+            assert_eq(actual[j], previewers_helper._FZF_PREVIEW_BAT[j])
+          end
+          assert_true(tbl.List:copy(actual):some(function(a)
+            local p = str.find(a, "--highlight-line=")
+            return type(p) == "number" and p > 0
+          end))
+        else
+          local n = #previewers_helper._FZF_PREVIEW_CAT
+          for j = 1, n do
+            assert_eq(actual[j], previewers_helper._FZF_PREVIEW_CAT[j])
+          end
+          assert_true(tbl.List:copy(actual):none(function(a)
+            local p = str.find(a, "--highlight-line=")
+            return type(p) == "number" and p > 0
+          end))
+        end
+        assert_eq(actual[#actual - 1], "--")
+        assert_true(str.endswith(actual[#actual], "README.md"))
+      end
+    end)
+  end)
+
+  describe("[buffer_preview_grep_no_filename]", function()
+    it("test", function()
+      local lines = { "1:1:ok", "2:1: this is the plugin" }
+      for i, line in ipairs(lines) do
+        local actual = previewers_helper.buffer_preview_grep_no_filename(line, make_context())
+        local splits = str.split(line, ":")
+        assert_eq(type(actual), "table")
+        assert_true(str.endswith(actual.filename, "README.md"))
+        assert_eq(actual.lineno, tonumber(splits[1]))
+      end
+    end)
+  end)
+
+  describe("[fzf_preview_git_commit]", function()
+    it("commit", function()
       local lines = {
         "44ee80e 2023-10-11 linrongbin16 (HEAD -> origin/feat_git_status) docs: wording",
         "706e1d6 2023-10-10 linrongbin16 chore",
-        "                                | 1:2| fzfx.nvim",
       }
       for _, line in ipairs(lines) do
-        local actual = previewers.preview_git_commit(line)
-        if actual ~= nil then
-          assert_eq(type(actual), "string")
-          assert_true(str.find(actual, "git show") > 0)
-          if vim.fn.executable("delta") > 0 then
-            assert_true(str.find(actual, "delta") > 0)
-          else
-            assert_true(str.find(actual, "delta") == nil)
-          end
+        local actual = previewers_helper.fzf_preview_git_commit(line)
+        assert_eq(type(actual), "string")
+        assert_true(str.find(actual, "git show") > 0)
+        if consts.HAS_DELTA then
+          assert_true(str.find(actual, "delta") > 0)
+        else
+          assert_true(str.find(actual, "delta") == nil)
         end
       end
     end)
-  end)
-
-  describe("[preview_files_with_line_range]", function()
-    it("test", function()
-      local actual = previewers.preview_files_with_line_range("lua/fzfx/config.lua", 135)
-      assert_eq(type(actual), "table")
-      print(string.format("preview_files_with_line_range:%s\n", vim.inspect(actual)))
-      if actual[1] == constants.BAT then
-        assert_eq(actual[1], constants.BAT)
-        assert_eq(actual[2], "--style=numbers,changes")
-        assert_true(str.startswith(actual[3], "--theme="))
-        assert_eq(actual[4], "--color=always")
-        assert_eq(actual[5], "--pager=never")
-        assert_eq(actual[6], "--highlight-line=135")
-        assert_true(str.startswith(actual[7], "--line-range"))
-        assert_true(str.endswith(actual[8], ":"))
-        assert_eq(actual[9], "--")
-        assert_eq(actual[10], "lua/fzfx/config.lua")
-      else
-        assert_eq(actual[1], "cat")
-        assert_eq(actual[2], "lua/fzfx/config.lua")
+    it("empty", function()
+      local lines = {
+        "                                | 1:2| fzfx.nvim",
+      }
+      for _, line in ipairs(lines) do
+        local actual = previewers_helper.fzf_preview_git_commit(line)
+        assert_eq(actual, nil)
       end
     end)
   end)
 
-  describe("[buffer_preview_files_grep]", function()
+  describe("[fzf_preview_grep_with_line_range]", function()
     it("test", function()
-      local lines = {
-        "~/github/linrongbin16/fzfx.nvim/README.md:1:3:hello world",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx.lua:3:7: hello",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/config.lua:8:9324",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/goodbye world/goodbye.lua:2:81",
-        "~/github/linrongbin16/fzfx.nvim/lua/fzfx/test/hello world.txt:8: hello",
-      }
-      for i, line in ipairs(lines) do
-        local actual = previewers.buffer_preview_files_grep(line)
-        print(
-          string.format("buffer_preview_files_grep-%s:%s\n", vim.inspect(i), vim.inspect(actual))
-        )
-        assert_eq(type(actual), "table")
-        local splits = str.split(line, ":")
-        assert_true(str.endswith(path.normalize(splits[1], { expand = true }), actual.filename))
-        assert_eq(tonumber(splits[2]), actual.lineno)
+      local filename = "lua/fzfx/config.lua"
+      local lineno = 135
+      local actual = previewers_helper.fzf_preview_grep_with_line_range(filename, lineno)
+      print(string.format("fzf_preview_grep_with_line_range:%s\n", vim.inspect(actual)))
+      assert_eq(type(actual), "table")
+      if consts.HAS_BAT then
+        local n = #previewers_helper._FZF_PREVIEW_BAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_BAT[i])
+        end
+        assert_true(tbl.List:copy(actual):some(function(a)
+          return a == string.format("--highlight-line=%d", lineno)
+        end))
+        assert_true(tbl.List:copy(actual):some(function(a)
+          return a == "--line-range"
+        end))
+      else
+        local n = #previewers_helper._FZF_PREVIEW_CAT
+        for i = 1, n do
+          assert_eq(actual[i], previewers_helper._FZF_PREVIEW_CAT[i])
+        end
+        assert_true(tbl.List:copy(actual):none(function(a)
+          return a == string.format("--highlight-line=%d", lineno)
+        end))
+        assert_true(tbl.List:copy(actual):none(function(a)
+          return a == "--line-range"
+        end))
       end
+      assert_eq(actual[#actual - 1], "--")
+      assert_true(str.endswith(actual[#actual], "config.lua"))
     end)
   end)
 end)

--- a/spec/helper/previewers_spec.lua
+++ b/spec/helper/previewers_spec.lua
@@ -267,11 +267,11 @@ describe("helper.previewers", function()
     end)
   end)
 
-  describe("[fzf_preview_grep_with_line_range]", function()
+  describe("[_fzf_preview_grep_with_line_range]", function()
     it("test", function()
       local filename = "lua/fzfx/config.lua"
       local lineno = 135
-      local actual = previewers_helper.fzf_preview_grep_with_line_range(filename, lineno)
+      local actual = previewers_helper._fzf_preview_grep_with_line_range(filename, lineno)
       print(string.format("fzf_preview_grep_with_line_range:%s\n", vim.inspect(actual)))
       assert_eq(type(actual), "table")
       if consts.HAS_BAT then

--- a/spec/helper/previewers_spec.lua
+++ b/spec/helper/previewers_spec.lua
@@ -245,6 +245,28 @@ describe("helper.previewers", function()
     end)
   end)
 
+  describe("[fzf_preview_git_status]", function()
+    it("test", function()
+      local lines = {
+        " M fzfx/config.lua",
+        " D fzfx/constants.lua",
+        " M fzfx/line_helpers.lua",
+        " M ../test/line_helpers_spec.lua",
+        "?? ../hello",
+      }
+      for _, line in ipairs(lines) do
+        local actual = previewers_helper.fzf_preview_git_status(line)
+        assert_eq(type(actual), "string")
+        assert_true(str.startswith(actual, "git diff"))
+        if consts.HAS_DELTA then
+          assert_true(str.find(actual, "delta") > 0)
+        else
+          assert_true(str.find(actual, "delta") == nil)
+        end
+      end
+    end)
+  end)
+
   describe("[fzf_preview_grep_with_line_range]", function()
     it("test", function()
       local filename = "lua/fzfx/config.lua"

--- a/spec/schema_spec.lua
+++ b/spec/schema_spec.lua
@@ -1,4 +1,3 @@
----@diagnostic disable: undefined-field, unused-local, missing-fields
 local cwd = vim.fn.getcwd()
 
 describe("schema", function()


### PR DESCRIPTION
# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [x] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [x] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [x] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [x] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
