### PR TITLE
refactor: remove "PreviewerLabelTypeEnum"

### DIFF
--- a/docs/ApiReferences/fzfx_helper.md
+++ b/docs/ApiReferences/fzfx_helper.md
@@ -200,13 +200,31 @@ There're two kinds of previewer implementations: fzf's builtin preview window, a
 
 To enable fzf's builtin preview window, set feature flag: `vim.g.fzfx_disable_buffer_previewer=1`. To enable Neovim's buffer, unset it.
 
-The fzf's builtin preview window is natively supported by the fzf command, it has the best performance. But we have to use `bat` or `cat` to preview file contents, which doesn't support a compatible colorscheme with the nvim editor.
+The fzf's builtin preview window is natively supported by the fzf command via `--preview-window` option, it has the best performance. But we have to use `bat` or `cat` when previewing file contents, which doesn't support a compatible colorscheme with the nvim editor.
 
-On the other hand, the Neovim buffer natively uses the nvim editor's colorscheme. But there's a huge gap between it and the fzf command, thus brings more development effort and architectural fragmentation, also limits some flexibility of the engine. But anyway, people love their colorschemes.
+On the other hand, the Neovim buffer natively supports colorscheme, and it's only needed when previewing the files. Since there's a huge gap between it and the fzf command, thus brings more development effort and architectural fragmentation, also limits some flexibility of the engine. But anyway, people love their colorschemes.
 
 ### [`fzf_preview_find`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L114)/[`buffer_preview_find`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L122)
 
-`fzf_preview_find` generates
+They preview the current line's text content for `fd`/`find` query results. `fzf_preview_find` works with fzf builtin preview window, `buffer_preview_find` works with Neovim buffer.
+
+### [`fzf_preview_grep`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L177)/[`buffer_preview_grep`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L185)
+
+They preview the current line's text content for `rg`/`grep`/`git grep` query results, `fzf_preview_grep` works with fzf builtin preview window, `buffer_preview_grep` works with Neovim buffer.
+
+### [`fzf_preview_grep_no_filename`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L198)/[`buffer_preview_grep_no_filename`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L215)
+
+They preview the current line's text content for `rg`/`grep`/`git grep` no filename query results (with `-I` option), `fzf_preview_grep_no_filename` works with fzf builtin preview window, `buffer_preview_grep_no_filename` works with Neovim buffer.
+
+### [`fzf_preview_git_commit`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L235)
+
+It previews the current line's git commit changes for `git log`/`git blame` query results.
+
+> There's no Neovim buffer previewer implementation.
+
+### [`fzf_preview_git_status`](https://github.com/linrongbin16/fzfx.nvim/blob/f99404575d7af6a54a6274a3edb9fc9d77905ed5/lua/fzfx/helper/previewers.lua?plain=1#L257)
+
+It previews the current line's git status (changed files) for `git status --short` query results.
 
 ## `previewer_labels`
 

--- a/docs/ApiReferences/fzfx_lib.md
+++ b/docs/ApiReferences/fzfx_lib.md
@@ -1,3 +1,89 @@
 # [`fzfx.lib`](https://github.com/linrongbin16/fzfx.nvim/tree/main/lua/fzfx/lib)
 
 The `fzfx.lib` package contains all fundamental infrastructures.
