### PR TITLE
feat(previewer)!: directly "open" a file to preview in buffer to reduce dev burden

### DIFF
--- a/lua/fzfx/detail/popup.lua
+++ b/lua/fzfx/detail/popup.lua
@@ -12,8 +12,10 @@ local popup_helpers = require("fzfx.detail.popup.popup_helpers")
 local fzf_popup_window = require("fzfx.detail.popup.fzf_popup_window")
 local buffer_popup_window = require("fzfx.detail.popup.buffer_popup_window")
 
+local M = {}
+
 --- @type table<integer, fzfx.PopupWindow>
-local PopupWindowInstances = {}
+M._PopupWindowInstances = {}
 
 --- @class fzfx.PopupWindow
 --- @field instance fzfx.FzfPopupWindow|fzfx.BufferPopupWindow
@@ -43,7 +45,7 @@ function PopupWindow:new(win_opts, window_type, buffer_previewer_opts)
   setmetatable(o, self)
   self.__index = self
 
-  PopupWindowInstances[instance:handle()] = o
+  M._PopupWindowInstances[instance:handle()] = o
 
   return o
 end
@@ -52,7 +54,7 @@ function PopupWindow:close()
   -- log.debug("|fzfx.popup - Popup:close| self:%s", vim.inspect(self))
 
   if self.instance then
-    PopupWindowInstances[self.instance:handle()] = nil
+    M._PopupWindowInstances[self.instance:handle()] = nil
     self.instance:close()
     self.instance = nil
   end
@@ -318,17 +320,17 @@ end
 
 --- @return table<integer, fzfx.PopupWindow>
 local function _get_instances()
-  return PopupWindowInstances
+  return M._PopupWindowInstances
 end
 
 local function _clear_instances()
-  PopupWindowInstances = {}
+  M._PopupWindowInstances = {}
 end
 
 --- @return integer
 local function _count_instances()
   local n = 0
-  for _, popup_win in pairs(PopupWindowInstances) do
+  for _, popup_win in pairs(M._PopupWindowInstances) do
     if popup_win then
       n = n + 1
     end
@@ -337,7 +339,7 @@ local function _count_instances()
 end
 
 local function _resize_instances()
-  for _, popup_win in pairs(PopupWindowInstances) do
+  for _, popup_win in pairs(M._PopupWindowInstances) do
     if popup_win then
       popup_win:resize()
     end
@@ -357,19 +359,17 @@ local function setup()
   end
 end
 
-local M = {
-  _get_instances = _get_instances,
-  _clear_instances = _clear_instances,
-  _count_instances = _count_instances,
-  _resize_instances = _resize_instances,
+M._get_instances = _get_instances
+M._clear_instances = _clear_instances
+M._count_instances = _count_instances
+M._resize_instances = _resize_instances
 
-  _make_expect_keys = _make_expect_keys,
-  _merge_fzf_actions = _merge_fzf_actions,
-  _make_fzf_command = _make_fzf_command,
+M._make_expect_keys = _make_expect_keys
+M._merge_fzf_actions = _merge_fzf_actions
+M._make_fzf_command = _make_fzf_command
 
-  PopupWindow = PopupWindow,
-  Popup = Popup,
-  setup = setup,
-}
+M.PopupWindow = PopupWindow
+M.Popup = Popup
+M.setup = setup
 
 return M

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -229,7 +229,6 @@ local function _set_provider_buf_opts(bufnr)
   vim.api.nvim_set_option_value("filetype", "fzf", { buf = bufnr })
 end
 
