### PR TITLE
feat(bat): more precisely bat theme generation

### DIFF
--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -319,7 +319,10 @@ M._make_renderers = function()
       { "entity.name.tag.block.any.html", "entity.name.tag.inline.any.html" }
     ),
     _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
-    _BatThemeScopeRenderer:new({ "markdownLink" }, "markup.underline.link"),
+    _BatThemeScopeRenderer:new(
+      { "@markup.link.markdown_inline", "markdownLink" },
+      "markup.underline.link.markdown"
+    ),
     _BatThemeScopeRenderer:new(
       { "@markup.link.label.markdown_inline", "markdownLinkText" },
       "meta.link.inline.description.markdown"

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -156,9 +156,8 @@ function _BatThemeScopeRenderer:new(hls, scope)
   local new_hls = {}
   for _, hl in ipairs(hls) do
     -- If "nvim-treesitter" doesn't exist, and `hl` is a treesitter hl, skip it.
-    if not M._nvim_treesitter_exists and _is_treesitter_hl(hl) then
-      -- Skip
-    else
+    -- Otherwise, add it to `new_hls` list.
+    if not (not M._nvim_treesitter_exists and _is_treesitter_hl(hl)) then
       table.insert(new_hls, hl)
     end
   end

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -143,10 +143,25 @@ function _BatThemeScopeRenderer:new(hls, scope)
   local value
   for _, hl in ipairs(hls) do
     local ok, hl_codes = pcall(color_hl.get_hl, hl)
+    -- log.debug(
+    --   string.format(
+    --     "BatThemeScopeRenderer:new-1 - hl:%s,hl_codes:%s",
+    --     vim.inspect(hl),
+    --     vim.inspect(hl_codes)
+    --   )
+    -- )
     if ok and tbl.tbl_not_empty(hl_codes) then
       local scope_value = M._make_scope_value(hl, scope, hl_codes)
       if scope_value then
         value = scope_value
+        -- log.debug(
+        --   string.format(
+        --     "BatThemeScopeRenderer:new-2 - hl:%s,hl_codes:%s,value:%s",
+        --     vim.inspect(hl),
+        --     vim.inspect(hl_codes),
+        --     vim.inspect(value)
+        --   )
+        -- )
         break
       end
     end
@@ -156,6 +171,9 @@ function _BatThemeScopeRenderer:new(hls, scope)
     scope = scope,
     value = value,
   }
+  -- log.debug(
+  --   string.format("BatThemeScopeRenderer:new-3 - hls:%s,o:%s", vim.inspect(hls), vim.inspect(o))
+  -- )
 
   setmetatable(o, self)
   self.__index = self
@@ -318,21 +336,23 @@ M._make_renderers = function()
       { "htmlTag" },
       { "puncuation.definition.tag.begin.html", "puncuation.definition.tag.end.html" }
     ),
+    _BatThemeScopeRenderer:new({ "htmlString" }, { "string.quoted.double.html" }),
     _BatThemeScopeRenderer:new(
       { "htmlTagName" },
       { "entity.name.tag.block.any.html", "entity.name.tag.inline.any.html" }
     ),
     _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
     _BatThemeScopeRenderer:new(
-      { "@markup.link.markdown_inline", "markdownLink" },
+      { "@markup.link", "markdownUrl", "markdownLink" },
       "markup.underline.link.markdown"
     ),