+
+## [`fzfx.lib.bufs`](https://github.com/linrongbin16/fzfx.nvim/blob/main/lua/fzfx/lib/bufs.lua)
+
+Neovim buffer related APIs.
+
+- [`buf_is_valid`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/bufs.lua?plain=1#L5): Whether the buffer (`bufnr`) is a valid and visible buffer for user
+
+## [`fzfx.lib.commands`](https://github.com/linrongbin16/fzfx.nvim/blob/main/lua/fzfx/lib/commands.lua)
+
+Executable shell command utilities.
+
+- [`@class fzfx.CommandResult`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/commands.lua?plain=1#L14): The executed results of a shell command, i.e. outputs, errors, exit code, etc.
+  - Fields
+    - `@field stdout string[]|nil`: The `stdout` output in lines.
+    - `@field stderr string[]|nil`: The `stderr` output in lines.
+    - `@field code integer`: The exit code.
+    - `@field signal integer`: The signal number.
+  - Methods
+    - `function CommandResult:new(stdout:string[]|nil, stderr:string[]|nil, code:integer, signal:integer):CommandResult`: Make a new command result.
+    - `function CommandResult:failed():boolean`: Whether the shell command is failed, it's `true` when the exit code is not `0`, or there's error messages printed in `stderr`. Otherwise it's `false`.
+- [`@class fzfx.Command`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/commands.lua?plain=1#L50): The executable shell command.
+  - Fields
+    - `@field source string[]`: The shell command splitted by whitespaces.
+    - `@field result fzfx.CommandResult?`: The executed result.
+  - Methods
+    - `function Command:run(source):fzfx.Command`: Make a new command and run it synchronously. Note: this method will block the editor.
+    - `function Command:failed():boolean`: Whether the shell command is failed. It's a short cut for `Command.result:failed()`.
+- [`@class fzfx.GitRootCommand`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/commands.lua?plain=1#L98): Run git command to find out the git repository's root directory. This is super helpful to detect whether current working directory is in a git repository.
+  - Methods
+    - `function GitRootCommand:run():fzfx.GitRootCommand`: Run `git rev-parse --show-toplevel` and make a command instance.
+    - `function GitRootCommand:failed():boolean`: Whether this command is failed.
+    - `function GitRootCommand:output():string?`: Get the output of this command.
+- [`@class fzfx.GitBranchesCommand`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/commands.lua?plain=1#L134): Run git command to find out it's local/remote branches.
+  - Methods
+    - `function GitBranchesCommand:run(remotes:boolean?):fzfx.GitBranchesCommand`: Run `git branch` (for local branches) or `git branches --remotes` (for remote branches) and make a command instance.
+    - `function GitBranchesCommand:failed():boolean`: Whether this command is failed.
+    - `function GitBranchesCommand:output():string[]|nil`: Get the output lines of this command. Each line is a git branch.
+- [`@class fzfx.GitCurrentBranchCommand`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/commands.lua?plain=1#L171): Run git command to find out current branch name.
+  - Methods
+    - `function GitCurrentBranchCommand:run():fzfx.GitCurrentBranchCommand`: Run `git rev-parse --abbrev-ref HEAD` and make a command instance.
+    - `function GitCurrentBranchCommand:failed():boolean`: Whether this command is failed.
+    - `function GitCurrentBranchCommand:output():string?`: Get the output of this command. The output is the current branch name.
+- [`@class fzfx.GitRemotesCommand`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/commands.lua?plain=1#L208): Run git command to find out the configured remotes.
+  - Methods
+    - `function GitRemotesCommand:run():fzfx.GitRemotesCommand`: Run `git remote` and make a command instance.
+    - `function GitRemotesCommand:failed():boolean`: Whether this command is failed.
+    - `function GitRemotesCommand:output():string[]|nil`: Get the output lines of this command. Each line is a configured remote, for example `origin`, `upstream`, etc.
+
+## [`fzfx.lib.constants`](https://github.com/linrongbin16/fzfx.nvim/blob/main/lua/fzfx/lib/constants.lua)
+
+All the constant variables, the value never change once the plugin is been setup.
+
+## [`fzfx.lib.env`](https://github.com/linrongbin16/fzfx.nvim/blob/main/lua/fzfx/lib/env.lua)
+
+Environment variable utilities.
+
+- [`debug_enabled`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/env.lua?plain=1#L4): Whether debug mode is enabled or not.
+- [`icon_enabled`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/env.lua?plain=1#L9): Whether icon is enabled or not.
+
+## [`fzfx.lib.log`](https://github.com/linrongbin16/fzfx.nvim/blob/main/lua/fzfx/lib/log.lua)
+
+Logging APIs, helpful for debugging and development.
+
+- [`LogLevels`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L5): Log levels .
+  - Enums: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `OFF`, they're compatible with the [`vim.log.levels`](https://neovim.io/doc/user/lua.html#log_levels), but in this plugin we don't use `TRACE` and `OFF`.
+- [`echo`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L20): Print logs as Neovim's message. Note: This API doesn't require this plugin setup, thus you can use it even before this plugin setup.
+- [`setup`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L56): Setup the logging system. Note: This API is been invoked automatically when this plugin setup.
+  - Function Signature: `function(opts:fzfx.Options?):nil`. The `opts` parameter is an optional lua table contains below fields:
+    - `level`: The `LogLevels`. By default it's `INFO` when debug mode is off, `DEBUG` when debug mode is on.
+    - `console_log`: Whether prints logs to Neovim's message. By default it's `true`, all the hints and error messages are printed as Neovim's message.
+    - `file_log`: Whether writes logs to local logging files. By default it's `false` when debug mode is off, `true` when debug mode is on.
+- [`debug`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L68)/[`info`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L82)/[`warn`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L96)/[`err`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L110): Log the message.
+- [`throw`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L124): Logs the message and throw an error to Neovim, equivalent to Neovim's `error` API.
+- [`ensure`](https://github.com/linrongbin16/fzfx.nvim/blob/6cde87c522460d4da2a9c657ce4615ce619cca45/lua/fzfx/lib/log.lua?plain=1#L140): Assert if the `condition` is true. When it's `false`, logs the message and throw an error to Neovim, equivalent to Neovim's `assert` API.
+
+## [`fzfx.lib.lsp`](https://github.com/linrongbin16/fzfx.nvim/blob/e136dc76a691a5c6a79d25a8f87d677d41952ea1/lua/fzfx/lib/lsp.lua)
+
+LSP compatible APIs, working across different Neovim versions.
+
+- [`get_clients`](https://github.com/linrongbin16/fzfx.nvim/blob/e136dc76a691a5c6a79d25a8f87d677d41952ea1/lua/fzfx/lib/lsp.lua#L6): Get LSP clients. For Neovim &ge; 0.10 use `vim.lsp.get_clients`, for Neovim &lt; 0.10 use `vim.lsp.get_active_clients`.
+
+## [`fzfx.lib.shells`](https://github.com/linrongbin16/fzfx.nvim/blob/main/lua/fzfx/lib/shells.lua)
+
+Shell related APIs, working on cross-platform: Windows & \*NIX.
+
+- [`shellescape`](https://github.com/linrongbin16/fzfx.nvim/blob/e136dc76a691a5c6a79d25a8f87d677d41952ea1/lua/fzfx/lib/shells.lua#L8): Escape shell parameters, on \*NIX it's simply wrapped around with single quotes `'`, on Windows it's wrapped around with double quotes `"`.

--- a/docs/Demo.md
+++ b/docs/Demo.md
@@ -1,0 +1,61 @@
+# Demo
+
+## Files & Buffers
+
+- `FzfxFiles`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/1b8ce1bc-3b26-4fc2-8e0c-e27d28e46385" type="video/mp4">
+  </video>
+
+## Grep
+
+- `FzfxLiveGrep`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/47b03150-14e3-479a-b1af-1b2995659403" type="video/mp4">
+  </video>
+
+## Lsp & Diagnostics
+
+- `FzfxLspDefinitions`/`FzfxLspTypeDefinitions`/`FzfxLspImplementations`/`FzfxLspReferences`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/3933f5f3-f45b-4772-a8e1-6cf8e97ca5be" type="video/mp4">
+  </video>
+
+## Git
+
+- `FzfxGCommits`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/5c33eef8-382e-4325-9d56-9bcf8f6bac05" type="video/mp4">
+  </video>
+
+- `FzfxGBlame`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/2e6343a5-7a5e-4683-b57b-6d6ef4173e0e" type="video/mp4">
+  </video>
+
+## Vim
+
+- `FzfxCommands`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/ed739170-3aba-4e44-9b4b-bb5263694cf8" type="video/mp4">
+  </video>
+
+- `FzfxKeyMaps`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/1cf345a4-1d14-43cb-a387-047b811ec176" type="video/mp4">
+  </video>
+
+## Misc
+
+- `FzfxFileExplorer`
+
+  <video width="80%" controls>
+    <source src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/65108eb2-632a-47c5-9f16-9ddb34f87353" type="video/mp4">
+  </video>

--- a/docs/GenericSchema.md
+++ b/docs/GenericSchema.md
@@ -95,11 +95,7 @@ We have several types of previewers:
 
 Sometimes we want to give a name to the preview window, for example we want to set the title of the preview window to the file name when we preview the file content. Here comes the **previewer label**, it's a lua function that runs with a line as parameter, and returns the label string.
 
-We have several types of previewers:
-
-- Plain label: A static lua string value which is the label for the preview window.
-- Function label: A lua function to run and returns the string value for the preview window.
-  > Note: The lua function will be invoke on every keystroke to archive the real-time updates.
+> Note: The lua function will be invoke on every keystroke to archive the real-time updates.
 
 ## Command Feed
 

--- a/docs/How.md
+++ b/docs/How.md
@@ -1,0 +1,30 @@
+# How?
+
+After deep dive into [fzf](https://github.com/junegunn/fzf) and [fzf.vim](https://github.com/junegunn/fzf.vim), I found fzf-based plugin is actually trying to start a fzf command inside a terminal and a float window of (Neo)VIM.
+
+The architecture (simply) looks like:
+
+<img width="40%" alt="image" src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/bfc1740f-5d2e-4afb-af72-2f5b224b5c29">
+
+The key of this kind of plugin is how to interact with the terminal/float-window and the fzf command.
+
+There're two technologies come to me:
+
+## Use `nvim` as a lua script interpreter
+
+It has several benefits:
+
+1. It avoid to run the raw shell command (for example `rg --column -n --no-heading -S -- {q}`), thus avoid the shell escaping characters.
+2. It avoid to develop the shell scripts or Windows Batch/PowerShell scripts, which makes the project development and maintenance easier.
+
+## Setup RPC connections
+
+When the plugin initialize, it starts a RPC server on `127.0.0.1`. When start searching, the `nvim` lua interpreter is been launched by fzf command, as a query command and a child process, it connects to the RPC server as a RPC client. This allows it works as if it's still running inside the Neovim editor we're using.
+
+For example, when we start the `FzfxBuffers` command, the `nvim` lua interpreter connects to Neovim editor to ask for the opened buffers list via a RPC call. The Neovim editor handles the query logic and send the query results to the lua interpreter, and the interpreter renders them and prints them to `stdout`, and we can see the output in fzf, i.e. the left side of popup window.
+
+?> Special thanks to [@ibhagwan](https://github.com/ibhagwan) and his [fzf-lua](https://github.com/ibhagwan/fzf-lua), I learned this from him.
+
+So the architecture becomes:
+
+<img width="100%" alt="image" src="https://github.com/linrongbin16/fzfx.nvim/assets/6496887/2f199c28-1833-47cc-9f94-d39499d21ce3">

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,16 @@
-<!-- markdownlint-disable MD001 MD013 MD034 MD033 MD051 MD026 -->
+<!-- markdownlint-disable -->
 
 # Welcome to fzfx.nvim's Documentation!
 
+- Design & Technologies
+  - [Why?](/Why.md)
+  - [How?](/How.md)
+  - [A Generic Schema for Creating FZF Command](/GenericSchema.md)
+- Features
+  - [Demo](/Demo.md)
 - [Known Issues](/KnownIssues.md)
-- [A Generic Schema for Creating FZF Command](/GenericSchema.md)
 - API References
   - [`fzfx.cfg`](/ApiReferences/fzfx_cfg.md)
   - [`fzfx.helper`](/ApiReferences/fzfx_helper.md)
+  - [`fzfx.lib`](/ApiReferences/fzfx_lib.md)
+- [Sponsor](/Sponsor.md)

--- a/docs/Sponsor.md
+++ b/docs/Sponsor.md
@@ -1,0 +1,16 @@
+# Sponsor
+
+Please sponsor me by:
+
+## GitHub Sponsor
+
+<https://github.com/sponsors/linrongbin16>
+
+## Alipay
+
+<img width="40%" alt="image" src="https://github.com/linrongbin16/lin.nvim/assets/6496887/5f8d1153-870d-422a-98cc-9a8ecc274591">
+
+## Wechat Pay
+
+<img width="40%" alt="image" src="https://github.com/linrongbin16/lin.nvim/assets/6496887/e901db4f-654d-4c29-af94-0d38e9b47191">
+

--- a/docs/Why.md
+++ b/docs/Why.md
@@ -1,0 +1,25 @@
+# Why?
+
+There're already lots of great fuzzy find plugins in (Neo)VIM community:
+
+- [fzf.vim](https://github.com/junegunn/fzf.vim)
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua)
+- [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
+
+Why build another one?
+
+There're no big stories:
+
+- I use fzf for many years, and I collect some really great out-of-box configurations to make fzf working with Vim. I believe it can help others as well.
+- `fzf.vim` doesn't has icon and real-time parsing `rg` options.
+- `fzf-lua` doesn't support Windows (Note: It supports Windows now, not at the time I wrote this). I had tried to add support for Windows, but failed.
+- `telescope` has the best features, flexibilities and communities. But its internal sorter is based on [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) and quite low performant, even with [telescope-fzf-native](https://github.com/nvim-telescope/telescope-fzf-native.nvim) extension. I cannot accept. I always miss fzf's performance and smooth when I'm using telescope.
+
+I had done some investigations, and found that it's possible to:
+
+- Use `nvim` as a lua script interpreter, instead of writing shell scripts or Windows Batch/PowerShell scripts. Lua is a much more high-level language that has data types, and syntax grammars, that can help implementing more complicated and dynamical logic when working with fzf. And it's even possible to use the full Neovim's builtin lua library, i.e. the `vim.api`, `vim.lsp`, `vim.fn`, etc. That makes the lua script more like a Neovim-based VM and runtime environment.
+- Use `nvim` the lua script interpreter as a RPC client, and the Neovim editor (the one you're editing files) as a RPC server . Thus we could send almost every data to the RPC client, and let it handle almost all kinds of logic when generating querying results for fzf.
+
+  ?> Special thanks to [@ibhagwan](https://github.com/ibhagwan) and his [fzf-lua](https://github.com/ibhagwan/fzf-lua), I learned this from him.
+
+So I decide to have a try.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,9 +1,15 @@
 <!-- markdownlint-disable MD001 MD013 MD034 MD033 MD051 MD041 -->
 
 - [Home](/)
+- Design & Technologies
+  - [Why?](/Why.md)
+  - [How?](/How.md)
+  - [A Generic Schema for Creating FZF Command](/GenericSchema.md)
+- Features
+  - [Demo](/Demo.md)
 - [Known Issues](/KnownIssues.md)
-- [A Generic Schema for Creating FZF Command](/GenericSchema.md)
 - API References
   - [`fzfx.cfg`](/ApiReferences/fzfx_cfg.md)
   - [`fzfx.helper`](/ApiReferences/fzfx_helper.md)
   - [`fzfx.lib`](/ApiReferences/fzfx_lib.md)
+- [Sponsor](/Sponsor.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,19 +29,7 @@
         plugins: [
           function (hook, vm) {
             hook.beforeEach(function (html) {
-              if (/githubusercontent\.com/.test(vm.route.file)) {
-                url = vm.route.file
-                  .replace("raw.githubusercontent.com", "github.com")
-                  .replace(/\/main/, "/blob/main");
-              } else {
-                url =
-                  "https://github.com/linrongbin16/fzfx.nvim/blob/main/docs/" +
-                  vm.route.file;
-              }
-              var editHtml = "[:memo: Edit Document](" + url + ")\n";
-
               return (
-                editHtml +
                 html +
                 "\n\n----\n\n" +
                 '<a href="https://docsify.js.org" target="_blank" style="color: inherit; font-weight: normal; text-decoration: none;">Powered by <span style="color:#42b983">docsify</span>.</a>'

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -46,17 +46,7 @@ local PreviewerTypeEnum = {
 --
 -- ========== Previewer Label ==========
 --
---- @alias fzfx.PlainPreviewerLabel string
--- Note: The 1st parameter 'line' is the current selected line in (the left side of) the fzf binary.
---- @alias fzfx.FunctionPreviewerLabel fun(line:string?,context:fzfx.PipelineContext?):string?
---- @alias fzfx.PreviewerLabel fzfx.PlainPreviewerLabel|fzfx.FunctionPreviewerLabel
----
---- @alias fzfx.PreviewerLabelType "plain"|"function"
---- @enum PreviewerLabelTypeEnum
-local PreviewerLabelTypeEnum = {
-  PLAIN = "plain",
-  FUNCTION = "function",
-}
+--- @alias fzfx.PreviewerLabel fun(line:string?,context:fzfx.PipelineContext?):string?
 --
 -- ========== Command Feed ==========
 --
@@ -99,8 +89,7 @@ local CommandFeedEnum = {
 -- 1. The "previewer" option is the **previewer** we mentioned above, that previews the content of the current line, i.e. generates lines (in the right side) of fzf binary.
 -- 2. The "previewer_type" option by default "command". Also see "get_previewer_type_or_default" function in below.
 -- 3. The "previewer_label" option is optional.
--- 4. The "previewer_label_type" option by default is "plain" or "function". Also see "get_previewer_label_type_or_default" function in below.
---- @alias fzfx.PreviewerConfig {previewer:fzfx.Previewer,previewer_type:fzfx.PreviewerType?,previewer_label:fzfx.PreviewerLabel?,previewer_label_type:fzfx.PreviewerLabelType?}
+--- @alias fzfx.PreviewerConfig {previewer:fzfx.Previewer,previewer_type:fzfx.PreviewerType?,previewer_label:fzfx.PreviewerLabel?}
 ---
 --
 -- Note: A pipeline name is the same with the provider name.
@@ -180,21 +169,9 @@ local function get_previewer_type_or_default(previewer_config)
   return previewer_config.previewer_type or PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING
 end
 
--- Get previewer label type or default.
---- @param previewer_config fzfx.PreviewerConfig
---- @return fzfx.PreviewerLabelType
-local function get_previewer_label_type_or_default(previewer_config)
-  return previewer_config.previewer_label_type
-    or (
-      type(previewer_config.previewer_label) == "function" and PreviewerLabelTypeEnum.FUNCTION
-      or PreviewerLabelTypeEnum.PLAIN
-    )
-end
-
 local M = {
   ProviderTypeEnum = ProviderTypeEnum,
   PreviewerTypeEnum = PreviewerTypeEnum,
-  PreviewerLabelTypeEnum = PreviewerLabelTypeEnum,
   CommandFeedEnum = CommandFeedEnum,
 
   is_variant_config = is_variant_config,
@@ -203,7 +180,6 @@ local M = {
 
   get_provider_type_or_default = get_provider_type_or_default,
   get_previewer_type_or_default = get_previewer_type_or_default,
-  get_previewer_label_type_or_default = get_previewer_label_type_or_default,
 }
 
 return M

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -33,17 +33,12 @@ local ProviderTypeEnum = {
 --- @alias fzfx.FunctionalCommandStringPreviewer fun(line:string?,context:fzfx.PipelineContext?):string?
 --- @alias fzfx.FunctionalCommandArrayPreviewer fun(line:string?,context:fzfx.PipelineContext?):string[]?
 --- @alias fzfx.BufferPreviewerResult  {filename:string,lineno:integer?,column:integer?}
---- @alias fzfx.BufferPreviewer    fun(line:string?,context:fzfx.PipelineContext?):fzfx.BufferPreviewerResult ?
+--- @alias fzfx.BufferPreviewer    fun(line:string?,context:fzfx.PipelineContext?):fzfx.BufferPreviewerResult?
 --- @alias fzfx.Previewer fzfx.FunctionalCommandStringPreviewer|fzfx.FunctionalCommandArrayPreviewer|fzfx.BufferPreviewer
 ---
 --- @alias fzfx.PreviewerType "FUNCTIONAL_COMMAND_STRING"|"FUNCTIONAL_COMMAND_ARRAY"|"BUFFER"
 --- @enum fzfx.PreviewerTypeEnum
 local PreviewerTypeEnum = {
-  -- COMMAND = "command",
-  -- COMMAND_LIST = "command_list",
-  -- LIST = "list",
-  -- BUFFER_FILE = "buffer_file",
-
   FUNCTIONAL_COMMAND_STRING = "FUNCTIONAL_COMMAND_STRING",
   FUNCTIONAL_COMMAND_ARRAY = "FUNCTIONAL_COMMAND_ARRAY",
   BUFFER = "BUFFER",

--- a/spec/schema_spec.lua
+++ b/spec/schema_spec.lua
@@ -12,7 +12,6 @@ describe("schema", function()
   local schema = require("fzfx.schema")
   local ProviderTypeEnum = schema.ProviderTypeEnum
   local PreviewerTypeEnum = schema.PreviewerTypeEnum
-  local PreviewerLabelTypeEnum = schema.PreviewerLabelTypeEnum
 
   describe("[ProviderConfig]", function()
     it("makes a plain provider", function()
@@ -223,14 +222,6 @@ describe("schema", function()
       )
       assert_eq(
         schema.get_provider_type_or_default({
-          key = "p3",
-          provider = "ls",
-          provider_type = "plain_list",
-        }),
-        "plain_list"
-      )
-      assert_eq(
-        schema.get_provider_type_or_default({
           key = "p4",
           provider = { "ls" },
           provider_type = ProviderTypeEnum.PLAIN_COMMAND_STRING,
@@ -265,66 +256,18 @@ describe("schema", function()
           previewer = function()
             return "ls"
           end,
-          previewer_type = "command",
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING,
         }),
-        "command"
+        PreviewerTypeEnum.FUNCTIONAL_COMMAND_STRING
       )
       assert_eq(
         schema.get_previewer_type_or_default({
           previewer = function()
             return { "ls" }
           end,
-          previewer_type = "command_list",
+          previewer_type = PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY,
         }),
-        "command_list"
-      )
-      assert_eq(
-        schema.get_previewer_type_or_default({
-          previewer = function()
-            return "ls"
-          end,
-          previewer_type = "command_list",
-        }),
-        "command_list"
-      )
-      assert_eq(
-        schema.get_previewer_type_or_default({
-          previewer = function()
-            return { "ls" }
-          end,
-          previewer_type = "command",
-        }),
-        "command"
-      )
-    end)
-  end)
-  describe("[get_previewer_label_type_or_default]", function()
-    it("default", function()
-      assert_eq(
-        schema.get_previewer_label_type_or_default({
-          previewer_label = function() end,
-        }),
-        "function"
-      )
-      assert_eq(
-        schema.get_previewer_label_type_or_default({
-          previewer_label = "Files Previewer",
-        }),
-        "plain"
-      )
-    end)
-    it("existed", function()
-      assert_eq(
-        schema.get_previewer_label_type_or_default({
-          previewer_label_type = schema.PreviewerLabelTypeEnum.FUNCTION,
-        }),
-        "function"
-      )
-      assert_eq(
-        schema.get_previewer_label_type_or_default({
-          previewer_label_type = schema.PreviewerLabelTypeEnum.PLAIN,
-        }),
-        PreviewerLabelTypeEnum.PLAIN
+        PreviewerTypeEnum.FUNCTIONAL_COMMAND_ARRAY
       )
     end)
   end)


### PR DESCRIPTION
Relate #751

# Regresion test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] FzfxFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `fd` and `find` works.
- [x] FzfxLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between restricted/unrestricted mode, and the lines count is consistent when press multiple times.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - Both `rg` and `grep` works.
- [ ] FzfxBufLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `-w` to match word only, use `-g *.lua` to search only lua files.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both `rg` and `grep` works.
- [x] FzfxBuffers
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-D` to delete buffers, and delete the `test/hello world.txt`, `test/goodbye world/goodbye.lua` buffers.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGFiles
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGLiveGrep
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxGStatus
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current folder mode.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
  - Both with/without `delta` works.
- [ ] FzfxGBranches
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-R`/`CTRL-O` to switch between local/remote branches.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to checkout branch.
- [ ] FzfxGCommits
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-A` to switch between git repo commits/current buffer commits.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxGBlame
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to copy commit hash.
  - Both with/without `delta` works.
- [ ] FzfxLspDiagnostics
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-W` to switch between workspace/current buffer diagnostics.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspDefinitions, FzfxLspTypeDefinitions, FzfxLspReferences, FzfxLspImplementations
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to definitions/references (this is the most 2 easiest use case when developing this lua plugin with lua_ls).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxLspIncomingCalls, FzfxLspOutgoingCalls
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Go to incoming/outgoing calls.
  - Press `ESC` to quit, `ENTER` to open file.
- [x] FzfxCommands
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-E`/`CTRL-A` to switch between user/ex/all vim commands.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim command.
- [ ] FzfxCommandHistory
  - Press `CTRL-J`/`CTRL-K` to move down/up.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim historical command.
- [ ] FzfxKeyMaps
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-O`/`CTRL-I`/`CTRL-A`/`CTRL-V` to switch between normal/insert/visual/all vim key mappings.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to feed vim keys.
- [ ] FzfxMarks
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file.
- [ ] FzfxFileExplorer
  - Press `CTRL-J`/`CTRL-K` to move down/up and preview contents.
  - Press `CTRL-U`/`CTRL-R` to switch between filter/include hidden files mode.
  - Press `ALT-L`/`ALT-H` to cd into folder and cd upper folder.
  - Use `V`/`W`/`P`/`R` variants (visual selection, cursor word, yank text, resume last).
  - Press `ESC` to quit, `ENTER` to open file, and open the `test/hello world.txt`, `test/goodbye world/goodbye.lua` files.
  - All `eza`/`lsd`/`ls` works.