-
 --- @param winnr integer
 --- @param current_winnr integer
 local function _set_provider_win_opts(winnr, current_winnr)

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -22,10 +22,10 @@ end
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_cursor_opts = function(
-  win_opts,
-  buffer_previewer_opts,
-  relative_winnr,
-  relative_win_first_line
+    win_opts,
+    buffer_previewer_opts,
+    relative_winnr,
+    relative_win_first_line
 )
   win_opts = vim.deepcopy(win_opts)
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
@@ -39,9 +39,9 @@ M._make_cursor_opts = function(
   )
   log.debug("|_make_cursor_opts| layout:" .. vim.inspect(layout))
   local provider_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
   local previewer_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_preview_window_opts.border]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 
   local result = {
     anchor = "NW",
@@ -64,6 +64,7 @@ M._make_cursor_opts = function(
     style = popup_helpers.FLOAT_WIN_STYLE,
     border = provider_border,
     zindex = popup_helpers.FLOAT_WIN_ZINDEX,
+    win = relative_winnr
   }
   result.previewer = {
     anchor = "NW",
@@ -75,13 +76,10 @@ M._make_cursor_opts = function(
     style = popup_helpers.FLOAT_WIN_STYLE,
     border = previewer_border,
     zindex = popup_helpers.FLOAT_WIN_ZINDEX,
+    win = relative_winnr,
     focusable = false,
   }
 
-  if relative == "win" then
-    result.provider.win = relative_winnr
-    result.previewer.win = relative_winnr
-  end
   log.debug("|_make_cursor_opts| result:" .. vim.inspect(result))
   return result
 end
@@ -92,10 +90,10 @@ end
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_center_opts = function(
-  win_opts,
-  buffer_previewer_opts,
-  relative_winnr,
-  relative_win_first_line
+    win_opts,
+    buffer_previewer_opts,
+    relative_winnr,
+    relative_win_first_line
 )
   win_opts = vim.deepcopy(win_opts)
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
@@ -109,9 +107,9 @@ M._make_center_opts = function(
     buffer_previewer_opts.fzf_preview_window_opts
   )
   local provider_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
   local previewer_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_preview_window_opts.border]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 
   local result = {
     anchor = "NW",
@@ -177,7 +175,7 @@ M.make_opts = function(win_opts, buffer_previewer_opts, relative_winnr, relative
         relative_winnr,
         relative_win_first_line
       )
-    or M._make_center_opts(win_opts, buffer_previewer_opts, relative_winnr, relative_win_first_line)
+      or M._make_center_opts(win_opts, buffer_previewer_opts, relative_winnr, relative_win_first_line)
 end
 
 -- BufferPopupWindow {
@@ -261,7 +259,7 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
   end
 
   local win_confs =
-    M.make_opts(win_opts, buffer_previewer_opts, current_winnr, current_win_first_line)
+      M.make_opts(win_opts, buffer_previewer_opts, current_winnr, current_win_first_line)
 
   local provider_win_confs
   local previewer_win_confs
@@ -417,9 +415,9 @@ function BufferPopupWindow:previewer_is_valid()
     return type(self.previewer_winnr) == "number" and type(self.previewer_bufnr) == "number"
   else
     return type(self.previewer_winnr) == "number"
-      and vim.api.nvim_win_is_valid(self.previewer_winnr)
-      and type(self.previewer_bufnr) == "number"
-      and vim.api.nvim_buf_is_valid(self.previewer_bufnr)
+        and vim.api.nvim_win_is_valid(self.previewer_winnr)
+        and type(self.previewer_bufnr) == "number"
+        and vim.api.nvim_buf_is_valid(self.previewer_bufnr)
   end
 end
 
@@ -428,9 +426,9 @@ function BufferPopupWindow:provider_is_valid()
     return type(self.provider_winnr) == "number" and type(self.provider_bufnr) == "number"
   else
     return type(self.provider_winnr) == "number"
-      and vim.api.nvim_win_is_valid(self.provider_winnr)
-      and type(self.provider_bufnr) == "number"
-      and vim.api.nvim_buf_is_valid(self.provider_bufnr)
+        and vim.api.nvim_win_is_valid(self.provider_winnr)
+        and type(self.provider_bufnr) == "number"
+        and vim.api.nvim_buf_is_valid(self.provider_bufnr)
   end
 end
 
@@ -456,7 +454,7 @@ function BufferPopupWindow:_make_view(preview_file_content)
   local win_height = vim.api.nvim_win_get_height(self.previewer_winnr)
   local view = center_line
       and buffer_popup_window_helpers.make_center_view(lines_count, win_height, center_line)
-    or buffer_popup_window_helpers.make_top_view(lines_count, win_height)
+      or buffer_popup_window_helpers.make_top_view(lines_count, win_height)
   -- log.debug(
   --   string.format(
   --     "|BufferPopupWindow:_make_view| center_line:%s, lines_count:%s, win_height:%s, view:%s",
@@ -921,7 +919,7 @@ function BufferPopupWindow:show_preview()
       local last_content = self._saved_previewing_file_content_job
       local last_view = self._saved_previewing_file_content_view ~= nil
           and self._saved_previewing_file_content_view
-        or self:_make_view(last_content)
+          or self:_make_view(last_content)
       self:preview_file_contents(last_content, last_view)
     end
   end)
@@ -1005,11 +1003,11 @@ function BufferPopupWindow:scroll_by(percent, up)
   local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
 
   local TOP_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "top")
-    or vim.fn.line("w0", self.previewer_winnr)
+      or vim.fn.line("w0", self.previewer_winnr)
   local BOTTOM_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "bottom")
-    or math.min(TOP_LINE + WIN_HEIGHT, LINES_COUNT)
+      or math.min(TOP_LINE + WIN_HEIGHT, LINES_COUNT)
   local CENTER_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "center")
-    or math.ceil((TOP_LINE + BOTTOM_LINE) / 2)
+      or math.ceil((TOP_LINE + BOTTOM_LINE) / 2)
   local HIGHLIGHT_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "highlight")
 
   local shift_lines = math.max(math.floor(WIN_HEIGHT / 100 * percent), 0)
