### PR TITLE
refactor: rename "PreviewerTypeEnum"

### DIFF
--- a/bin/previewer.lua
+++ b/bin/previewer.lua
@@ -8,6 +8,7 @@ local str = require("fzfx.commons.str")
 local tbl = require("fzfx.commons.tbl")
 local fileio = require("fzfx.commons.fileio")
 local spawn = require("fzfx.commons.spawn")
+local schema = require("fzfx.schema")
 local shell_helpers = require("fzfx.detail.shell_helpers")
 shell_helpers.setup("previewer")
 
@@ -66,7 +67,8 @@ local function println(l)
   end
 end
 
-if metaopts.previewer_type == "command" then
+local PreviewerTypeEnum = schema.PreviewerTypeEnum
+if metaopts.previewer_type == PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING then
   local cmd = fileio.readfile(resultfile, { trim = true })
   shell_helpers.log_debug("cmd:" .. vim.inspect(cmd))
   if str.empty(cmd) then
@@ -74,7 +76,7 @@ if metaopts.previewer_type == "command" then
   else
     os.execute(cmd)
   end
-elseif metaopts.previewer_type == "command_list" then
+elseif metaopts.previewer_type == PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY then
   local cmd = fileio.readfile(resultfile, { trim = true })
   shell_helpers.log_debug("cmd:" .. vim.inspect(cmd))
   if str.empty(cmd) then
@@ -90,16 +92,6 @@ elseif metaopts.previewer_type == "command_list" then
   local sp = spawn.run(cmd_splits, { on_stdout = println, on_stderr = function() end })
   shell_helpers.log_ensure(sp ~= nil, "failed to run command:" .. vim.inspect(cmd_splits))
   sp:wait()
-elseif metaopts.previewer_type == "list" then
-  local f = io.open(resultfile, "r")
-  shell_helpers.log_ensure(f ~= nil, "failed to open resultfile:" .. vim.inspect(resultfile))
-  --- @diagnostic disable-next-line: need-check-nil
-  for l in f:lines("*line") do
-    shell_helpers.log_debug("line:" .. l)
-    io.write(string.format("%s\n", l))
-  end
-  --- @diagnostic disable-next-line: need-check-nil
-  f:close()
 else
   shell_helpers.log_throw("unknown previewer meta:" .. vim.inspect(metajsonstring))
 end

--- a/bin/provider.lua
+++ b/bin/provider.lua
@@ -149,7 +149,7 @@ then
     return
   end
 
-  local sp = spawn.run(cmd_splits, { on_stdout = println, on_stderr = function() end }) --[[@as vim.SystemObj]]
+  local sp = spawn.run(cmd_splits, { on_stdout = println, on_stderr = function() end })
   shell_helpers.log_ensure(sp ~= nil, "failed to run command:" .. vim.inspect(cmd_splits))
   sp:wait()
 elseif metaopts.provider_type == ProviderTypeEnum.DIRECT then

--- a/lua/fzfx/cfg/_lsp_locations.lua
+++ b/lua/fzfx/cfg/_lsp_locations.lua
@@ -555,10 +555,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_grep
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_grep
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/buf_live_grep.lua
+++ b/lua/fzfx/cfg/buf_live_grep.lua
@@ -121,10 +121,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_grep_no_filename
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_grep_no_filename
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/buffers.lua
+++ b/lua/fzfx/cfg/buffers.lua
@@ -84,10 +84,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_find
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_find
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/file_explorer.lua
+++ b/lua/fzfx/cfg/file_explorer.lua
@@ -311,12 +311,12 @@ end
 M.previewers = {
   filter_hidden = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = previewer_label,
   },
   include_hidden = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = previewer_label,
   },
 }

--- a/lua/fzfx/cfg/files.lua
+++ b/lua/fzfx/cfg/files.lua
@@ -154,10 +154,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_find
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_find
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/git_files.lua
+++ b/lua/fzfx/cfg/git_files.lua
@@ -122,10 +122,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_find
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_find
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/git_live_grep.lua
+++ b/lua/fzfx/cfg/git_live_grep.lua
@@ -84,10 +84,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_grep
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_grep
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/live_grep.lua
+++ b/lua/fzfx/cfg/live_grep.lua
@@ -222,10 +222,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_grep
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_grep
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/lsp_diagnostics.lua
+++ b/lua/fzfx/cfg/lsp_diagnostics.lua
@@ -260,10 +260,10 @@ local previewer
 local previewer_type
 if switches.buffer_previewer_disabled() then
   previewer = previewers_helper.fzf_preview_grep
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
 else
   previewer = previewers_helper.buffer_preview_grep
