### PR TITLE
feat(context): add "context_shutdown" hook to recycle resources on search complete

### DIFF
--- a/docs/GenericSchema.md
+++ b/docs/GenericSchema.md
@@ -54,7 +54,7 @@ So we need a way to store the **_current_** buffer/window info in somewhere, so 
 
 A **shutdown** is some operations that will be invoked when a search is complete, it recycles all the resources allocated during the search.
 
-For example the **context** will create a temporary file to dump/pass some data between providers/previewers. Thus it also needs a **shutdown** operation to delete the temporary file when the popup is closed.
+For example the **context** will create a temporary file to help passing data between providers/previewers. Thus it also needs a **shutdown** operation to delete the temporary file when the popup is closed.
 
 ## Provider
 

--- a/docs/GenericSchema.md
+++ b/docs/GenericSchema.md
@@ -52,7 +52,7 @@ So we need a way to store the **_current_** buffer/window info in somewhere, so 
 
 ## Shutdown
 
-A **shutdown** is some operations that will be invoked when a search is complete, it usually recycle resources.
+A **shutdown** is some operations that will be invoked when a search is complete, it recycles all the resources allocated during the search.
 
 For example the **context** will create a temporary file to dump/pass some data between providers/previewers. Thus it also needs a **shutdown** operation to delete the temporary file when the popup is closed.
 

--- a/docs/GenericSchema.md
+++ b/docs/GenericSchema.md
@@ -6,6 +6,7 @@
 
 - [Introduction](#introduction)
 - [Context](#context)
+- [Shutdown](#shutdown)
 - [Provider](#provider)
 - [Provider Decorator](#provider-decorator)
 - [Previewer](#previewer)
@@ -48,6 +49,12 @@ A **context** is some data that passing to pipeline.
 Starting a searching command is actually creating a popup window and a terminal, running a fzf shell command inside it. Thus there's no way to get the current buffer number (`bufnr`) or current window number (`winnr`) you're editing (actually it's the _previous_ buffer/window).
 
 So we need a way to store the **_current_** buffer/window info in somewhere, so we need to create a context before creating the popup window and launching the shell command.
+
+## Shutdown
+
+A **shutdown** is some operations that will be invoked when a search is complete, it usually recycle resources.
+
+For example the **context** will create a temporary file to dump/pass some data between providers/previewers. Thus it also needs a **shutdown** operation to delete the temporary file when the popup is closed.
 
 ## Provider
 

--- a/docs/GenericSchema.md
+++ b/docs/GenericSchema.md
@@ -54,7 +54,7 @@ So we need a way to store the **_current_** buffer/window info in somewhere, so 
 
 A **shutdown** is some operations that will be invoked when a search is complete, it recycles all the resources allocated during the search.
 
-For example the **context** will create a temporary file to help passing data between providers/previewers. Thus it also needs a **shutdown** operation to delete the temporary file when the popup is closed.
+For example a **context** create a temporary file to help passing data between providers/previewers. Thus we also needs a **shutdown** to delete the temporary file when the search complete.
 
 ## Provider
 

--- a/lua/fzfx/cfg/file_explorer.lua
+++ b/lua/fzfx/cfg/file_explorer.lua
@@ -1,6 +1,7 @@
 local str = require("fzfx.commons.str")
 local path = require("fzfx.commons.path")
 local fio = require("fzfx.commons.fio")
+local uv = require("fzfx.commons.uv")
 
 local consts = require("fzfx.lib.constants")
 local shells = require("fzfx.lib.shells")
@@ -401,8 +402,18 @@ M._context_maker = function()
   return context
 end
 
+--- @param context fzfx.FileExplorerPipelineContext
+M._context_shutdown = function(context)
+  ---@diagnostic disable-next-line: undefined-field
+  if uv.fs_stat(context.cwd) then
+    ---@diagnostic disable-next-line: undefined-field
+    uv.fs_unlink(context.cwd, function() end)
+  end
+end
+
 M.other_opts = {
   context_maker = M._context_maker,
+  context_shutdown = M._context_shutdown,
 }
 
 return M

--- a/lua/fzfx/cfg/vim_commands.lua
+++ b/lua/fzfx/cfg/vim_commands.lua
@@ -2,6 +2,7 @@ local tbl = require("fzfx.commons.tbl")
 local str = require("fzfx.commons.str")
 local path = require("fzfx.commons.path")
 local fio = require("fzfx.commons.fio")
+local uv = require("fzfx.commons.uv")
 
 local consts = require("fzfx.lib.constants")
 local log = require("fzfx.lib.log")
@@ -285,6 +286,13 @@ M._get_commands_output_in_lines = function()
     tmpfile
   ))
   local lines = fio.readlines(tmpfile) --[[@as string[] ]]
+
+  ---@diagnostic disable-next-line: undefined-field
+  if uv.fs_stat(tmpfile) then
+    ---@diagnostic disable-next-line: undefined-field
+    uv.fs_unlink(tmpfile, function() end)
+  end
+
   return lines
 end
 

--- a/lua/fzfx/cfg/vim_commands.lua
+++ b/lua/fzfx/cfg/vim_commands.lua
@@ -287,11 +287,13 @@ M._get_commands_output_in_lines = function()
   ))
   local lines = fio.readlines(tmpfile) --[[@as string[] ]]
 
-  ---@diagnostic disable-next-line: undefined-field
-  if uv.fs_stat(tmpfile) then
+  vim.schedule(function()
     ---@diagnostic disable-next-line: undefined-field
-    uv.fs_unlink(tmpfile, function() end)
-  end
+    if uv.fs_stat(tmpfile) then
+      ---@diagnostic disable-next-line: undefined-field
+      uv.fs_unlink(tmpfile, function() end)
+    end
+  end)
 
   return lines
 end

--- a/lua/fzfx/cfg/vim_keymaps.lua
+++ b/lua/fzfx/cfg/vim_keymaps.lua
@@ -182,11 +182,13 @@ M._get_maps_output_in_lines = function()
 
   local lines = fio.readlines(tmpfile) --[[@as string[] ]]
 
-  ---@diagnostic disable-next-line: undefined-field
-  if uv.fs_stat(tmpfile) then
+  vim.schedule(function()
     ---@diagnostic disable-next-line: undefined-field
-    uv.fs_unlink(tmpfile, function() end)
-  end
+    if uv.fs_stat(tmpfile) then
+      ---@diagnostic disable-next-line: undefined-field
+      uv.fs_unlink(tmpfile, function() end)
+    end
+  end)
 
   return lines
 end

--- a/lua/fzfx/cfg/vim_keymaps.lua
+++ b/lua/fzfx/cfg/vim_keymaps.lua
@@ -2,6 +2,7 @@ local tbl = require("fzfx.commons.tbl")
 local str = require("fzfx.commons.str")
 local fio = require("fzfx.commons.fio")
 local path = require("fzfx.commons.path")
+local uv = require("fzfx.commons.uv")
 
 local constants = require("fzfx.lib.constants")
 local log = require("fzfx.lib.log")
@@ -180,6 +181,13 @@ M._get_maps_output_in_lines = function()
   ))
 
   local lines = fio.readlines(tmpfile) --[[@as string[] ]]
+
+  ---@diagnostic disable-next-line: undefined-field
+  if uv.fs_stat(tmpfile) then
+    ---@diagnostic disable-next-line: undefined-field
+    uv.fs_unlink(tmpfile, function() end)
+  end
+
   return lines
 end
 

--- a/lua/fzfx/cfg/vim_marks.lua
+++ b/lua/fzfx/cfg/vim_marks.lua
@@ -169,11 +169,13 @@ M._get_marks_output_in_lines = function()
   ))
   local lines = fio.readlines(tmpfile) --[[@as string[] ]]
 