@@ -1018,7 +1016,7 @@ function BufferPopupWindow:scroll_by(percent, up)
   end
   local first_line = num.bound(TOP_LINE + shift_lines, 1, LINES_COUNT)
   local last_line =
-    buffer_popup_window_helpers.calculate_bottom_by_top(first_line, LINES_COUNT, WIN_HEIGHT)
+      buffer_popup_window_helpers.calculate_bottom_by_top(first_line, LINES_COUNT, WIN_HEIGHT)
   -- log.debug(
   --   "|BufferPopupWindow:scroll_by|-1 percent:%s, up:%s, LINES/HEIGHT/SHIFT:%s/%s/%s, top/bottom/center:%s/%s/%s, first/last:%s/%s",
   --   vim.inspect(percent),

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -99,6 +99,7 @@ M._make_center_opts = function(
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
 
   win_opts.relative = win_opts.relative or "editor"
+  assert(win_opts.relative == "editor" or win_opts.relative == "win")
 
   local layout = popup_helpers.make_center_layout(
     relative_winnr,

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -203,16 +203,15 @@ end
 local BufferPopupWindow = {}
 
 --- @param bufnr integer
-local function _set_default_buf_options(bufnr)
+local function _set_previewer_buf_opts(bufnr)
   vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = bufnr })
   vim.api.nvim_set_option_value("buflisted", false, { buf = bufnr })
-  vim.api.nvim_set_option_value("filetype", "fzf", { buf = bufnr })
 end
 
 --- @param winnr integer
 --- @param wrap boolean
 --- @param current_winnr integer
-local function _set_default_previewer_win_options(winnr, wrap, current_winnr)
+local function _set_previewer_win_opts(winnr, wrap, current_winnr)
   local number_opt = vim.api.nvim_get_option_value("number", { win = current_winnr })
   vim.api.nvim_set_option_value("number", number_opt, { win = winnr })
   vim.api.nvim_set_option_value("spell", false, { win = winnr })
@@ -223,9 +222,17 @@ local function _set_default_previewer_win_options(winnr, wrap, current_winnr)
   vim.api.nvim_set_option_value("wrap", wrap, { win = winnr })
 end
 
+--- @param bufnr integer
+local function _set_provider_buf_opts(bufnr)
+  vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = bufnr })
+  vim.api.nvim_set_option_value("buflisted", false, { buf = bufnr })
+  vim.api.nvim_set_option_value("filetype", "fzf", { buf = bufnr })
+end
+
+
 --- @param winnr integer
 --- @param current_winnr integer
-local function _set_default_provider_win_options(winnr, current_winnr)
+local function _set_provider_win_opts(winnr, current_winnr)
   vim.api.nvim_set_option_value("number", false, { win = winnr })
   vim.api.nvim_set_option_value("spell", false, { win = winnr })
   vim.api.nvim_set_option_value("winhighlight", "Pmenu:,Normal:Normal", { win = winnr })
@@ -246,17 +253,15 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
   -- save current window context
   local window_opts_context = popup_helpers.WindowOptsContext:save()
 
-  --- @type integer
-  local provider_bufnr = vim.api.nvim_create_buf(false, true)
+  local provider_bufnr = vim.api.nvim_create_buf(false, true) --[[@as integer]]
   log.ensure(provider_bufnr > 0, "failed to create provider buf")
-  _set_default_buf_options(provider_bufnr)
+  _set_provider_buf_opts(provider_bufnr)
 
-  --- @type integer
   local previewer_bufnr
   if not buffer_previewer_opts.fzf_preview_window_opts.hidden then
-    previewer_bufnr = vim.api.nvim_create_buf(false, true)
+    previewer_bufnr = vim.api.nvim_create_buf(false, true) --[[@as integer]]
     log.ensure(previewer_bufnr > 0, "failed to create previewer buf")