+    -- _BatThemeScopeRenderer:new({ "markdownUrl", "markdownLink" }, "markup.underline.link.markdown"),
     _BatThemeScopeRenderer:new(
-      { "@markup.link.label.markdown_inline", "markdownLinkText" },
+      { "@markup.link.label", "markdownLinkText" },
       "meta.link.inline.description.markdown"
     ),
     _BatThemeScopeRenderer:new(
-      { "@markup.link.markdown_inline", "markdownLinkTextDelimiter" },
+      { "@markup.link", "markdownLinkTextDelimiter" },
       { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
     ),
     _BatThemeScopeRenderer:new(
@@ -369,14 +389,12 @@ M._make_renderers = function()
       { "@markup.heading.6.markdown", "markdownH6" },
       { "markup.heading.6.markdown" }
     ),
-    _BatThemeScopeRenderer:new(
-      { "@markup.list.markdown", "markdownListMarker" },
-      { "puncuation.definition.list_item.markdown", "markup.list.unnumbered" }
-    ),
-    _BatThemeScopeRenderer:new(
-      { "@markup.list.markdown", "markdownOrderedListMarker" },
-      { "markup.list.numbered" }
-    ),
+    -- _BatThemeScopeRenderer:new(
+    --   { "@markup.list.markdown", "markdownListMarker" },
+    --   { "puncuation.definition.list_item.markdown" }
+    -- ),
+    -- _BatThemeScopeRenderer:new({ "@markup.list.markdown" }, { "markup.list.unnumbered" }),
+    -- _BatThemeScopeRenderer:new({ "@markup.list.markdown" }, { "markup.list.numbered" }),
     _BatThemeScopeRenderer:new({ "@markup.raw.block.markdown", "markdownCodeDelimiter" }, {
       "puncuation.definition.raw.code-fence.begin.markdown",
       "puncuation.definition.raw.code-fence.end.markdown",

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -236,14 +236,12 @@ M._make_renderers = function()
       "GitGutterAdd",
       "DiffAdd",
       "DiffAdded",
-      "@diff.plus",
       "Added",
     }, "lineDiffAdded", "fg"),
     _BatThemeGlobalRenderer:new({
       "GitSignsChange",
       "GitGutterChange",
       "DiffChange",
-      "@diff.delta",
       "Changed",
     }, "lineDiffModified", "fg"),
     _BatThemeGlobalRenderer:new({
@@ -251,7 +249,6 @@ M._make_renderers = function()
       "GitGutterDelete",
       "DiffDelete",
       "DiffRemoved",
-      "@diff.minus",
       "Removed",
     }, "lineDiffDeleted", "fg"),
   }
@@ -259,11 +256,11 @@ M._make_renderers = function()
   -- Scope theme
   local SCOPE_RENDERERS = {
     -- comment {
-    _BatThemeScopeRenderer:new({ "@comment", "Comment" }, "comment"),
+    _BatThemeScopeRenderer:new({ "Comment" }, "comment"),
     -- comment }
 
     -- constant {
-    _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "constant"),
+    _BatThemeScopeRenderer:new({ "Constant" }, "constant"),
     _BatThemeScopeRenderer:new({ "@number", "Number" }, "constant.numeric"),
     _BatThemeScopeRenderer:new({ "@number.float", "Float" }, "constant.numeric.float"),
     _BatThemeScopeRenderer:new({ "@boolean", "Boolean" }, "constant.language"),
@@ -271,62 +268,94 @@ M._make_renderers = function()
       { "@character", "Character" },
       { "constant.character", "character" }
     ),
