### PR TITLE
feat(bat): more precisely bat themes with LSP token

### DIFF
--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -351,7 +351,10 @@ M._make_renderers = function()
       { "@lsp.typemod.function.defaultLibrary", "@function.builtin" },
       { "support.function.builtin" }
     ),
-    _BatThemeScopeRenderer:new({ "@type", "Type" }, { "storage.type", "support.type" }),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.type.struct", "@type", "Type" },
+      { "storage.type", "support.type" }
+    ),
     _BatThemeScopeRenderer:new(
       { "@lsp.typemod.keyword.documentation" },
       { "entity.name.tag.documentation" }

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -503,30 +503,30 @@ M._make_renderers = function()
     -- markup }
   }
 
-  local builtin_syntax_filenames = vim.fn.glob(vim.env.VIMRUNTIME .. "/syntax/*")
-  builtin_syntax_filenames =
-    str.split(builtin_syntax_filenames, "\n", { plain = true, trimempty = true })
-  for _, syntax_file in ipairs(builtin_syntax_filenames) do
-    local normalized = path.normalize(syntax_file, { double_backslash = true, expand = true })
-    local syntax = vim.fn.fnamemodify(normalized, ":t")
-    local lang = vim.fn.fnamemodify(syntax, ":r")
-    log.debug(string.format("syntax lang:%s", lang))
-    table.insert(
-      SCOPE_RENDERERS,
-      _BatThemeScopeRenderer:new({ lang .. "Structure" }, { "keyword.declaration.struct." .. lang })
-    )
-    table.insert(
-      SCOPE_RENDERERS,
-      _BatThemeScopeRenderer:new(
-        { lang .. "Keyword" },
-        { "storage.modifier." .. lang, "keyword.declaration." .. lang }
-      )
-    )
-    table.insert(
-      SCOPE_RENDERERS,
-      _BatThemeScopeRenderer:new({ lang .. "Identifier" }, { "entity.name.struct." .. lang })
-    )
-  end
+  -- local builtin_syntax_filenames = vim.fn.glob(vim.env.VIMRUNTIME .. "/syntax/*")
+  -- builtin_syntax_filenames =
+  --   str.split(builtin_syntax_filenames, "\n", { plain = true, trimempty = true })
+  -- for _, syntax_file in ipairs(builtin_syntax_filenames) do
+  --   local normalized = path.normalize(syntax_file, { double_backslash = true, expand = true })
+  --   local syntax = vim.fn.fnamemodify(normalized, ":t")
+  --   local lang = vim.fn.fnamemodify(syntax, ":r")
+  --   log.debug(string.format("syntax lang:%s", lang))
+  --   table.insert(
+  --     SCOPE_RENDERERS,
+  --     _BatThemeScopeRenderer:new({ lang .. "Structure" }, { "keyword.declaration.struct." .. lang })
+  --   )
+  --   table.insert(
+  --     SCOPE_RENDERERS,
+  --     _BatThemeScopeRenderer:new(
+  --       { lang .. "Keyword" },
+  --       { "storage.modifier." .. lang, "keyword.declaration." .. lang }
+  --     )
+  --   )
+  --   table.insert(
+  --     SCOPE_RENDERERS,
+  --     _BatThemeScopeRenderer:new({ lang .. "Identifier" }, { "entity.name.struct." .. lang })
+  --   )
+  -- end
 
   return {
     globals = GLOBAL_RENDERERS,

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -323,7 +323,7 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "constant"),
     _BatThemeScopeRenderer:new({ "@number", "Number" }, "constant.numeric"),
     _BatThemeScopeRenderer:new({ "@number.float", "Float" }, "constant.numeric.float"),
-    _BatThemeScopeRenderer:new({ "@boolean", "Boolean" }, "constant.language"),
+    _BatThemeScopeRenderer:new({ "@constant.builtin", "Boolean" }, "constant.language"),
     _BatThemeScopeRenderer:new(
       { "@character", "Character" },
       { "constant.character", "character" }
@@ -340,9 +340,16 @@ M._make_renderers = function()
     _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "entity.name.constant"),
     _BatThemeScopeRenderer:new({ "@function.call", "Function" }, { "variable.function" }),
     _BatThemeScopeRenderer:new({ "@function.macro" }, { "support.macro" }),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.typemod.function.defaultLibrary", "@function.builtin" },
+      { "support.function.builtin" }
+    ),
     _BatThemeScopeRenderer:new({ "@type", "Type" }, { "storage.type", "support.type" }),