-    _set_default_buf_options(previewer_bufnr)
+    _set_previewer_buf_opts(previewer_bufnr)
   end
 
   local win_confs =
@@ -275,15 +280,15 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
 
   local previewer_winnr
   if previewer_bufnr then
-    previewer_winnr = vim.api.nvim_open_win(previewer_bufnr, true, previewer_win_confs)
+    previewer_winnr = vim.api.nvim_open_win(previewer_bufnr, true, previewer_win_confs) --[[@as integer]]
     log.ensure(previewer_winnr > 0, "failed to create previewer win")
     local wrap = buffer_previewer_opts.fzf_preview_window_opts.wrap
-    _set_default_previewer_win_options(previewer_winnr, wrap, current_winnr)
+    _set_previewer_win_opts(previewer_winnr, wrap, current_winnr)
   end
 
   local provider_winnr = vim.api.nvim_open_win(provider_bufnr, true, provider_win_confs)
   log.ensure(provider_winnr > 0, "failed to create provider win")
-  _set_default_provider_win_options(provider_winnr, current_winnr)
+  _set_provider_win_opts(provider_winnr, current_winnr)
 
   -- set cursor at provider window
   vim.api.nvim_set_current_win(provider_winnr)
@@ -374,7 +379,7 @@ function BufferPopupWindow:resize()
       self.provider_winnr,
       vim.tbl_deep_extend("force", old_win_confs, new_win_confs)
     )
-    _set_default_provider_win_options(self.provider_winnr, self._saved_current_winnr)
+    _set_provider_win_opts(self.provider_winnr, self._saved_current_winnr)
   else
     local old_provider_win_confs = vim.api.nvim_win_get_config(self.provider_winnr)
     local win_confs = M.make_opts(
@@ -387,7 +392,7 @@ function BufferPopupWindow:resize()
       self.provider_winnr,
       vim.tbl_deep_extend("force", old_provider_win_confs, win_confs.provider or {})
     )
-    _set_default_provider_win_options(self.provider_winnr, self._saved_current_winnr)
+    _set_provider_win_opts(self.provider_winnr, self._saved_current_winnr)
 
     if self:previewer_is_valid() then
       local old_previewer_win_confs = vim.api.nvim_win_get_config(self.previewer_winnr)
@@ -397,7 +402,7 @@ function BufferPopupWindow:resize()
       )
 
       local wrap = self._saved_buffer_previewer_opts.fzf_preview_window_opts.wrap
-      _set_default_previewer_win_options(self.previewer_winnr, wrap, self._saved_current_winnr)
+      _set_previewer_win_opts(self.previewer_winnr, wrap, self._saved_current_winnr)
     end
   end
 
@@ -625,7 +630,7 @@ function BufferPopupWindow:preview_file_contents(file_content, content_view, on_
       }
       vim.api.nvim_win_set_config(self.previewer_winnr, title_opts)
       local wrap = self._saved_buffer_previewer_opts.fzf_preview_window_opts.wrap
-      _set_default_previewer_win_options(self.previewer_winnr, wrap, self._saved_current_winnr)
+      _set_previewer_win_opts(self.previewer_winnr, wrap, self._saved_current_winnr)
     end
 
     if str.not_empty(file_content.previewer_label_result) then
@@ -903,10 +908,10 @@ function BufferPopupWindow:show_preview()
   )
 
   self.previewer_bufnr = vim.api.nvim_create_buf(false, true)
-  _set_default_buf_options(self.previewer_bufnr)
+  _set_previewer_buf_opts(self.previewer_bufnr)
   self.previewer_winnr = vim.api.nvim_open_win(self.previewer_bufnr, true, win_confs.previewer)
   local wrap = self._saved_buffer_previewer_opts.fzf_preview_window_opts.wrap
