### PR TITLE
feat(bat)!: add bat theme autogen switch, by default disabled

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -3,4 +3,8 @@
   "MD013": false,
   // Fenced code blocks should have a language specified
   "MD040": false,
+  // Inline HTML
+  "MD033": false,
+  // Bare URL used
+  "MD034": false,
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ https://github.com/linrongbin16/fzfx.nvim/assets/6496887/b5e2b0dc-4dd6-4c18-b1da
   - [API References](#api-references)
 - [Known Issues](#-known-issues)
 - [Alternatives](#-alternatives)
-- [Development](#-development)
+- [Development](#%EF%B8%8F-development)
 - [Contribute](#-contribute)
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -1812,7 +1812,7 @@ For advanced configurations, please check [Advanced Configuration](https://githu
 
 To enable/disable some features, please define below global variables before setup this plugin:
 
-- `vim.g.fzfx_disable_buffer_previewer`: Disable nvim buffer for previewing file contents, use fzf builtin preview window via `bat` with best performance.
+- `vim.g.fzfx_disable_buffer_previewer`: Disable nvim buffer for previewing file contents, use fzf builtin preview window via `bat` with best performance. By default this feature is enabled.
 
    <details>
    <summary><i>Click here to see how to configure</i></summary>
@@ -1825,6 +1825,23 @@ To enable/disable some features, please define below global variables before set
   ```lua
   -- lua scripts
   vim.g.fzfx_disable_buffer_previewer = 1 -- or true
+  ```
+
+   </details>
+
+- `vim.g.fzfx_enable_bat_theme_autogen`: Enable [bat themes](https://github.com/sharkdp/bat#adding-new-themes) auto generation for fzf's builtin preview window, it generates the [TextMate `.tmTheme` file](https://macromates.com/manual/en/themes) (widely used by text editors such as [Sublime Text](https://www.sublimetext.com/docs/color_schemes_tmtheme.html), [VS Code](https://code.visualstudio.com/docs/getstarted/themes) and `bat` command) for `bat` based on current Neovim's colorscheme, thus makes a closer looking to Neovim's buffer. By default this feature is disabled.
+
+   <details>
+   <summary><i>Click here to see how to configure</i></summary>
+
+  ```vim
+  " vim scripts
+  let g:fzfx_enable_bat_theme_autogen = 1 " or v:true
+  ```
+
+  ```lua
+  -- lua scripts
+  vim.g.fzfx_enable_bat_theme_autogen = 1 -- or true
   ```
 
    </details>

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -27,6 +27,7 @@ local fileio = require("fzfx.commons.fileio")
 local spawn = require("fzfx.commons.spawn")
 
 local consts = require("fzfx.lib.constants")
+local switches = require("fzfx.lib.switches")
 local log = require("fzfx.lib.log")
 
 local bat_themes_helper = require("fzfx.helper.bat_themes")
@@ -563,6 +564,10 @@ M._build_theme = function(colorname)
 end
 
 M.setup = function()
+  if not switches.bat_theme_autogen_enabled() then
+    return
+  end
+
   if not consts.HAS_BAT then
     return
   end

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -574,8 +574,9 @@ M.setup = function()
 
   bat_themes_helper.async_get_theme_dir(function()
     vim.schedule(function()
-      if str.not_empty(vim.g.colors_name) then
-        M._build_theme(vim.g.colors_name)
+      local colorname = bat_themes_helper.get_color_name()
+      if str.not_empty(colorname) then
+        M._build_theme(colorname)
       end
     end)
   end)
@@ -583,8 +584,9 @@ M.setup = function()
   vim.api.nvim_create_autocmd({ "ColorScheme" }, {
     callback = function(event)
       vim.schedule(function()
-        if str.not_empty(vim.g.colors_name) then
-          M._build_theme(vim.g.colors_name)
+        local colorname = bat_themes_helper.get_color_name()
+        if str.not_empty(colorname) then
+          M._build_theme(colorname)
         end
       end)
     end,

--- a/lua/fzfx/helper/bat_themes.lua
+++ b/lua/fzfx/helper/bat_themes.lua
@@ -7,6 +7,11 @@ local log = require("fzfx.lib.log")
 
 local M = {}
 
+--- @return string
+M.get_color_name = function()
+  return vim.g.colors_name or "default"
+end
+
 -- theme dir {
 
 -- Create directory if it doesn't exist.

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -12,6 +12,7 @@ local tbl = require("fzfx.commons.tbl")
 local consts = require("fzfx.lib.constants")
 local shells = require("fzfx.lib.shells")
 local log = require("fzfx.lib.log")
+local switches = require("fzfx.lib.switches")
 
 local parsers_helper = require("fzfx.helper.parsers")
 local bat_themes_helper = require("fzfx.helper.bat_themes")
@@ -37,8 +38,8 @@ M._bat_theme = function()
     return "--theme=" .. theme
   end
 
-  if consts.HAS_BAT and vim.opt.termguicolors then
-    local colorname = vim.g.colors_name --[[@as string]]
+  if switches.bat_theme_autogen_enabled() and consts.HAS_BAT and vim.opt.termguicolors then
+    local colorname = bat_themes_helper.get_color_name()
     if str.not_empty(colorname) then
       local theme_config_file = bat_themes_helper.get_theme_config_filename(colorname) --[[@as string]]
       if str.not_empty(theme_config_file) and path.isfile(theme_config_file) then

--- a/lua/fzfx/lib/switches.lua
+++ b/lua/fzfx/lib/switches.lua
@@ -2,13 +2,26 @@ local M = {}
 
 --- @return boolean
 M.buffer_previewer_disabled = function()
-  return (
-    type(vim.g.fzfx_disable_buffer_previewer) == "number"
-    and vim.g.fzfx_disable_buffer_previewer > 0
-  )
-    or (
-      type(vim.g.fzfx_disable_buffer_previewer) == "boolean" and vim.g.fzfx_disable_buffer_previewer
-    )
+  local value = vim.g.fzfx_disable_buffer_previewer
+  if type(value) == "number" then
+    return value > 0
+  end
+  if type(value) == "boolean" then
+    return value
+  end
+  return false
+end
+
+--- @return boolean
+M.bat_theme_autogen_enabled = function()
+  local value = vim.g.fzfx_enable_bat_theme_autogen
+  if type(value) == "number" then
+    return value > 0
+  end
+  if type(value) == "boolean" then
+    return value
+  end
+  return false
 end
 
 return M

--- a/lua/fzfx/lib/switches.lua
+++ b/lua/fzfx/lib/switches.lua
@@ -1,8 +1,8 @@
 local M = {}
 
+--- @param value any
 --- @return boolean
-M.buffer_previewer_disabled = function()
-  local value = vim.g.fzfx_disable_buffer_previewer
+M._convert_boolean = function(value)
   if type(value) == "number" then
     return value > 0
   end
@@ -13,15 +13,13 @@ M.buffer_previewer_disabled = function()
 end
 
 --- @return boolean
+M.buffer_previewer_disabled = function()
+  return M._convert_boolean(vim.g.fzfx_disable_buffer_previewer)
+end
+
+--- @return boolean
 M.bat_theme_autogen_enabled = function()
-  local value = vim.g.fzfx_enable_bat_theme_autogen
-  if type(value) == "number" then
-    return value > 0
-  end
-  if type(value) == "boolean" then
-    return value
-  end
-  return false
+  return M._convert_boolean(vim.g.fzfx_enable_bat_theme_autogen)
 end
 
 return M

--- a/spec/lib/switches_spec.lua
+++ b/spec/lib/switches_spec.lua
@@ -10,26 +10,32 @@ describe("lib.switches", function()
   end)
 
   local switches = require("fzfx.lib.switches")
+  describe("[_convert_boolean]", function()
+    it("test", function()
+      assert_true(switches._convert_boolean(1))
+      assert_true(switches._convert_boolean(true))
+      assert_false(switches._convert_boolean("true"))
+      assert_false(switches._convert_boolean(nil))
+      assert_false(switches._convert_boolean())
+      assert_false(switches._convert_boolean(false))
+      assert_false(switches._convert_boolean("false"))
+      assert_false(switches._convert_boolean(0))
+    end)
+  end)
   describe("[fzfx_disable_buffer_previewer]", function()
-    it("disabled", function()
+    it("test", function()
       vim.g.fzfx_disable_buffer_previewer = 1
       assert_true(switches.buffer_previewer_disabled())
       vim.g.fzfx_disable_buffer_previewer = true
       assert_true(switches.buffer_previewer_disabled())
-      vim.g.fzfx_disable_buffer_previewer = "true"
-      assert_false(switches.buffer_previewer_disabled())
-      vim.g.fzfx_disable_buffer_previewer = nil
-      assert_false(switches.buffer_previewer_disabled())
     end)
-    it("enabled", function()
-      vim.g.fzfx_disable_buffer_previewer = 0
-      assert_false(switches.buffer_previewer_disabled())
-      vim.g.fzfx_disable_buffer_previewer = false
-      assert_false(switches.buffer_previewer_disabled())
-      vim.g.fzfx_disable_buffer_previewer = "false"
-      assert_false(switches.buffer_previewer_disabled())
-      vim.g.fzfx_disable_buffer_previewer = nil
-      assert_false(switches.buffer_previewer_disabled())
+  end)
+  describe("[fzfx_enable_bat_theme_autogen]", function()
+    it("test", function()
+      vim.g.fzfx_enable_bat_theme_autogen = 1
+      assert_true(switches.bat_theme_autogen_enabled())
+      vim.g.fzfx_enable_bat_theme_autogen = true
+      assert_true(switches.bat_theme_autogen_enabled())
     end)
   end)
 end)


### PR DESCRIPTION
Resolves #741 .

# Regresion test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [ ] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