-  previewer_type = PreviewerTypeEnum.BUFFER_FILE
+  previewer_type = PreviewerTypeEnum.BUFFER
 end
 
 M.previewers = {

--- a/lua/fzfx/cfg/vim_command_history.lua
+++ b/lua/fzfx/cfg/vim_command_history.lua
@@ -80,7 +80,7 @@ M._previewer = function() end
 M.previewers = {
   key = "default",
   previewer = M._previewer,
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
 }
 
 M.actions = {

--- a/lua/fzfx/cfg/vim_commands.lua
+++ b/lua/fzfx/cfg/vim_commands.lua
@@ -577,17 +577,17 @@ end
 M.previewers = {
   all_commands = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_command,
   },
   ex_commands = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_command,
   },
   user_commands = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_command,
   },
 }

--- a/lua/fzfx/cfg/vim_keymaps.lua
+++ b/lua/fzfx/cfg/vim_keymaps.lua
@@ -530,22 +530,22 @@ end
 M.previewers = {
   all_mode = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_keymap,
   },
   n_mode = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_keymap,
   },
   i_mode = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_keymap,
   },
   v_mode = {
     previewer = M._previewer,
-    previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+    previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
     previewer_label = labels_helper.label_vim_keymap,
   },
 }

--- a/lua/fzfx/cfg/vim_marks.lua
+++ b/lua/fzfx/cfg/vim_marks.lua
@@ -286,7 +286,7 @@ end
 
 M.previewers = {
   previewer = M._previewer,
-  previewer_type = PreviewerTypeEnum.COMMAND_LIST,
+  previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
   previewer_label = labels_helper.label_vim_mark,
 }
 

--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -21,7 +21,7 @@ local PopupWindow = {}
 --- @package
 --- @param win_opts fzfx.WindowOpts
 --- @param window_type "fzf"|"buffer"
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @return fzfx.PopupWindow
 function PopupWindow:new(win_opts, window_type, buffer_previewer_opts)
   -- check executables
@@ -64,7 +64,7 @@ function PopupWindow:resize()
 end
 
 --- @param job_id integer
---- @param previewer_result fzfx.BufferFilePreviewerResult
+--- @param previewer_result fzfx.BufferPreviewerResult
 --- @param previewer_label_result string?
 function PopupWindow:preview_file(job_id, previewer_result, previewer_label_result)
   self.instance:preview_file(job_id, previewer_result, previewer_label_result)