-    _BatThemeScopeRenderer:new({ "@string", "String" }, { "string", "string.quoted" }),
+    _BatThemeScopeRenderer:new({ "String" }, { "string", "string.quoted" }),
     _BatThemeScopeRenderer:new({ "@string.regexp" }, { "string.regexp" }),
     _BatThemeScopeRenderer:new(
-      { "@string.escape", "SpecialChar" },
+      { "Special" },
       { "constant.character.escaped", "constant.character.escape" }
     ),
     -- constant }
 
     -- entity {
-    _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "entity.name.constant"),
-    _BatThemeScopeRenderer:new({ "@function.call", "Function" }, "variable.function"),
-    _BatThemeScopeRenderer:new({ "@function.macro", "Function" }, { "support.macro" }),
-    _BatThemeScopeRenderer:new({ "@function.builtin" }, { "support.function" }),
-    _BatThemeScopeRenderer:new({ "@type", "Type" }, { "storage.type", "support.type" }),
-    _BatThemeScopeRenderer:new({ "@module" }, { "meta.path" }),
-    _BatThemeScopeRenderer:new({ "@tag" }, "entity.name.tag"),
-    _BatThemeScopeRenderer:new({ "@label", "Label" }, "entity.name.label"),
+    _BatThemeScopeRenderer:new({ "Constant" }, "entity.name.constant"),
+    _BatThemeScopeRenderer:new({ "Function" }, { "variable.function" }),
+    _BatThemeScopeRenderer:new({ "PreProc" }, { "support.macro" }),
+    _BatThemeScopeRenderer:new({ "Type" }, { "storage.type", "support.type" }),
+    _BatThemeScopeRenderer:new({ "Identifier" }, { "entity.name.module" }),
+    -- _BatThemeScopeRenderer:new({ "@label", "Label" }, "entity.name.label"),
     -- entity }
 
     -- variable {
-    _BatThemeScopeRenderer:new({ "@variable" }, "variable"),
-    _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
-    _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
-    _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
+    -- _BatThemeScopeRenderer:new({ "@variable" }, "variable"),
+    -- _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
+    -- _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
+    -- _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
     -- variable }
 
     -- Puncuation {
-    _BatThemeScopeRenderer:new({ "@puncuation.bracket", "Delimiter" }, "puncuation.brackets"),
-    _BatThemeScopeRenderer:new({ "@puncuation.delimiter", "Delimiter" }, "puncuation.semi"),
+    _BatThemeScopeRenderer:new({ "Delimiter" }, "puncuation.brackets"),
+    _BatThemeScopeRenderer:new({ "Delimiter" }, "puncuation.semi"),
     -- Puncuation }
 
     -- keyword {
-    _BatThemeScopeRenderer:new({ "@keyword", "Keyword" }, "keyword"),
-    _BatThemeScopeRenderer:new({ "@keyword.modifier" }, "keyword.declaration"),
-    _BatThemeScopeRenderer:new({ "@keyword.function" }, "storage.modifier"),
-    _BatThemeScopeRenderer:new({ "@operator", "Operator" }, "keyword.operator"),
-    _BatThemeScopeRenderer:new({ "@keyword.conditional", "Conditional" }, "keyword.control"),
-    _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
+    _BatThemeScopeRenderer:new({ "Keyword" }, "keyword"),
+    _BatThemeScopeRenderer:new({ "StorageClass" }, "keyword.declaration.variable.static"),
+    _BatThemeScopeRenderer:new({ "StorageClass" }, "storage.modifier"),
+    _BatThemeScopeRenderer:new({ "Operator" }, "keyword.operator"),
+    _BatThemeScopeRenderer:new({ "Conditional" }, "keyword.control"),
     -- keyword }
 
     -- markup {
-    _BatThemeScopeRenderer:new({ "@markup.link" }, "markup.underline.link"),
-    _BatThemeScopeRenderer:new({ "@markup.link.label" }, { "meta.link.inline" }),
-    _BatThemeScopeRenderer:new({ "@markup.strong" }, "markup.bold"),
-    _BatThemeScopeRenderer:new({ "@markup.italic" }, "markup.italic"),
+    _BatThemeScopeRenderer:new(
+      { "htmlTag" },
+      { "puncuation.definition.tag.begin.html", "puncuation.definition.tag.end.html" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "htmlTagName" },
+      { "entity.name.tag.block.any.html", "entity.name.tag.inline.any.html" }
+    ),
+    _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
+    _BatThemeScopeRenderer:new({ "markdownLink" }, "markup.underline.link"),
+    _BatThemeScopeRenderer:new(
+      { "markdownLinkText" },
+      "meta.link.inline.link.description.markdown"
+    ),
+    _BatThemeScopeRenderer:new(
+      { "markdownLinkTextDelimiter" },
+      { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "markdownBlockquote" },
+      { "puncuation.definition.blockquote.markdown" }
+    ),
+    _BatThemeScopeRenderer:new({ "markdownBold" }, "markup.bold"),
+    _BatThemeScopeRenderer:new({ "markdownItalic" }, "markup.italic"),
     _BatThemeScopeRenderer:new({ "@markup.list" }, "markup.list"),
     _BatThemeScopeRenderer:new({ "@markup.underline" }, "markup.underline"),
-    _BatThemeScopeRenderer:new({ "@markup.heading" }, { "markup.heading" }),
-    -- _BatThemeScopeRenderer:new({ "@markup.raw" }, "meta.code-fence"),
-    _BatThemeScopeRenderer:new({ "@markup.quote" }, "markup.quote"),
+    _BatThemeScopeRenderer:new({ "markdownHeadingDelimiter" }, {
+      "puncuation.definition.heading.begin.markdown",
+      "puncuation.definition.heading.end.markdown",
+    }),
+    _BatThemeScopeRenderer:new({ "markdownH1" }, { "markup.heading.1.markdown" }),
+    _BatThemeScopeRenderer:new({ "markdownH2" }, { "markup.heading.2.markdown" }),
+    _BatThemeScopeRenderer:new({ "markdownH3" }, { "markup.heading.3.markdown" }),
+    _BatThemeScopeRenderer:new({ "markdownH4" }, { "markup.heading.4.markdown" }),
+    _BatThemeScopeRenderer:new({ "markdownH5" }, { "markup.heading.5.markdown" }),
+    _BatThemeScopeRenderer:new({ "markdownH6" }, { "markup.heading.6.markdown" }),
+    _BatThemeScopeRenderer:new(
+      { "markdownListMarker" },
+      { "puncuation.definition.list_item.markdown", "markup.list.unnumbered" }
+    ),
+    _BatThemeScopeRenderer:new({ "markdownOrderedListMarker" }, { "markup.list.numbered" }),
+    _BatThemeScopeRenderer:new({ "markdownCodeDelimiter" }, {
+      "puncuation.definition.raw.code-fence.begin.markdown",
+      "puncuation.definition.raw.code-fence.end.markdown",
+    }),
     _BatThemeScopeRenderer:new({
       "GitSignsAdd",
       "GitGutterAdd",
       "DiffAdd",
       "DiffAdded",
-      "@diff.plus",
       "Added",
     }, { "markup.inserted" }),
     _BatThemeScopeRenderer:new({
@@ -334,14 +363,12 @@ M._make_renderers = function()
       "GitGutterDelete",
       "DiffDelete",
       "DiffRemoved",
-      "@diff.minus",
       "Removed",
     }, { "markup.deleted" }),
     _BatThemeScopeRenderer:new({
       "GitGutterChange",
       "GitSignsChange",
       "DiffChange",
-      "@diff.delta",
       "Changed",
     }, { "markup.changed" }),
     -- markup }

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -284,7 +284,7 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@function.call", "Function" }, { "variable.function" }),
     _BatThemeScopeRenderer:new({ "@function.macro" }, { "support.macro" }),
     _BatThemeScopeRenderer:new({ "@type", "Type" }, { "storage.type", "support.type" }),