-  _set_default_previewer_win_options(self.previewer_winnr, wrap, self._saved_current_winnr)
+  _set_previewer_win_opts(self.previewer_winnr, wrap, self._saved_current_winnr)
   vim.api.nvim_set_current_win(self.provider_winnr)
 
   self:resize()

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -22,10 +22,10 @@ end
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_cursor_opts = function(
-  win_opts,
-  buffer_previewer_opts,
-  relative_winnr,
-  relative_win_first_line
+    win_opts,
+    buffer_previewer_opts,
+    relative_winnr,
+    relative_win_first_line
 )
   win_opts = vim.deepcopy(win_opts)
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
@@ -39,9 +39,9 @@ M._make_cursor_opts = function(
   )
   log.debug("|_make_cursor_opts| layout:" .. vim.inspect(layout))
   local provider_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
   local previewer_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_preview_window_opts.border]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 
   local result = {
     anchor = "NW",
@@ -90,10 +90,10 @@ end
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_center_opts = function(
-  win_opts,
-  buffer_previewer_opts,
-  relative_winnr,
-  relative_win_first_line
+    win_opts,
+    buffer_previewer_opts,
+    relative_winnr,
+    relative_win_first_line
 )
   win_opts = vim.deepcopy(win_opts)
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
@@ -108,9 +108,9 @@ M._make_center_opts = function(
     buffer_previewer_opts.fzf_preview_window_opts
   )
   local provider_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
   local previewer_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_preview_window_opts.border]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 
   local result = {
     anchor = "NW",
@@ -176,7 +176,7 @@ M.make_opts = function(win_opts, buffer_previewer_opts, relative_winnr, relative
         relative_winnr,
         relative_win_first_line
       )
-    or M._make_center_opts(win_opts, buffer_previewer_opts, relative_winnr, relative_win_first_line)
+      or M._make_center_opts(win_opts, buffer_previewer_opts, relative_winnr, relative_win_first_line)
 end
 
 -- BufferPopupWindow {
@@ -260,7 +260,7 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
   end
 
   local win_confs =
-    M.make_opts(win_opts, buffer_previewer_opts, current_winnr, current_win_first_line)
+      M.make_opts(win_opts, buffer_previewer_opts, current_winnr, current_win_first_line)
 
   local provider_win_confs
   local previewer_win_confs
@@ -416,9 +416,9 @@ function BufferPopupWindow:previewer_is_valid()
     return type(self.previewer_winnr) == "number" and type(self.previewer_bufnr) == "number"
   else
     return type(self.previewer_winnr) == "number"
-      and vim.api.nvim_win_is_valid(self.previewer_winnr)
-      and type(self.previewer_bufnr) == "number"
-      and vim.api.nvim_buf_is_valid(self.previewer_bufnr)
+        and vim.api.nvim_win_is_valid(self.previewer_winnr)
+        and type(self.previewer_bufnr) == "number"
+        and vim.api.nvim_buf_is_valid(self.previewer_bufnr)
   end
 end
 
@@ -427,9 +427,9 @@ function BufferPopupWindow:provider_is_valid()
     return type(self.provider_winnr) == "number" and type(self.provider_bufnr) == "number"
   else
     return type(self.provider_winnr) == "number"
-      and vim.api.nvim_win_is_valid(self.provider_winnr)
-      and type(self.provider_bufnr) == "number"
-      and vim.api.nvim_buf_is_valid(self.provider_bufnr)
+        and vim.api.nvim_win_is_valid(self.provider_winnr)
+        and type(self.provider_bufnr) == "number"
+        and vim.api.nvim_buf_is_valid(self.provider_bufnr)
   end
 end
 
@@ -455,7 +455,7 @@ function BufferPopupWindow:_make_view(preview_file_content)
   local win_height = vim.api.nvim_win_get_height(self.previewer_winnr)
   local view = center_line
       and buffer_popup_window_helpers.make_center_view(lines_count, win_height, center_line)
-    or buffer_popup_window_helpers.make_top_view(lines_count, win_height)
+      or buffer_popup_window_helpers.make_top_view(lines_count, win_height)
   -- log.debug(
   --   string.format(
   --     "|BufferPopupWindow:_make_view| center_line:%s, lines_count:%s, win_height:%s, view:%s",
@@ -920,7 +920,7 @@ function BufferPopupWindow:show_preview()
       local last_content = self._saved_previewing_file_content_job
       local last_view = self._saved_previewing_file_content_view ~= nil
           and self._saved_previewing_file_content_view
-        or self:_make_view(last_content)
+          or self:_make_view(last_content)
       self:preview_file_contents(last_content, last_view)
     end
   end)
@@ -1004,11 +1004,11 @@ function BufferPopupWindow:scroll_by(percent, up)
   local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
 
   local TOP_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "top")
-    or vim.fn.line("w0", self.previewer_winnr)
+      or vim.fn.line("w0", self.previewer_winnr)
   local BOTTOM_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "bottom")
-    or math.min(TOP_LINE + WIN_HEIGHT, LINES_COUNT)
+      or math.min(TOP_LINE + WIN_HEIGHT, LINES_COUNT)
   local CENTER_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "center")