-  ---@diagnostic disable-next-line: undefined-field
-  if uv.fs_stat(tmpfile) then
+  vim.schedule(function()
     ---@diagnostic disable-next-line: undefined-field
-    uv.fs_unlink(tmpfile, function() end)
-  end
+    if uv.fs_stat(tmpfile) then
+      ---@diagnostic disable-next-line: undefined-field
+      uv.fs_unlink(tmpfile, function() end)
+    end
+  end)
 
   return lines
 end

--- a/lua/fzfx/cfg/vim_marks.lua
+++ b/lua/fzfx/cfg/vim_marks.lua
@@ -3,6 +3,7 @@ local num = require("fzfx.commons.num")
 local str = require("fzfx.commons.str")
 local fio = require("fzfx.commons.fio")
 local path = require("fzfx.commons.path")
+local uv = require("fzfx.commons.uv")
 
 local constants = require("fzfx.lib.constants")
 local log = require("fzfx.lib.log")
@@ -167,6 +168,13 @@ M._get_marks_output_in_lines = function()
     tmpfile
   ))
   local lines = fio.readlines(tmpfile) --[[@as string[] ]]
+
+  ---@diagnostic disable-next-line: undefined-field
+  if uv.fs_stat(tmpfile) then
+    ---@diagnostic disable-next-line: undefined-field
+    uv.fs_unlink(tmpfile, function() end)
+  end
+
   return lines
 end
 

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -821,6 +821,7 @@ end
 --- @param pipeline_configs fzfx.Options
 --- @return fzfx.PipelineContext
 local function _get_context(pipeline_configs)