-    -- _BatThemeScopeRenderer:new({ "Identifier" }, { "entity.name.module" }),
-    -- _BatThemeScopeRenderer:new({ "@label", "Label" }, "entity.name.label"),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.typemod.keyword.documentation" },
+      { "entity.name.tag.documentation" }
+    ),
+    _BatThemeScopeRenderer:new({ "@lsp.type.property" }, { "meta.property" }),
     -- entity }
 
     -- variable {

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -141,9 +141,9 @@ end
 --- @return boolean
 local function _is_treesitter_hl(hl)
   local result = str.not_empty(hl) and str.startswith(hl, "@") and not str.startswith(hl, "@lsp")
-  log.debug(
-    string.format("is_treesitter_hl - hl:%s,result:%s", vim.inspect(hl), vim.inspect(result))
-  )
+  -- log.debug(
+  --   string.format("is_treesitter_hl - hl:%s,result:%s", vim.inspect(hl), vim.inspect(result))
+  -- )
   return result
 end
 
@@ -161,38 +161,38 @@ function _BatThemeScopeRenderer:new(hls, scope)
       table.insert(new_hls, hl)
     end
   end
-  log.debug(
-    string.format(
-      "BatThemeScopeRenderer:new-0 - ts_exist:%s,(old)hls:%s,new_hls:%s",
-      vim.inspect(M._nvim_treesitter_exists),
-      vim.inspect(hls),
-      vim.inspect(new_hls)
-    )
-  )
+  -- log.debug(
+  --   string.format(
+  --     "BatThemeScopeRenderer:new-0 - ts_exist:%s,(old)hls:%s,new_hls:%s",
+  --     vim.inspect(M._nvim_treesitter_exists),
+  --     vim.inspect(hls),
+  --     vim.inspect(new_hls)
+  --   )
+  -- )
   hls = new_hls
 
   local value
   for _, hl in ipairs(hls) do
     local ok, hl_codes = pcall(color_hl.get_hl, hl)
-    log.debug(
-      string.format(
-        "BatThemeScopeRenderer:new-1 - hl:%s,hl_codes:%s",
-        vim.inspect(hl),
-        vim.inspect(hl_codes)
-      )
-    )
+    -- log.debug(
+    --   string.format(
+    --     "BatThemeScopeRenderer:new-1 - hl:%s,hl_codes:%s",
+    --     vim.inspect(hl),
+    --     vim.inspect(hl_codes)
+    --   )
+    -- )
     if ok and tbl.tbl_not_empty(hl_codes) then
       local scope_value = M._make_scope_value(hl, scope, hl_codes)
       if scope_value then
         value = scope_value
-        log.debug(
-          string.format(
-            "BatThemeScopeRenderer:new-2 - hl:%s,hl_codes:%s,value:%s",
-            vim.inspect(hl),
-            vim.inspect(hl_codes),
-            vim.inspect(value)
-          )
-        )
+        -- log.debug(
+        --   string.format(
+        --     "BatThemeScopeRenderer:new-2 - hl:%s,hl_codes:%s,value:%s",
+        --     vim.inspect(hl),
+        --     vim.inspect(hl_codes),
+        --     vim.inspect(value)
+        --   )
+        -- )
         break
       end
     end
@@ -202,9 +202,9 @@ function _BatThemeScopeRenderer:new(hls, scope)
     scope = scope,
     value = value,
   }