-    or math.ceil((TOP_LINE + BOTTOM_LINE) / 2)
+      or math.ceil((TOP_LINE + BOTTOM_LINE) / 2)
   local HIGHLIGHT_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "highlight")
 
   local shift_lines = math.max(math.floor(WIN_HEIGHT / 100 * percent), 0)
@@ -1017,7 +1017,7 @@ function BufferPopupWindow:scroll_by(percent, up)
   end
   local first_line = num.bound(TOP_LINE + shift_lines, 1, LINES_COUNT)
   local last_line =
-    buffer_popup_window_helpers.calculate_bottom_by_top(first_line, LINES_COUNT, WIN_HEIGHT)
+      buffer_popup_window_helpers.calculate_bottom_by_top(first_line, LINES_COUNT, WIN_HEIGHT)
   -- log.debug(
   --   "|BufferPopupWindow:scroll_by|-1 percent:%s, up:%s, LINES/HEIGHT/SHIFT:%s/%s/%s, top/bottom/center:%s/%s/%s, first/last:%s/%s",
   --   vim.inspect(percent),

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -501,11 +501,47 @@ function BufferPopupWindow:preview_file(job_id, previewer_result, previewer_labe
   if type(previewer_result.lineno) == 'number' and previewer_result.lineno > 0 then
     vim.api.nvim_win_call(self.previewer_winnr, function()
       if type(previewer_result.lineno) == 'number' and previewer_result.lineno > 0 then
+        -- Set the interested `lineno` to the center of the preview window.
+        -- Just like executing `normal! zz`.
         local height = vim.api.nvim_win_get_height(self.previewer_winnr)
         local topline = math.max(1, previewer_result.lineno - math.floor(height / 2))
         vim.api.nvim_command(string.format([[call winrestview({'topline':%d})]], topline))
         -- vim.api.nvim_win_set_cursor(self.previewer_winnr, { previewer_result.lineno, 0 })
         -- vim.cmd.execute("normal! zz")
+
+        -- -- Set the `lineno` highlight to `CursorLineNr`
+        -- local extmark_ns = vim.api.nvim_create_namespace(string.format("fzfx-buffer-previewer-%s", tostring(job_id)))
+        -- local old_extmarks = vim.api.nvim_buf_get_extmarks(
+        --   self.previewer_bufnr,
+        --   extmark_ns,
+        --   { 0, 0 },
+        --   { -1, -1 },
+        --   {}
+        -- )
+        -- if tbl.list_not_empty(old_extmarks) then
+        --   for i, m in ipairs(old_extmarks) do
+        --     pcall(vim.api.nvim_buf_del_extmark, self.previewer_bufnr, extmark_ns, m[1])
+        --   end
+        -- end
+        --
+        -- local opts = {
+        --   end_row = end_row,
+        --   end_col = end_col,
+        --   strict = false,
+        --   sign_hl_group = "CursorLineSign",
+        --   number_hl_group = "CursorLineNr",
+        --   line_hl_group = "Visual",
+        -- }
+        --
+        -- ---@diagnostic disable-next-line: unused-local
+        -- local extmark_ok, extmark_result = pcall(
+        --   vim.api.nvim_buf_set_extmark,
+        --   self.previewer_bufnr,
+        --   extmark_ns,
+        --   start_row,
+        --   start_col,
+        --   opts
+        -- )
       end
     end)
   end

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -336,6 +336,7 @@ function BufferPopupWindow:close()
   --   )
   -- )
 
+  -- Clean up windows.
   if type(self.provider_winnr) == "number" and vim.api.nvim_win_is_valid(self.provider_winnr) then
     vim.api.nvim_win_close(self.provider_winnr, true)
     self.provider_winnr = nil
@@ -345,6 +346,7 @@ function BufferPopupWindow:close()
     self.previewer_winnr = nil
   end
 
+  -- Clean up buffers.
   if type(self.provider_bufnr) == 'number' and vim.api.nvim_buf_is_valid(self.provider_bufnr) then
     vim.api.nvim_buf_delete(self.provider_bufnr)
     self.provider_bufnr = nil
@@ -353,6 +355,8 @@ function BufferPopupWindow:close()
     vim.api.nvim_buf_delete(self.previewer_bufnr)
     self.previewer_bufnr = nil
   end
+
+  -- Restore window options.
   self.window_opts_context:restore()
 end
 