+  --- @type fzfx.PipelineContextMaker
   local context_maker = function()
     return {
       bufnr = vim.api.nvim_get_current_buf(),

--- a/lua/fzfx/detail/general.lua
+++ b/lua/fzfx/detail/general.lua
@@ -818,13 +818,36 @@ local function get_pipeline_size(pipeline_configs)
   return n
 end
 
+--- @param pipeline_configs fzfx.Options
 --- @return fzfx.PipelineContext
-local function _make_default_context()
-  return {
-    bufnr = vim.api.nvim_get_current_buf(),
-    winnr = vim.api.nvim_get_current_win(),
-    tabnr = vim.api.nvim_get_current_tabpage(),
-  }
+local function _get_context(pipeline_configs)
+  local context_maker = function()
+    return {
+      bufnr = vim.api.nvim_get_current_buf(),
+      winnr = vim.api.nvim_get_current_win(),
+      tabnr = vim.api.nvim_get_current_tabpage(),
+    }
+  end
+
+  local context_maker_opt = tbl.tbl_get(pipeline_configs, "other_opts", "context_maker")
+  if context_maker_opt ~= nil and vim.is_callable(context_maker_opt) then
+    context_maker = context_maker_opt
+  end
+
+  return context_maker()
+end
+
+--- @param pipeline_configs fzfx.Options
+--- @return fzfx.PipelineContextShutdown
+local function _get_context_shutdown(pipeline_configs)
+  local context_shutdown = function() end
+
+  local context_shutdown_opt = tbl.tbl_get(pipeline_configs, "other_opts", "context_shutdown")
+  if context_shutdown_opt ~= nil and vim.is_callable(context_shutdown_opt) then
+    context_shutdown = context_shutdown_opt
+  end
+
+  return context_shutdown
 end
 
 --- @param name string
@@ -865,12 +888,9 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
   local previewer_switch =
     PreviewerSwitch:new(name, default_pipeline, pipeline_configs.previewers, fzf_port_file)
 
-  local context_maker = _make_default_context
-  local pipeline_context_maker = tbl.tbl_get(pipeline_configs, "other_opts", "context_maker")
-  if pipeline_context_maker ~= nil and vim.is_callable(pipeline_context_maker) then
-    context_maker = pipeline_context_maker
-  end
-  local context = context_maker()
+  local context = _get_context(pipeline_configs)
+  local context_shutdown = _get_context_shutdown(pipeline_configs)
+
   local rpc_registries = {}
 
   --- @param query_params string
@@ -1090,6 +1110,9 @@ local function general(name, query, bang, pipeline_configs, default_pipeline)
       --   )
       -- )
     end)
+
+    -- Shutdown context
+    context_shutdown(context)
   end)
 end
 

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -45,6 +45,7 @@ end
 M._PREVIEW_BAT = {
   consts.BAT,
   "--color=always",
+  "--decorations=always",
   "--pager=never",
 }
 

--- a/lua/fzfx/helper/previewers.lua
+++ b/lua/fzfx/helper/previewers.lua
@@ -44,8 +44,7 @@ end
 
 M._PREVIEW_BAT = {
   consts.BAT,
-  "--color=always",
-  "--decorations=always",
+  "-f", -- Alias for --color=always, --decorations=always
   "--pager=never",
 }
 

--- a/lua/fzfx/schema.lua
+++ b/lua/fzfx/schema.lua
@@ -2,6 +2,7 @@
 --
 --- @alias fzfx.PipelineContext {bufnr:integer,winnr:integer,tabnr:integer}
 --- @alias fzfx.PipelineContextMaker fun():fzfx.PipelineContext
+--- @alias fzfx.PipelineContextShutdown fun(context:fzfx.PipelineContext?):any
 --
 --
 -- ========== Provider ==========

--- a/spec/cfg/vim_marks_spec.lua
+++ b/spec/cfg/vim_marks_spec.lua
@@ -90,7 +90,7 @@ describe("fzfx.cfg.vim_marks", function()
                 return a == "--line-range"
               end))
               assert_true(tbl.List:copy(actual):some(function(a)
-                return a == "--color=always"
+                return a == "-f"
               end))
               assert_true(tbl.List:copy(actual):some(function(a)
                 return a == "--pager=never"
@@ -109,7 +109,7 @@ describe("fzfx.cfg.vim_marks", function()
                 return a == "--line-range"
               end))
               assert_true(tbl.List:copy(actual):none(function(a)
-                return a == "--color=always"
+                return a == "-f"
               end))
               assert_true(tbl.List:copy(actual):none(function(a)
                 return a == "--pager=never"


### PR DESCRIPTION
This PR adds a hook function "context_shutdown" that recycles resources allocated during search. It works like a GC that collects resources allocated, for example some temporary files.

This PR also delete all the temporary files while searching, thus no extra disk is been used after searching is complete.