@@ -153,7 +153,7 @@ end
 --- @param context fzfx.PipelineContext
 --- @param on_close fzfx.OnPopupExit?
 --- @param use_buffer_previewer boolean?
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @return fzfx.Popup
 function Popup:new(
   win_opts,

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -10,9 +10,9 @@ local buffer_popup_window_helpers = require("fzfx.detail.popup.buffer_popup_wind
 
 local M = {}
 
---- @alias fzfx.BufferFilePreviewerOpts {fzf_preview_window_opts:fzfx.FzfPreviewWindowOpts,fzf_border_opts:string}
+--- @alias fzfx.BufferPreviewerOpts  {fzf_preview_window_opts:fzfx.FzfPreviewWindowOpts,fzf_border_opts:string}
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @param relative_winnr integer
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
@@ -82,7 +82,7 @@ M._make_cursor_opts = function(
 end
 
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @param relative_winnr integer
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
@@ -151,7 +151,7 @@ M._make_center_opts = function(
 end
 
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @param relative_winnr integer
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
@@ -186,7 +186,7 @@ end
 --- @field _saved_current_winnr integer
 --- @field _saved_current_win_first_line integer
 --- @field _saved_win_opts fzfx.WindowOpts
---- @field _saved_buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @field _saved_buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @field _saved_previewing_file_content_job fzfx.BufferPopupWindowPreviewFileContentJob
 --- @field _saved_previewing_file_content_view fzfx.BufferPopupWindowPreviewFileContentView
 --- @field _current_previewing_file_job_id integer?
@@ -233,7 +233,7 @@ end
 
 --- @package
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @return fzfx.BufferPopupWindow
 function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
   local current_winnr = vim.api.nvim_get_current_win()
@@ -464,9 +464,9 @@ function BufferPopupWindow:_make_view(preview_file_content)
   return view
 end
 
---- @alias fzfx.BufferPopupWindowPreviewFileJob {job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
+--- @alias fzfx.BufferPopupWindowPreviewFileJob {job_id:integer,previewer_result:fzfx.BufferPreviewerResult ,previewer_label_result:string?}
 --- @param job_id integer
---- @param previewer_result fzfx.BufferFilePreviewerResult
+--- @param previewer_result fzfx.BufferPreviewerResult
 --- @param previewer_label_result string?
 function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_label_result)
   if str.empty(tbl.tbl_get(previewer_result, "filename")) then
@@ -578,7 +578,7 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
   end, 20)
 end
 
---- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferFilePreviewerResult,previewer_label_result:string?}
+--- @alias fzfx.BufferPopupWindowPreviewFileContentJob {contents:string[],job_id:integer,previewer_result:fzfx.BufferPreviewerResult ,previewer_label_result:string?}
 --- @param file_content fzfx.BufferPopupWindowPreviewFileContentJob
 --- @param content_view fzfx.BufferPopupWindowPreviewFileContentView
 --- @param on_complete (fun(done:boolean):any)|nil

--- a/lua/fzfx/detail/popup/fzf_popup_window.lua
+++ b/lua/fzfx/detail/popup/fzf_popup_window.lua
@@ -5,7 +5,7 @@ local popup_helpers = require("fzfx.detail.popup.popup_helpers")
 local M = {}
 
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @param relative_winnr integer
 --- @param relative_win_first_line integer
 --- @return fzfx.NvimFloatWinOpts
@@ -46,7 +46,7 @@ M._make_cursor_opts = function(
 end
 
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @param relative_winnr integer
 --- @param relative_win_first_line integer
 --- @return fzfx.NvimFloatWinOpts
@@ -86,7 +86,7 @@ M._make_center_opts = function(
 end
 
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @param relative_winnr integer
 --- @param relative_win_first_line integer
 --- @return fzfx.NvimFloatWinOpts
@@ -119,13 +119,13 @@ end
 --- @field _saved_current_winnr integer
 --- @field _saved_current_win_first_line integer
 --- @field _saved_win_opts fzfx.WindowOpts
---- @field _saved_buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @field _saved_buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @field _resizing boolean
 local FzfPopupWindow = {}
 
 --- @package
 --- @param win_opts fzfx.WindowOpts
---- @param buffer_previewer_opts fzfx.BufferFilePreviewerOpts
+--- @param buffer_previewer_opts fzfx.BufferPreviewerOpts
 --- @return fzfx.FzfPopupWindow
 function FzfPopupWindow:new(win_opts, buffer_previewer_opts)
   local current_winnr = vim.api.nvim_get_current_win()

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -21,23 +21,15 @@ local ProviderTypeEnum = {
   FUNCTIONAL_COMMAND_STRING = "FUNCTIONAL_COMMAND_STRING",
   FUNCTIONAL_COMMAND_ARRAY = "FUNCTIONAL_COMMAND_ARRAY",
   DIRECT = "DIRECT",
-
-  -- PLAIN = "plain",
-  -- PLAIN_LIST = "plain_list",
-  -- COMMAND = "command",
-  -- COMMAND_LIST = "command_list",
-  -- LIST = "list",
 }
 --
 -- ========== Provider Decorator ==========
 --
--- Note: In `fzfx._FunctionProviderDecorator`, the 1st parameter `line` is the raw generated line from providers.
---- @alias fzfx._FunctionProviderDecorator fun(line:string?):string?
+--- @alias fzfx._FunctionalProviderDecorator fun(line:string?):string?
 --- @alias fzfx.ProviderDecorator {module:string,rtp:string?}
 --
 -- ========== Previewer ==========
 --
--- Note: The 1st parameter 'line' is the current selected line in (the left side of) the fzf binary.
 --- @alias fzfx.CommandPreviewer fun(line:string?,context:fzfx.PipelineContext?):string|string[]|nil
 --- @alias fzfx.ListPreviewer fun(line:string?,context:fzfx.PipelineContext?):string[]?
 --- @alias fzfx.BufferFilePreviewerResult {filename:string,lineno:integer?,column:integer?}

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -30,22 +30,23 @@ local ProviderTypeEnum = {
 --
 -- ========== Previewer ==========
 --
---- @alias fzfx.CommandPreviewer fun(line:string?,context:fzfx.PipelineContext?):string|string[]|nil
---- @alias fzfx.ListPreviewer fun(line:string?,context:fzfx.PipelineContext?):string[]?
---- @alias fzfx.BufferFilePreviewerResult {filename:string,lineno:integer?,column:integer?}
---- @alias fzfx.BufferFilePreviewer fun(line:string?,context:fzfx.PipelineContext?):fzfx.BufferFilePreviewerResult?
---- @alias fzfx.Previewer fzfx.CommandPreviewer|fzfx.ListPreviewer|fzfx.BufferFilePreviewer
+--- @alias fzfx.FunctionalCommandStringPreviewer fun(line:string?,context:fzfx.PipelineContext?):string?
+--- @alias fzfx.FunctionalCommandArrayPreviewer fun(line:string?,context:fzfx.PipelineContext?):string[]?
+--- @alias fzfx.BufferPreviewerResult  {filename:string,lineno:integer?,column:integer?}
+--- @alias fzfx.BufferPreviewer    fun(line:string?,context:fzfx.PipelineContext?):fzfx.BufferPreviewerResult ?
+--- @alias fzfx.Previewer fzfx.FunctionalCommandStringPreviewer|fzfx.FunctionalCommandArrayPreviewer|fzfx.BufferPreviewer
 ---
---- @alias fzfx.PreviewerType "command"|"command_list"|"list"|"buffer_file"
+--- @alias fzfx.PreviewerType "FUNCTIONAL_COMMAND_STRING"|"FUNCTIONAL_COMMAND_ARRAY"|"BUFFER"
 --- @enum fzfx.PreviewerTypeEnum
 local PreviewerTypeEnum = {
-  -- For fzfx.CommandPreviewer
-  COMMAND = "command",
-  COMMAND_LIST = "command_list",
-  -- For fzfx.ListPreviewer
-  LIST = "list",
-  -- For fzfx.BufferFilePreviewer
-  BUFFER_FILE = "buffer_file",
+  -- COMMAND = "command",
+  -- COMMAND_LIST = "command_list",
+  -- LIST = "list",
+  -- BUFFER_FILE = "buffer_file",
+
+  FUNCTIONAL_COMMAND_STRING = "FUNCTIONAL_COMMAND_STRING",
+  FUNCTIONAL_COMMAND_ARRAY = "FUNCTIONAL_COMMAND_ARRAY",
+  BUFFER = "BUFFER",
 }
 --
 -- ========== Previewer Label ==========
@@ -181,7 +182,7 @@ end
 --- @param previewer_config fzfx.PreviewerConfig
 --- @return fzfx.PreviewerType
 local function get_previewer_type_or_default(previewer_config)
-  return previewer_config.previewer_type or PreviewerTypeEnum.COMMAND
+  return previewer_config.previewer_type or PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING
 end
 
 -- Get previewer label type or default.

--- a/spec/detail/general_spec.lua
+++ b/spec/detail/general_spec.lua
@@ -315,7 +315,7 @@ describe("detail.general", function()
           previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
         },
       }, FZFPORTFILE)
-      assert_eq(ps:preview("hello", {}), "command")
+      assert_eq(ps:preview("hello", {}), PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
       if not github_actions then
         local meta1 = fileio.readfile(general._previewer_metafile(), { trim = true })
         local result1 = fileio.readfile(general._previewer_resultfile(), { trim = true })
@@ -328,7 +328,7 @@ describe("detail.general", function()
         assert_eq(result1, "ls -lh")
       end
       ps:switch("p2")
-      assert_eq(ps:preview("world", {}), "command_list")
+      assert_eq(ps:preview("world", {}), PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY)
       if not github_actions then
         local meta2 = fileio.readfile(general._previewer_metafile(), { trim = true })
         local result2 = fileio.readfile(general._previewer_resultfile(), { trim = true })

--- a/spec/detail/general_spec.lua
+++ b/spec/detail/general_spec.lua
@@ -21,6 +21,7 @@ describe("detail.general", function()
 
   local schema = require("fzfx.schema")
   local ProviderTypeEnum = schema.ProviderTypeEnum
+  local PreviewerTypeEnum = schema.PreviewerTypeEnum
 
   local config = require("fzfx.config")
   require("fzfx").setup({
@@ -264,11 +265,11 @@ describe("detail.general", function()
           previewer = function()
             return { "ls", "-lha", "~" }
           end,
-          previewer_type = "command_list",
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
         },
       }, FZFPORTFILE)
       print(string.format("GITHUB_ACTIONS:%s\n", os.getenv("GITHUB_ACTIONS")))
-      assert_eq(ps:preview("hello", {}), "command")
+      assert_eq(ps:preview("hello", {}), PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
       if not github_actions then
         local meta1 = fileio.readfile(general._previewer_metafile(), { trim = true })
         local result1 = fileio.readfile(general._previewer_resultfile(), { trim = true })
@@ -276,12 +277,12 @@ describe("detail.general", function()
         local metajson1 = vim.json.decode(meta1) --[[@as table]]
         assert_eq(type(metajson1), "table")
         assert_eq(metajson1.pipeline, "p1")
-        assert_eq(metajson1.previewer_type, "command")
+        assert_eq(metajson1.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
         print(string.format("resultfile1:%s\n", result1))
         assert_eq(result1, "ls -lh")
       end
       ps:switch("p2")
-      assert_eq(ps:preview("world", {}), "command_list")
+      assert_eq(ps:preview("world", {}), PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY)
       if not github_actions then
         local meta2 = fileio.readfile(general._previewer_metafile(), { trim = true })
         local result2 = fileio.readfile(general._previewer_resultfile(), { trim = true })
@@ -289,7 +290,7 @@ describe("detail.general", function()
         local metajson2 = vim.json.decode(meta2) --[[@as table]]
         assert_eq(type(metajson2), "table")
         assert_eq(metajson2.pipeline, "p2")
-        assert_eq(metajson2.previewer_type, "command_list")
+        assert_eq(metajson2.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY)
         print(string.format("resultfile2:%s\n", result2))
         local resultjson2 = vim.json.decode(result2) --[[@as table]]
         assert_eq(type(resultjson2), "table")
@@ -305,13 +306,13 @@ describe("detail.general", function()
           previewer = function()
             return "ls -lh"
           end,
-          previewer_type = schema.PreviewerTypeEnum.COMMAND,
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING,
         },
         p2 = {
           previewer = function()
             return { "ls", "-lha", "~" }
           end,
-          previewer_type = schema.PreviewerTypeEnum.COMMAND_LIST,
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
         },
       }, FZFPORTFILE)
       assert_eq(ps:preview("hello", {}), "command")
@@ -322,7 +323,7 @@ describe("detail.general", function()
         local metajson1 = vim.json.decode(meta1) --[[@as table]]
         assert_eq(type(metajson1), "table")
         assert_eq(metajson1.pipeline, "p1")
-        assert_eq(metajson1.previewer_type, "command")
+        assert_eq(metajson1.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
         print(string.format("resultfile:%s\n", result1))
         assert_eq(result1, "ls -lh")
       end
@@ -335,7 +336,7 @@ describe("detail.general", function()
         local metajson2 = vim.json.decode(meta2) --[[@as table]]
         assert_eq(type(metajson2), "table")
         assert_eq(metajson2.pipeline, "p2")
-        assert_eq(metajson2.previewer_type, "command_list")
+        assert_eq(metajson2.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY)
         print(string.format("resultfile:%s\n", result2))
         local resultjson2 = vim.json.decode(result2) --[[@as table]]
         assert_eq(type(resultjson2), "table")
@@ -360,7 +361,10 @@ describe("detail.general", function()
       assert_false(tbl.tbl_empty(ps.previewer_configs))
       assert_eq(type(ps.previewer_configs.default.previewer), "function")
       assert_eq(ps.previewer_configs.default.previewer(), "ls -1")
-      assert_eq(ps.previewer_configs.default.previewer_type, "command")
+      assert_eq(
+        ps.previewer_configs.default.previewer_type,
+        PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING
+      )
       assert_eq(ps.fzf_port_reader.filename, FZFPORTFILE)
       assert_eq(ps:switch("default"), nil)
     end)
@@ -383,14 +387,14 @@ describe("detail.general", function()
       assert_false(tbl.tbl_empty(ps.previewer_configs))
       assert_eq(type(ps.previewer_configs.p1.previewer), "function")
       assert_eq(ps.previewer_configs.p1.previewer(), "p1")
-      assert_eq(ps.previewer_configs.p1.previewer_type, "command")
+      assert_eq(ps.previewer_configs.p1.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
       assert_eq(ps:switch("p1"), nil)
 
       assert_eq(type(ps.previewer_configs), "table")
       assert_false(tbl.tbl_empty(ps.previewer_configs))
       assert_eq(type(ps.previewer_configs.p2.previewer), "function")
       assert_eq(ps.previewer_configs.p2.previewer(), "p2")
-      assert_eq(ps.previewer_configs.p2.previewer_type, "command")
+      assert_eq(ps.previewer_configs.p2.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
       assert_eq(ps:switch("p2"), nil)
     end)
   end)
@@ -409,7 +413,7 @@ describe("detail.general", function()
           previewer = function()
             return { "ls", "-lha", "~" }
           end,
-          previewer_type = "command_list",
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
         },
       }, FZFPORTFILE)
       print(string.format("GITHUB_ACTIONS:%s\n", os.getenv("GITHUB_ACTIONS")))
@@ -433,7 +437,7 @@ describe("detail.general", function()
           previewer = function()
             return { "ls", "-lha", "~" }
           end,
-          previewer_type = "command_list",
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
           previewer_label = function(line)
             return nil
           end,
@@ -460,7 +464,7 @@ describe("detail.general", function()
           previewer = function()
             return { "ls", "-lha", "~" }
           end,
-          previewer_type = "command_list",
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
         },
       }, FZFPORTFILE)
       local actual = ps:current()
@@ -591,27 +595,18 @@ describe("detail.general", function()
     it("makes without icon", function()
       local actual1 = general.make_previewer_meta_opts("test1", {
         previewer = function() end,
-        previewer_type = "command",
+        previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING,
       })
       assert_eq(type(actual1), "table")
       assert_eq(actual1.pipeline, "test1")
-      assert_eq(actual1.previewer_type, "command")
+      assert_eq(actual1.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING)
       local actual2 = general.make_previewer_meta_opts("test2", {
         previewer = function() end,
-        previewer_type = "command_list",
+        previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
       })
       assert_eq(type(actual2), "table")
       assert_eq(actual2.pipeline, "test2")
-      assert_eq(actual2.previewer_type, "command_list")
-    end)
-    it("makes with icon", function()
-      local actual = general.make_previewer_meta_opts("test3", {
-        previewer = function() end,
-        previewer_type = "list",
-      })
-      assert_eq(type(actual), "table")
-      assert_eq(actual.pipeline, "test3")
-      assert_eq(actual.previewer_type, "list")
+      assert_eq(actual2.previewer_type, PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY)
     end)
   end)
   describe("[_make_user_command]", function()
@@ -720,16 +715,4 @@ describe("detail.general", function()
       assert_eq(actual12.fzf_border_opts, "double")
     end)
   end)
-  -- describe("[decode_fzf_status_current_text]", function()
-  --   it("test", function()
-  --     local input1 =
-  --       '{"reading":false,"progress":100,"query":"f","position":0,"sort":true,"totalCount":148,"matchCount":100,"current":{"index":92,"text":" lua/fzfx.lua"},"matches":[{"index":93,"text":" lua/config.lua"}]}'
-  --     local actual1 = general.decode_fzf_status_current_text(input1)
-  --     assert_eq(actual1, " lua/fzfx.lua")
-  --     local input2 =
-  --       [[{"reading":false,"progress":100,"query":"f","position":0,"sort":true,"totalCount":148,"matchCount":100,"current":{"index":92,"text":" \"lua/fzfx.lua"},"matches":[{"index":93,"text":" lua/config.lua"}]}]]
-  --     local actual2 = general.decode_fzf_status_current_text(input2)
-  --     assert_eq(actual2, [[ \"lua/fzfx.lua]])
-  --   end)
-  -- end)
 end)

--- a/spec/schema_spec.lua
+++ b/spec/schema_spec.lua
@@ -11,6 +11,8 @@ describe("schema", function()
 
   local schema = require("fzfx.schema")
   local ProviderTypeEnum = schema.ProviderTypeEnum
+  local PreviewerTypeEnum = schema.PreviewerTypeEnum
+  local PreviewerLabelTypeEnum = schema.PreviewerLabelTypeEnum
 
   describe("[ProviderConfig]", function()
     it("makes a plain provider", function()
@@ -245,7 +247,7 @@ describe("schema", function()
             return "ls"
           end,
         }),
-        "command"
+        PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING
       )
       assert_eq(
         schema.get_previewer_type_or_default({
@@ -254,7 +256,7 @@ describe("schema", function()
             return { "ls" }
           end,
         }),
-        "command"
+        PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING
       )
     end)
     it("use existed", function()
@@ -322,7 +324,7 @@ describe("schema", function()
         schema.get_previewer_label_type_or_default({
           previewer_label_type = schema.PreviewerLabelTypeEnum.PLAIN,
         }),
-        "plain"
+        PreviewerLabelTypeEnum.PLAIN
       )
     end)
   end)


### PR DESCRIPTION
Relate #751 

# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [ ] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [x] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxCommandHistory
  - Press `CTRL-J`/`CTRL-K` to move down/up.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim historical command.
- [x] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [x] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