--- a/lua/fzfx/detail/popup/buffer_popup_window.lua
+++ b/lua/fzfx/detail/popup/buffer_popup_window.lua
@@ -22,10 +22,10 @@ end
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_cursor_opts = function(
-  win_opts,
-  buffer_previewer_opts,
-  relative_winnr,
-  relative_win_first_line
+    win_opts,
+    buffer_previewer_opts,
+    relative_winnr,
+    relative_win_first_line
 )
   win_opts = vim.deepcopy(win_opts)
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
@@ -39,9 +39,9 @@ M._make_cursor_opts = function(
   )
   log.debug("|_make_cursor_opts| layout:" .. vim.inspect(layout))
   local provider_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
   local previewer_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_preview_window_opts.border]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 
   local result = {
     anchor = "NW",
@@ -90,10 +90,10 @@ end
 --- @param relative_win_first_line integer
 --- @return {provider:fzfx.NvimFloatWinOpts,previewer:fzfx.NvimFloatWinOpts}
 M._make_center_opts = function(
-  win_opts,
-  buffer_previewer_opts,
-  relative_winnr,
-  relative_win_first_line
+    win_opts,
+    buffer_previewer_opts,
+    relative_winnr,
+    relative_win_first_line
 )
   win_opts = vim.deepcopy(win_opts)
   buffer_previewer_opts = vim.deepcopy(buffer_previewer_opts)
@@ -108,9 +108,9 @@ M._make_center_opts = function(
     buffer_previewer_opts.fzf_preview_window_opts
   )
   local provider_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_border_opts]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
   local previewer_border = fzf_helpers.FZF_BORDER_OPTS_MAP[buffer_previewer_opts.fzf_preview_window_opts.border]
-    or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
+      or fzf_helpers.FZF_DEFAULT_BORDER_OPTS
 
   local result = {
     anchor = "NW",
@@ -176,7 +176,7 @@ M.make_opts = function(win_opts, buffer_previewer_opts, relative_winnr, relative
         relative_winnr,
         relative_win_first_line
       )
-    or M._make_center_opts(win_opts, buffer_previewer_opts, relative_winnr, relative_win_first_line)
+      or M._make_center_opts(win_opts, buffer_previewer_opts, relative_winnr, relative_win_first_line)
 end
 
 -- BufferPopupWindow {
@@ -264,7 +264,7 @@ function BufferPopupWindow:new(win_opts, buffer_previewer_opts)
   end
 
   local win_confs =
-    M.make_opts(win_opts, buffer_previewer_opts, current_winnr, current_win_first_line)
+      M.make_opts(win_opts, buffer_previewer_opts, current_winnr, current_win_first_line)
 
   local provider_win_confs
   local previewer_win_confs
@@ -345,8 +345,14 @@ function BufferPopupWindow:close()
     self.previewer_winnr = nil
   end
 
-  self.provider_bufnr = nil
-  self.previewer_bufnr = nil
+  if type(self.provider_bufnr) == 'number' and vim.api.nvim_buf_is_valid(self.provider_bufnr) then
+    vim.api.nvim_buf_delete(self.provider_bufnr)
+    self.provider_bufnr = nil
+  end
+  if type(self.previewer_bufnr) == 'number' and vim.api.nvim_buf_is_valid(self.previewer_bufnr) then
+    vim.api.nvim_buf_delete(self.previewer_bufnr)
+    self.previewer_bufnr = nil
+  end
   self.window_opts_context:restore()
 end
 
@@ -420,9 +426,9 @@ function BufferPopupWindow:previewer_is_valid()
     return type(self.previewer_winnr) == "number" and type(self.previewer_bufnr) == "number"
   else
     return type(self.previewer_winnr) == "number"
-      and vim.api.nvim_win_is_valid(self.previewer_winnr)
-      and type(self.previewer_bufnr) == "number"
-      and vim.api.nvim_buf_is_valid(self.previewer_bufnr)
+        and vim.api.nvim_win_is_valid(self.previewer_winnr)
+        and type(self.previewer_bufnr) == "number"
+        and vim.api.nvim_buf_is_valid(self.previewer_bufnr)
   end
 end
 
@@ -431,9 +437,9 @@ function BufferPopupWindow:provider_is_valid()
     return type(self.provider_winnr) == "number" and type(self.provider_bufnr) == "number"
   else
     return type(self.provider_winnr) == "number"
-      and vim.api.nvim_win_is_valid(self.provider_winnr)
-      and type(self.provider_bufnr) == "number"
-      and vim.api.nvim_buf_is_valid(self.provider_bufnr)
+        and vim.api.nvim_win_is_valid(self.provider_winnr)
+        and type(self.provider_bufnr) == "number"
+        and vim.api.nvim_buf_is_valid(self.provider_bufnr)
   end
 end
 
@@ -459,7 +465,7 @@ function BufferPopupWindow:_make_view(preview_file_content)
   local win_height = vim.api.nvim_win_get_height(self.previewer_winnr)
   local view = center_line
       and buffer_popup_window_helpers.make_center_view(lines_count, win_height, center_line)
-    or buffer_popup_window_helpers.make_top_view(lines_count, win_height)
+      or buffer_popup_window_helpers.make_top_view(lines_count, win_height)
   -- log.debug(
   --   string.format(
   --     "|BufferPopupWindow:_make_view| center_line:%s, lines_count:%s, win_height:%s, view:%s",
@@ -924,7 +930,7 @@ function BufferPopupWindow:show_preview()
       local last_content = self._saved_previewing_file_content_job
       local last_view = self._saved_previewing_file_content_view ~= nil
           and self._saved_previewing_file_content_view
-        or self:_make_view(last_content)
+          or self:_make_view(last_content)
       self:preview_file_contents(last_content, last_view)
     end
   end)
@@ -1008,11 +1014,11 @@ function BufferPopupWindow:scroll_by(percent, up)
   local WIN_HEIGHT = vim.api.nvim_win_get_height(self.previewer_winnr)
 
   local TOP_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "top")
-    or vim.fn.line("w0", self.previewer_winnr)
+      or vim.fn.line("w0", self.previewer_winnr)
   local BOTTOM_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "bottom")
-    or math.min(TOP_LINE + WIN_HEIGHT, LINES_COUNT)
+      or math.min(TOP_LINE + WIN_HEIGHT, LINES_COUNT)
   local CENTER_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "center")