-    _BatThemeScopeRenderer:new({ "Identifier" }, { "entity.name.module" }),
+    -- _BatThemeScopeRenderer:new({ "Identifier" }, { "entity.name.module" }),
     -- _BatThemeScopeRenderer:new({ "@label", "Label" }, "entity.name.label"),
     -- entity }
 
@@ -292,7 +292,7 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@variable" }, "variable.other"),
     _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
     _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
-    -- _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
+    _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
     -- variable }
 
     -- Puncuation {
@@ -308,6 +308,10 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@operator", "Operator" }, "keyword.operator"),
     _BatThemeScopeRenderer:new({ "@keyword.conditional", "Conditional" }, "keyword.control"),
     -- keyword }
+
+    -- meta {
+    _BatThemeScopeRenderer:new({ "@module" }, "meta.path"),
+    -- meta }
 
     -- markup {
     _BatThemeScopeRenderer:new(

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -349,7 +349,7 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@variable" }, "variable.other"),
     _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
     _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
-    _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
+    -- _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
     -- variable }
 
     -- Puncuation {
@@ -362,7 +362,10 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@keyword", "StorageClass" }, "keyword.declaration.variable"),
     _BatThemeScopeRenderer:new({ "@keyword.modifier", "StorageClass" }, "storage.modifier"),
     _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
-    _BatThemeScopeRenderer:new({ "@operator", "Operator" }, "keyword.operator"),
+    _BatThemeScopeRenderer:new(
+      { "@operator", "Operator" },
+      { "keyword.operator.assignment", "keyword.operator" }
+    ),
     _BatThemeScopeRenderer:new({ "@keyword.conditional", "Conditional" }, "keyword.control"),
     -- keyword }
 

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -280,9 +280,9 @@ M._make_renderers = function()
     -- constant }
 
     -- entity {
-    _BatThemeScopeRenderer:new({ "@constant" }, "entity.name.constant"),
+    _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "entity.name.constant"),
     _BatThemeScopeRenderer:new({ "@function.call", "Function" }, { "variable.function" }),
-    _BatThemeScopeRenderer:new({ "@function.macro", "PreProc" }, { "support.macro" }),
+    _BatThemeScopeRenderer:new({ "@function.macro" }, { "support.macro" }),
     _BatThemeScopeRenderer:new({ "@type", "Type" }, { "storage.type", "support.type" }),
     _BatThemeScopeRenderer:new({ "Identifier" }, { "entity.name.module" }),
     -- _BatThemeScopeRenderer:new({ "@label", "Label" }, "entity.name.label"),

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -263,7 +263,7 @@ M._make_renderers = function()
     -- comment }
 
     -- constant {
-    _BatThemeScopeRenderer:new({ "Constant" }, "constant"),
+    _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "constant"),
     _BatThemeScopeRenderer:new({ "@number", "Number" }, "constant.numeric"),
     _BatThemeScopeRenderer:new({ "@number.float", "Float" }, "constant.numeric.float"),
     _BatThemeScopeRenderer:new({ "@boolean", "Boolean" }, "constant.language"),