-  log.debug(
-    string.format("BatThemeScopeRenderer:new-3 - hls:%s,o:%s", vim.inspect(hls), vim.inspect(o))
-  )
+  -- log.debug(
+  --   string.format("BatThemeScopeRenderer:new-3 - hls:%s,o:%s", vim.inspect(hls), vim.inspect(o))
+  -- )
 
   setmetatable(o, self)
   self.__index = self

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -316,7 +316,7 @@ M._make_renderers = function()
   -- Scope theme
   local SCOPE_RENDERERS = {
     -- comment {
-    _BatThemeScopeRenderer:new({ "@comment", "Comment" }, "comment"),
+    _BatThemeScopeRenderer:new({ "@lsp.type.comment", "@comment", "Comment" }, "comment"),
     -- comment }
 
     -- constant {
@@ -337,9 +337,16 @@ M._make_renderers = function()
     -- constant }
 
     -- entity {
-    _BatThemeScopeRenderer:new({ "@constant", "Constant" }, "entity.name.constant"),
-    _BatThemeScopeRenderer:new({ "@function.call", "Function" }, { "variable.function" }),
-    _BatThemeScopeRenderer:new({ "@function.macro" }, { "support.macro" }),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.typemod.static.declaration", "@constant", "Constant" },
+      "entity.name.constant"
+    ),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.type.method", "@lsp.type.function", "@function.call", "Function" },
+      { "variable.function" }
+    ),
+    _BatThemeScopeRenderer:new({ "@lsp.type.method" }, { "entity.name.function" }),
+    _BatThemeScopeRenderer:new({ "@lsp.type.macro", "@function.macro" }, { "support.macro" }),
     _BatThemeScopeRenderer:new(
       { "@lsp.typemod.function.defaultLibrary", "@function.builtin" },
       { "support.function.builtin" }
@@ -355,8 +362,15 @@ M._make_renderers = function()
     -- variable {
     _BatThemeScopeRenderer:new({ "@variable" }, "variable.other"),
     _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
-    _BatThemeScopeRenderer:new({ "@variable.parameter" }, { "variable.parameter" }),
-    -- _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.type.parameter", "@variable.parameter" },
+      { "variable.parameter" }
+    ),
+    _BatThemeScopeRenderer:new({ "@variable.builtin" }, { "variable.language" }),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.typemod.variable.defaultLibrary", "@module.builtin" },
+      { "support.constant.builtin" }
+    ),
     -- variable }
 
     -- Puncuation {
@@ -377,7 +391,7 @@ M._make_renderers = function()
     -- keyword }
 
     -- meta {
-    _BatThemeScopeRenderer:new({ "@module" }, "meta.path"),
+    _BatThemeScopeRenderer:new({ "@lsp.type.namespace", "@module" }, "meta.path"),
     -- meta }
 
     -- markup {

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -696,6 +696,17 @@ M.setup = function()
       end)
     end,
   })