-    or math.ceil((TOP_LINE + BOTTOM_LINE) / 2)
+      or math.ceil((TOP_LINE + BOTTOM_LINE) / 2)
   local HIGHLIGHT_LINE = tbl.tbl_get(self._saved_previewing_file_content_view, "highlight")
 
   local shift_lines = math.max(math.floor(WIN_HEIGHT / 100 * percent), 0)
@@ -1021,7 +1027,7 @@ function BufferPopupWindow:scroll_by(percent, up)
   end
   local first_line = num.bound(TOP_LINE + shift_lines, 1, LINES_COUNT)
   local last_line =
-    buffer_popup_window_helpers.calculate_bottom_by_top(first_line, LINES_COUNT, WIN_HEIGHT)
+      buffer_popup_window_helpers.calculate_bottom_by_top(first_line, LINES_COUNT, WIN_HEIGHT)
   -- log.debug(
   --   "|BufferPopupWindow:scroll_by|-1 percent:%s, up:%s, LINES/HEIGHT/SHIFT:%s/%s/%s, top/bottom/center:%s/%s/%s, first/last:%s/%s",
   --   vim.inspect(percent),


### PR DESCRIPTION
This RP is the going to try a new solution: simlifies the buffer previewer implementation.

In previous work, I did something "partially rendering" + coroutine schedule in the preview buffer:

1. The preview buffer renderings every X lines (say, 50 lines) each time. Note: This job is actually heavy CPU calculation and if it renders a lot, it can really block the whole nvim editor.
2. After X lines rendering done, it schedules a job and wait for next coroutine scheduled after 10 milliseconds. Thus the preview buffer gives the single-thread back to user to not block the editor.
3. It only renders what need to show in the window. For example when the previewer only needs to show the `60~90` lines, but the file has actually 1000+ lines. And the preview buffer actually only renders the `60~90` lines, it skips the above lines before 59 and the bottom lines after 91.

But this introduces two issues:
1. It is quite hard to maintain if we want to add extend it. Now I want to support running shell commands inside the preview buffer, i.e. the buffer will become a terminal buffer and run some shell commands for previewing (This is to replace the fzf's native preview window as it allow user to run a shell command to generate the preview contents).
2. Since the rendering is only a small part in the real file, the highlighting system could generate wrong color. For example treesitter cannot correctly parse the buffer content, and leads to wrong highlighting color.

This PR will simplifies the preview buffer, it just simply opens the file just like running the `:edit` command in the buffer. It will slow down the previewing, but unblock new features implementation.