@@ -271,7 +271,7 @@ M._make_renderers = function()
       { "@character", "Character" },
       { "constant.character", "character" }
     ),
-    _BatThemeScopeRenderer:new({ "String" }, { "string", "string.quoted" }),
+    _BatThemeScopeRenderer:new({ "@string", "String" }, { "string", "string.quoted" }),
     _BatThemeScopeRenderer:new({ "@string.regexp" }, { "string.regexp" }),
     _BatThemeScopeRenderer:new(
       { "Special" },
@@ -280,10 +280,10 @@ M._make_renderers = function()
     -- constant }
 
     -- entity {
-    _BatThemeScopeRenderer:new({ "Constant" }, "entity.name.constant"),
-    _BatThemeScopeRenderer:new({ "Function" }, { "variable.function" }),
-    _BatThemeScopeRenderer:new({ "PreProc" }, { "support.macro" }),
-    _BatThemeScopeRenderer:new({ "Type" }, { "storage.type", "support.type" }),
+    _BatThemeScopeRenderer:new({ "@constant" }, "entity.name.constant"),
+    _BatThemeScopeRenderer:new({ "@function.call", "Function" }, { "variable.function" }),
+    _BatThemeScopeRenderer:new({ "@function.macro", "PreProc" }, { "support.macro" }),
+    _BatThemeScopeRenderer:new({ "@type", "Type" }, { "storage.type", "support.type" }),
     _BatThemeScopeRenderer:new({ "Identifier" }, { "entity.name.module" }),
     -- _BatThemeScopeRenderer:new({ "@label", "Label" }, "entity.name.label"),
     -- entity }
@@ -302,9 +302,13 @@ M._make_renderers = function()
 
     -- keyword {
     _BatThemeScopeRenderer:new({ "Keyword" }, "keyword"),
-    _BatThemeScopeRenderer:new({ "StorageClass" }, "keyword.declaration.variable.static"),
+    _BatThemeScopeRenderer:new(
+      { "@keyword.modifier", "StorageClass" },
+      "keyword.declaration.variable.static"
+    ),
     _BatThemeScopeRenderer:new({ "StorageClass" }, "storage.modifier"),
-    _BatThemeScopeRenderer:new({ "Operator" }, "keyword.operator"),
+    _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
+    _BatThemeScopeRenderer:new({ "@operator", "Operator" }, "keyword.operator"),
     _BatThemeScopeRenderer:new({ "Conditional" }, "keyword.control"),
     -- keyword }
 

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -274,7 +274,7 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@string", "String" }, { "string", "string.quoted" }),
     _BatThemeScopeRenderer:new({ "@string.regexp" }, { "string.regexp" }),
     _BatThemeScopeRenderer:new(
-      { "Special" },
+      { "@string.escape", "Special" },
       { "constant.character.escaped", "constant.character.escape" }
     ),
     -- constant }