+
+  vim.api.nvim_create_autocmd({ "LspTokenUpdate" }, {
+    callback = function(event)
+      vim.schedule(function()
+        local colorname = bat_themes_helper.get_color_name()
+        if str.not_empty(colorname) then
+          M._build_theme(colorname)
+        end
+      end)
+    end,
+  })
 end
 
 return M

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -390,7 +390,6 @@ M._make_renderers = function()
 
     -- keyword {
     _BatThemeScopeRenderer:new({ "@keyword", "Keyword" }, "keyword"),
-    _BatThemeScopeRenderer:new({ "@keyword", "StorageClass" }, "keyword.declaration.variable"),
     _BatThemeScopeRenderer:new({ "@keyword.modifier" }, "storage.modifier"),
     _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
     _BatThemeScopeRenderer:new(
@@ -517,10 +516,7 @@ M._make_renderers = function()
   --   )
   --   table.insert(
   --     SCOPE_RENDERERS,
-  --     _BatThemeScopeRenderer:new(
-  --       { lang .. "Keyword" },
-  --       { "storage.modifier." .. lang, "keyword.declaration." .. lang }
-  --     )
+  --     _BatThemeScopeRenderer:new({ lang .. "Keyword" }, { "keyword.declaration.module." .. lang })
   --   )
   --   table.insert(
   --     SCOPE_RENDERERS,

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -389,7 +389,7 @@ M._make_renderers = function()
     -- Puncuation }
 
     -- keyword {
-    _BatThemeScopeRenderer:new({ "@keyword", "Keyword" }, "keyword"),
+    _BatThemeScopeRenderer:new({ "@lsp.type.keyword", "@keyword", "Keyword" }, "keyword"),
     _BatThemeScopeRenderer:new({ "@keyword.modifier" }, "storage.modifier"),
     _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
     _BatThemeScopeRenderer:new(

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -391,7 +391,7 @@ M._make_renderers = function()
     -- keyword {
     _BatThemeScopeRenderer:new({ "@keyword", "Keyword" }, "keyword"),
     _BatThemeScopeRenderer:new({ "@keyword", "StorageClass" }, "keyword.declaration.variable"),
-    _BatThemeScopeRenderer:new({ "@keyword.modifier", "StorageClass" }, "storage.modifier"),
+    _BatThemeScopeRenderer:new({ "@keyword.modifier" }, "storage.modifier"),
     _BatThemeScopeRenderer:new({ "@keyword.import" }, "keyword.declaration.import"),
     _BatThemeScopeRenderer:new(
       { "@operator", "Operator" },

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -35,7 +35,7 @@ local bat_themes_helper = require("fzfx.helper.bat_themes")
 local M = {}
 
 --- @type boolean?
-M._nvim_treesitter_exists = nil
+-- M._nvim_treesitter_exists = nil
 
 --- @param ind integer
 --- @param fmt string
@@ -153,23 +153,23 @@ end
 function _BatThemeScopeRenderer:new(hls, scope)
   assert(type(hls) == "table")
 
-  local new_hls = {}
-  for _, hl in ipairs(hls) do
-    -- If "nvim-treesitter" doesn't exist, and `hl` is a treesitter hl, skip it.
-    -- Otherwise, add it to `new_hls` list.
-    if not (not M._nvim_treesitter_exists and _is_treesitter_hl(hl)) then
-      table.insert(new_hls, hl)
-    end
-  end
-  -- log.debug(
-  --   string.format(
-  --     "BatThemeScopeRenderer:new-0 - ts_exist:%s,(old)hls:%s,new_hls:%s",
-  --     vim.inspect(M._nvim_treesitter_exists),
-  --     vim.inspect(hls),
-  --     vim.inspect(new_hls)
-  --   )
-  -- )
-  hls = new_hls
+  -- local new_hls = {}
+  -- for _, hl in ipairs(hls) do
+  --   -- If "nvim-treesitter" doesn't exist, and `hl` is a treesitter hl, skip it.
+  --   -- Otherwise, add it to `new_hls` list.
+  --   if not (not M._nvim_treesitter_exists and _is_treesitter_hl(hl)) then
+  --     table.insert(new_hls, hl)
+  --   end
+  -- end
+  -- -- log.debug(
+  -- --   string.format(
+  -- --     "BatThemeScopeRenderer:new-0 - ts_exist:%s,(old)hls:%s,new_hls:%s",
+  -- --     vim.inspect(M._nvim_treesitter_exists),
+  -- --     vim.inspect(hls),
+  -- --     vim.inspect(new_hls)
+  -- --   )
+  -- -- )
+  -- hls = new_hls
 
   local value
   for _, hl in ipairs(hls) do
@@ -275,18 +275,20 @@ M._BatThemeScopeRenderer = _BatThemeScopeRenderer
 --- @return {globals:fzfx._BatThemeGlobalRenderer[],scopes:fzfx._BatThemeScopeRenderer[]}
 M._make_renderers = function()
   -- Detect if "nvim-treesitter" is installed
-  local ok, nvim_ts = pcall(require, "nvim-treesitter")
-  if ok and nvim_ts then
-    M._nvim_treesitter_exists = true
-  else
-    M._nvim_treesitter_exists = false
-  end
+  -- local ok, nvim_ts = pcall(require, "nvim-treesitter")
+  -- if ok and nvim_ts then
+  --   M._nvim_treesitter_exists = true
+  -- else
+  --   M._nvim_treesitter_exists = false
+  -- end
 
   -- Global theme
   local GLOBAL_RENDERERS = {
     _BatThemeGlobalRenderer:new("Normal", "background", "bg"),
     _BatThemeGlobalRenderer:new("Normal", "foreground", "fg"),
     _BatThemeGlobalRenderer:new("NonText", "invisibles", "fg"),
+    -- _BatThemeGlobalRenderer:new("LineNr", "gutter", "fg"),
+    -- _BatThemeGlobalRenderer:new("CursorLineNr", "gutterForeground", "fg"),
     _BatThemeGlobalRenderer:new({ "Visual" }, "lineHighlight", "bg"),
     _BatThemeGlobalRenderer:new({
       "GitSignsAdd",
@@ -364,7 +366,10 @@ M._make_renderers = function()
 
     -- variable {
     _BatThemeScopeRenderer:new({ "@variable" }, "variable.other"),
-    _BatThemeScopeRenderer:new({ "@variable.member" }, { "variable.other.member" }),
+    _BatThemeScopeRenderer:new(
+      { "@lsp.type.property", "@variable.member" },
+      { "variable.other.member" }
+    ),
     _BatThemeScopeRenderer:new(
       { "@lsp.type.parameter", "@variable.parameter" },
       { "variable.parameter" }
@@ -374,6 +379,8 @@ M._make_renderers = function()
       { "@lsp.typemod.variable.defaultLibrary", "@module.builtin" },
       { "support.constant.builtin" }
     ),
+    _BatThemeScopeRenderer:new({ "@lsp.type.property", "@property" }, { "string.unquoted.key" }),
+    _BatThemeScopeRenderer:new({ "@lsp.type.decorator" }, { "variable.annotation" }),
     -- variable }
 
     -- Puncuation {
@@ -408,17 +415,22 @@ M._make_renderers = function()
       { "entity.name.tag.block.any.html", "entity.name.tag.inline.any.html" }
     ),
     _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
+    -- _BatThemeScopeRenderer:new(
+    --   { "@markup.link", "markdownUrl", "markdownLink" },
+    --   "markup.underline.link.markdown"
+    -- ),
+    _BatThemeScopeRenderer:new({ "markdownUrl", "markdownLink" }, "markup.underline.link.markdown"),
+    -- _BatThemeScopeRenderer:new(
+    --   { "@markup.link.label", "markdownLinkText" },
+    --   "meta.link.inline.description.markdown"
+    -- ),
+    _BatThemeScopeRenderer:new({ "markdownLinkText" }, "meta.link.inline.description.markdown"),
+    -- _BatThemeScopeRenderer:new(
+    --   { "@markup.link", "markdownLinkTextDelimiter" },
+    --   { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
+    -- ),
     _BatThemeScopeRenderer:new(
-      { "@markup.link", "markdownUrl", "markdownLink" },
-      "markup.underline.link.markdown"
-    ),
-    -- _BatThemeScopeRenderer:new({ "markdownUrl", "markdownLink" }, "markup.underline.link.markdown"),
-    _BatThemeScopeRenderer:new(
-      { "@markup.link.label", "markdownLinkText" },
-      "meta.link.inline.description.markdown"
-    ),
-    _BatThemeScopeRenderer:new(
-      { "@markup.link", "markdownLinkTextDelimiter" },
+      { "markdownLinkTextDelimiter" },
       { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
     ),
     _BatThemeScopeRenderer:new(
@@ -699,12 +711,12 @@ M.setup = function()
 
   vim.api.nvim_create_autocmd({ "LspTokenUpdate" }, {
     callback = function(event)
-      vim.schedule(function()
+      vim.defer_fn(function()
         local colorname = bat_themes_helper.get_color_name()
         if str.not_empty(colorname) then
           M._build_theme(colorname)
         end
-      end)
+      end, 200)
     end,
   })
 end

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -400,7 +400,8 @@ M._make_renderers = function()
     -- keyword }
 
     -- meta {
-    _BatThemeScopeRenderer:new({ "@lsp.type.namespace", "@module" }, "meta.path"),
+    -- _BatThemeScopeRenderer:new({ "@lsp.type.namespace", "@module" }, "meta.path"),
+    _BatThemeScopeRenderer:new({ "@module" }, { "meta.path", "meta.module" }),
     -- meta }
 
     -- markup {

--- a/lua/fzfx/detail/bat_helpers.lua
+++ b/lua/fzfx/detail/bat_helpers.lua
@@ -35,7 +35,7 @@ local bat_themes_helper = require("fzfx.helper.bat_themes")
 local M = {}
 
 --- @type boolean?
--- M._nvim_treesitter_exists = nil
+M._nvim_treesitter_exists = nil
 
 --- @param ind integer
 --- @param fmt string
@@ -153,23 +153,23 @@ end
 function _BatThemeScopeRenderer:new(hls, scope)
   assert(type(hls) == "table")
 
-  -- local new_hls = {}
-  -- for _, hl in ipairs(hls) do
-  --   -- If "nvim-treesitter" doesn't exist, and `hl` is a treesitter hl, skip it.
-  --   -- Otherwise, add it to `new_hls` list.
-  --   if not (not M._nvim_treesitter_exists and _is_treesitter_hl(hl)) then
-  --     table.insert(new_hls, hl)
-  --   end
-  -- end
-  -- -- log.debug(
-  -- --   string.format(
-  -- --     "BatThemeScopeRenderer:new-0 - ts_exist:%s,(old)hls:%s,new_hls:%s",
-  -- --     vim.inspect(M._nvim_treesitter_exists),
-  -- --     vim.inspect(hls),
-  -- --     vim.inspect(new_hls)
-  -- --   )
-  -- -- )
-  -- hls = new_hls
+  local new_hls = {}
+  for _, hl in ipairs(hls) do
+    -- If "nvim-treesitter" doesn't exist, and `hl` is a treesitter hl, skip it.
+    -- Otherwise, add it to `new_hls` list.
+    if not (not M._nvim_treesitter_exists and _is_treesitter_hl(hl)) then
+      table.insert(new_hls, hl)
+    end
+  end
+  -- log.debug(
+  --   string.format(
+  --     "BatThemeScopeRenderer:new-0 - ts_exist:%s,(old)hls:%s,new_hls:%s",
+  --     vim.inspect(M._nvim_treesitter_exists),
+  --     vim.inspect(hls),
+  --     vim.inspect(new_hls)
+  --   )
+  -- )
+  hls = new_hls
 
   local value
   for _, hl in ipairs(hls) do
@@ -275,12 +275,12 @@ M._BatThemeScopeRenderer = _BatThemeScopeRenderer
 --- @return {globals:fzfx._BatThemeGlobalRenderer[],scopes:fzfx._BatThemeScopeRenderer[]}
 M._make_renderers = function()
   -- Detect if "nvim-treesitter" is installed
-  -- local ok, nvim_ts = pcall(require, "nvim-treesitter")
-  -- if ok and nvim_ts then
-  --   M._nvim_treesitter_exists = true
-  -- else
-  --   M._nvim_treesitter_exists = false
-  -- end
+  local ok, nvim_ts = pcall(require, "nvim-treesitter")
+  if ok and nvim_ts then
+    M._nvim_treesitter_exists = true
+  else
+    M._nvim_treesitter_exists = false
+  end
 
   -- Global theme
   local GLOBAL_RENDERERS = {
@@ -415,24 +415,24 @@ M._make_renderers = function()
       { "entity.name.tag.block.any.html", "entity.name.tag.inline.any.html" }
     ),
     _BatThemeScopeRenderer:new({ "htmlArg" }, "entity.other.attribute-name.html"),
-    -- _BatThemeScopeRenderer:new(
-    --   { "@markup.link", "markdownUrl", "markdownLink" },
-    --   "markup.underline.link.markdown"
-    -- ),
-    _BatThemeScopeRenderer:new({ "markdownUrl", "markdownLink" }, "markup.underline.link.markdown"),
-    -- _BatThemeScopeRenderer:new(
-    --   { "@markup.link.label", "markdownLinkText" },
-    --   "meta.link.inline.description.markdown"
-    -- ),
-    _BatThemeScopeRenderer:new({ "markdownLinkText" }, "meta.link.inline.description.markdown"),
-    -- _BatThemeScopeRenderer:new(
-    --   { "@markup.link", "markdownLinkTextDelimiter" },
-    --   { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
-    -- ),
     _BatThemeScopeRenderer:new(
-      { "markdownLinkTextDelimiter" },
+      { "@markup.link", "markdownUrl", "markdownLink" },
+      "markup.underline.link.markdown"
+    ),
+    -- _BatThemeScopeRenderer:new({ "markdownUrl", "markdownLink" }, "markup.underline.link.markdown"),
+    _BatThemeScopeRenderer:new(
+      { "@markup.link.label", "markdownLinkText" },
+      "meta.link.inline.description.markdown"
+    ),
+    -- _BatThemeScopeRenderer:new({ "markdownLinkText" }, "meta.link.inline.description.markdown"),
+    _BatThemeScopeRenderer:new(
+      { "@markup.link", "markdownLinkTextDelimiter" },
       { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
     ),
+    -- _BatThemeScopeRenderer:new(
+    --   { "markdownLinkTextDelimiter" },
+    --   { "puncuation.definition.link.begin.markdown", "puncuation.definition.link.end.markdown" }
+    -- ),
     _BatThemeScopeRenderer:new(
       { "markdownBlockquote" },
       { "puncuation.definition.blockquote.markdown" }

--- a/spec/detail/bat_helpers_spec.lua
+++ b/spec/detail/bat_helpers_spec.lua
@@ -106,14 +106,6 @@ describe("detail.bat_helpers", function()
     end)
   end)
 
-  describe("[_BatThemeRenderer]", function()
-    it("test", function()
-      local r = bat_helpers._BatThemeRenderer:new()
-      local actual = r:render(vim.g.colors_name)
-      assert_true(tbl.tbl_not_empty(actual))
-    end)
-  end)
-
   describe("[_build_theme]", function()
     it("test", function()
       if consts.HAS_BAT then


### PR DESCRIPTION
Related discussion: https://github.com/linrongbin16/fzfx.nvim/discussions/770

Once the bat theme auto-generation (based on Regex + TreeSitter + LSP token) is quite compatbile with nvim colorscheme, I will fully drop the "buffer previewer" feature, thus reduce the maintainance and future development effort to make this plugin neat and clean.

I will bump this plugin to v8.x to announce the break changes.