@@ -289,27 +289,24 @@ M._make_renderers = function()
     -- entity }
 
     -- variable {
-    -- _BatThemeScopeRenderer:new({ "@variable" }, "variable"),
-    -- _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
+    _BatThemeScopeRenderer:new({ "@variable" }, "variable.other"),
+    _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
+    _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
     -- _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
-    -- _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
     -- variable }
 
     -- Puncuation {
-    _BatThemeScopeRenderer:new({ "Delimiter" }, "puncuation.brackets"),
-    _BatThemeScopeRenderer:new({ "Delimiter" }, "puncuation.semi"),
+    _BatThemeScopeRenderer:new({ "@puncuation.bracket", "Delimiter" }, "puncuation.brackets"),
+    _BatThemeScopeRenderer:new({ "@puncuation.delimiter", "Delimiter" }, "puncuation.terminator"),
     -- Puncuation }
 
     -- keyword {
-    _BatThemeScopeRenderer:new({ "Keyword" }, "keyword"),
-    _BatThemeScopeRenderer:new(
-      { "@keyword.modifier", "StorageClass" },
-      "keyword.declaration.variable.static"
-    ),
-    _BatThemeScopeRenderer:new({ "StorageClass" }, "storage.modifier"),
+    _BatThemeScopeRenderer:new({ "@keyword", "Keyword" }, "keyword"),
+    _BatThemeScopeRenderer:new({ "@keyword", "StorageClass" }, "keyword.declaration.variable"),
+    _BatThemeScopeRenderer:new({ "@keyword.modifier", "StorageClass" }, "storage.modifier"),
     _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
     _BatThemeScopeRenderer:new({ "@operator", "Operator" }, "keyword.operator"),
-    _BatThemeScopeRenderer:new({ "Conditional" }, "keyword.control"),
+    _BatThemeScopeRenderer:new({ "@keyword.conditional", "Conditional" }, "keyword.control"),
     -- keyword }
 
     -- markup {
@@ -323,33 +320,57 @@ M._make_renderers = function()
     ),
     _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
     _BatThemeScopeRenderer:new({ "markdownLink" }, "markup.underline.link"),
-    _BatThemeScopeRenderer:new({ "markdownLinkText" }, "meta.link.inline.description.markdown"),
     _BatThemeScopeRenderer:new(
-      { "markdownLinkTextDelimiter" },
+      { "@markup.link.label.markdown_inline", "markdownLinkText" },
+      "meta.link.inline.description.markdown"
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.link.markdown_inline", "markdownLinkTextDelimiter" },
       { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
     ),
     _BatThemeScopeRenderer:new(
       { "markdownBlockquote" },
       { "puncuation.definition.blockquote.markdown" }
     ),
-    _BatThemeScopeRenderer:new({ "markdownBold" }, "markup.bold"),
-    _BatThemeScopeRenderer:new({ "markdownItalic" }, "markup.italic"),
+    _BatThemeScopeRenderer:new({ "@markup.strong", "markdownBold" }, "markup.bold"),
+    _BatThemeScopeRenderer:new({ "@markup.italic", "markdownItalic" }, "markup.italic"),
     _BatThemeScopeRenderer:new({ "markdownHeadingDelimiter" }, {
       "puncuation.definition.heading.begin.markdown",
       "puncuation.definition.heading.end.markdown",
     }),
-    _BatThemeScopeRenderer:new({ "markdownH1" }, { "markup.heading.1.markdown" }),
-    _BatThemeScopeRenderer:new({ "markdownH2" }, { "markup.heading.2.markdown" }),
-    _BatThemeScopeRenderer:new({ "markdownH3" }, { "markup.heading.3.markdown" }),
-    _BatThemeScopeRenderer:new({ "markdownH4" }, { "markup.heading.4.markdown" }),
-    _BatThemeScopeRenderer:new({ "markdownH5" }, { "markup.heading.5.markdown" }),
-    _BatThemeScopeRenderer:new({ "markdownH6" }, { "markup.heading.6.markdown" }),
     _BatThemeScopeRenderer:new(
-      { "markdownListMarker" },
+      { "@markup.heading.1.markdown", "markdownH1" },
+      { "markup.heading.1.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.heading.2.markdown", "markdownH2" },
+      { "markup.heading.2.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.heading.3.markdown", "markdownH3" },
+      { "markup.heading.3.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.heading.4.markdown", "markdownH4" },
+      { "markup.heading.4.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.heading.5.markdown", "markdownH5" },
+      { "markup.heading.5.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.heading.6.markdown", "markdownH6" },
+      { "markup.heading.6.markdown" }
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@markup.list.markdown", "markdownListMarker" },
       { "puncuation.definition.list_item.markdown", "markup.list.unnumbered" }
     ),
-    _BatThemeScopeRenderer:new({ "markdownOrderedListMarker" }, { "markup.list.numbered" }),
-    _BatThemeScopeRenderer:new({ "markdownCodeDelimiter" }, {
+    _BatThemeScopeRenderer:new(
+      { "@markup.list.markdown", "markdownOrderedListMarker" },
+      { "markup.list.numbered" }
+    ),
+    _BatThemeScopeRenderer:new({ "@markup.raw.block.markdown", "markdownCodeDelimiter" }, {
       "puncuation.definition.raw.code-fence.begin.markdown",
       "puncuation.definition.raw.code-fence.end.markdown",
     }),

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -236,12 +236,14 @@ M._make_renderers = function()
       "GitGutterAdd",
       "DiffAdd",
       "DiffAdded",
+      "@diff.plus",
       "Added",
     }, "lineDiffAdded", "fg"),
     _BatThemeGlobalRenderer:new({
       "GitSignsChange",
       "GitGutterChange",
       "DiffChange",
+      "@diff.delta",
       "Changed",
     }, "lineDiffModified", "fg"),
     _BatThemeGlobalRenderer:new({
@@ -249,6 +251,7 @@ M._make_renderers = function()
       "GitGutterDelete",
       "DiffDelete",
       "DiffRemoved",
+      "@diff.minus",
       "Removed",
     }, "lineDiffDeleted", "fg"),
   }
@@ -256,7 +259,7 @@ M._make_renderers = function()
   -- Scope theme
   local SCOPE_RENDERERS = {
     -- comment {
-    _BatThemeScopeRenderer:new({ "Comment" }, "comment"),
+    _BatThemeScopeRenderer:new({ "@comment", "Comment" }, "comment"),
     -- comment }
 
     -- constant {
@@ -351,21 +354,24 @@ M._make_renderers = function()
       "GitGutterAdd",
       "DiffAdd",
       "DiffAdded",
+      "@diff.plus",
       "Added",
     }, { "markup.inserted" }),
+    _BatThemeScopeRenderer:new({
+      "GitSignsChange",
+      "GitGutterChange",
+      "DiffChange",
+      "@diff.delta",
+      "Changed",
+    }, { "markup.changed" }),
     _BatThemeScopeRenderer:new({
       "GitSignsDelete",
       "GitGutterDelete",
       "DiffDelete",
       "DiffRemoved",
+      "@diff.minus",
       "Removed",
     }, { "markup.deleted" }),
-    _BatThemeScopeRenderer:new({
-      "GitGutterChange",
-      "GitSignsChange",
-      "DiffChange",
-      "Changed",
-    }, { "markup.changed" }),
     -- markup }
   }
 

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -316,10 +316,7 @@ M._make_renderers = function()
     ),
     _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
     _BatThemeScopeRenderer:new({ "markdownLink" }, "markup.underline.link"),
-    _BatThemeScopeRenderer:new(
-      { "markdownLinkText" },
-      "meta.link.inline.link.description.markdown"
-    ),
+    _BatThemeScopeRenderer:new({ "markdownLinkText" }, "meta.link.inline.description.markdown"),
     _BatThemeScopeRenderer:new(
       { "markdownLinkTextDelimiter" },
       { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
@@ -330,8 +327,6 @@ M._make_renderers = function()
     ),
     _BatThemeScopeRenderer:new({ "markdownBold" }, "markup.bold"),
     _BatThemeScopeRenderer:new({ "markdownItalic" }, "markup.italic"),
-    _BatThemeScopeRenderer:new({ "@markup.list" }, "markup.list"),
-    _BatThemeScopeRenderer:new({ "@markup.underline" }, "markup.underline"),
     _BatThemeScopeRenderer:new({ "markdownHeadingDelimiter" }, {
       "puncuation.definition.heading.begin.markdown",
       "puncuation.definition.heading.end.markdown",


### PR DESCRIPTION
It seems a more precisely theme generation needs 3 layers:
1. Regex color
2. Treesitter Color
3. LSP token color

This PR adds regex color as a very fundamental fallback for all colors, to keep it correct when user don't have LSP or treesitter.

Here's few images to show the difference between buffer previewer (**left**) and bat auto-generated theme (**right**):

- Monokai ColorScheme

  <p align="center">
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/fabaf418-9663-47bc-8f20-ffb9934382ac" />
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/0211c6d5-a36f-4b79-97f0-9e9a7e3f4275" />
  </p>

- GitHub Dark ColorScheme

  <p align="center">
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/e2074789-a1f8-4cd2-a698-f59d87818d36" />
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/7018e94b-dbf4-417a-a672-859797d257a6" />
  </p>

- Gruvbox ColorScheme 


  <p align="center">
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/92555b2e-6c02-4ec8-b15a-e651d7b1b249" />
  <img width="49%" alt="image" src="https://github.com/user-attachments/assets/a1bbba95-254f-45cd-96d8-3cf8e7f9e08d" />
  </p>

Related discussion: https://github.com/linrongbin16/fzfx.nvim/discussions/770